### PR TITLE
Column-level security v2: jsqltranspiler-backed rewriter (experimental, opt-in) + Caffeine cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,6 +177,7 @@ lazy val root = (project in file("."))
       Dependencies.javaJwt,
       Dependencies.nimbusJoseJwt,
       Dependencies.jsqlParser,
+      Dependencies.jsqltranspiler,
       Dependencies.kubernetesClient,
       Dependencies.kubernetesServerMock,
       Dependencies.junit4,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,9 @@ object Dependencies {
   val nimbusJoseJwt         = "com.nimbusds" % "nimbus-jose-jwt" % Versions.nimbusJoseJwt
 
   val jsqlParser            = "com.manticore-projects.jsqlformatter" % "jsqlparser" % Versions.jsqlParser
+  // jsqltranspiler  provides JSQLColumResolver for column-level
+  // security rewriting. Shares the JSqlParser 5.3.218 ABI with jsqlParser above.
+  val jsqltranspiler        = "ai.starlake.jsqltranspiler" % "jsqltranspiler" % Versions.jsqltranspiler
   val catsCore              = "org.typelevel" %% "cats-core" % Versions.cats
   val kubernetesClient      = "io.fabric8" % "kubernetes-client" % Versions.fabric8
   val kubernetesServerMock  = "io.fabric8" % "kubernetes-server-mock" % Versions.fabric8 % Test

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -12,6 +12,7 @@ object Versions {
   val nimbusJoseJwt  = "9.47"
   val scalaTest      = "3.2.17"
   val jsqlParser     = "5.3.218"
+  val jsqltranspiler = "1.9"
   val circeYaml      = "0.16.1"
   val cats           = "2.13.0"
   val netty          = "4.1.118.Final"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -12,7 +12,7 @@ object Versions {
   val nimbusJoseJwt  = "9.47"
   val scalaTest      = "3.2.17"
   val jsqlParser     = "5.3.218"
-  val jsqltranspiler = "1.9"
+  val jsqltranspiler = "1.10"
   val circeYaml      = "0.16.1"
   val cats           = "2.13.0"
   val netty          = "4.1.118.Final"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -48,6 +48,16 @@ quack-on-demand {
     rollback = ${?QOD_CLASSIFIER_ROLLBACK}
   }
 
+  # Column-level security knobs. Default: passthrough - if the DuckLake catalog
+  # cannot enumerate a referenced table (typo, federated alias the rewriter
+  # doesn't know about, or a metadata race), fall back to the unrewritten SQL
+  # (the v1 behavior). Set to "deny" for the safer posture that rejects the
+  # statement instead.
+  cls {
+    unresolvedTable = "passthrough"
+    unresolvedTable = ${?QOD_CLS_UNRESOLVED_TABLE}
+  }
+
   # Toggle the JNI-backed native Quack wire client in QuackHttpClient.
   # Default: true (the JNI native path is the production-grade default).
   # Set QOD_NATIVE_CLIENT=false (or change

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -48,12 +48,21 @@ quack-on-demand {
     rollback = ${?QOD_CLASSIFIER_ROLLBACK}
   }
 
-  # Column-level security knobs. Default: pass - if the DuckLake catalog cannot
+  # Column-level security (EXPERIMENTAL).
+  # `enabled` is the kill switch. When false (the default), every statement
+  # bypasses the rewriter entirely - no catalog lookup, no jsqltranspiler
+  # call, no per-statement overhead. Set true to opt in. The feature is
+  # still under hardening; expect rough edges around federated sources,
+  # LateralSubSelect/TableFunction FROM items, and the 5-second catalog
+  # cache TTL race documented at website/docs/operating/rbac-model.md.
+  # `unresolvedTable` decides what happens when the DuckLake catalog cannot
   # enumerate a referenced table (typo, federated alias the rewriter doesn't
-  # know about, or a metadata race), fall back to the unrewritten SQL (the v1
-  # behavior). Set to "deny" for the safer posture that rejects the statement
-  # instead.
+  # know about, or a metadata race). Default: "pass" - fall back to the
+  # unrewritten SQL (the v1 behavior). Set to "deny" for the safer posture
+  # that rejects the statement instead. Ignored when `enabled = false`.
   cls {
+    enabled = false
+    enabled = ${?QOD_CLS_ENABLED}
     unresolvedTable = "pass"
     unresolvedTable = ${?QOD_CLS_UNRESOLVED_TABLE}
   }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -48,13 +48,13 @@ quack-on-demand {
     rollback = ${?QOD_CLASSIFIER_ROLLBACK}
   }
 
-  # Column-level security knobs. Default: passthrough - if the DuckLake catalog
-  # cannot enumerate a referenced table (typo, federated alias the rewriter
-  # doesn't know about, or a metadata race), fall back to the unrewritten SQL
-  # (the v1 behavior). Set to "deny" for the safer posture that rejects the
-  # statement instead.
+  # Column-level security knobs. Default: pass - if the DuckLake catalog cannot
+  # enumerate a referenced table (typo, federated alias the rewriter doesn't
+  # know about, or a metadata race), fall back to the unrewritten SQL (the v1
+  # behavior). Set to "deny" for the safer posture that rejects the statement
+  # instead.
   cls {
-    unresolvedTable = "passthrough"
+    unresolvedTable = "pass"
     unresolvedTable = ${?QOD_CLS_UNRESOLVED_TABLE}
   }
 

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -451,11 +451,15 @@ object Main extends IOApp with LazyLogging:
       )
       val classifier = new StatementClassifier(classifierCfg)
 
+      val clsConfig = com.typesafe.config.ConfigFactory.load().getConfig("quack-on-demand.cls")
+      val clsEnabled: Boolean = clsConfig.getBoolean("enabled")
+      if !clsEnabled then
+        logger.info(
+          "column-level security is DISABLED (quack-on-demand.cls.enabled=false). " +
+            "Every statement bypasses the rewriter."
+        )
       val unresolvedTableMode: ai.starlake.quack.edge.cls.UnresolvedMode =
-        com.typesafe.config.ConfigFactory
-          .load()
-          .getString("quack-on-demand.cls.unresolvedTable")
-          .toLowerCase match
+        clsConfig.getString("unresolvedTable").toLowerCase match
           case "deny" => ai.starlake.quack.edge.cls.UnresolvedMode.Deny
           case "pass" => ai.starlake.quack.edge.cls.UnresolvedMode.Pass
           case other  =>
@@ -490,7 +494,8 @@ object Main extends IOApp with LazyLogging:
         )
       val columnPolicyRewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
         catalog = columnCatalog,
-        unresolvedMode = unresolvedTableMode
+        unresolvedMode = unresolvedTableMode,
+        enabled = clsEnabled
       )
 
       val fsRouter = new FlightSqlRouter(

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -452,8 +452,28 @@ object Main extends IOApp with LazyLogging:
       )
       val classifier = new StatementClassifier(classifierCfg)
 
+      // Resolve a DuckDB-side catalog name to its DuckLakeCatalogReader by looking up the
+      // tenant-db owning that catalog and reusing the cache populated by `catalogHandlers`.
+      // Returns Nil for unknown catalogs; the rewriter's unresolvedMode then decides whether
+      // to deny or pass through.
       val columnCatalog: ai.starlake.quack.edge.cls.ColumnCatalog =
-        new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(Map.empty) // TODO: wire DuckLakeCatalogReader
+        new ai.starlake.quack.edge.cls.DuckLakeColumnCatalog(
+          fetch = (cat, sch, tab) =>
+            IO.blocking {
+              sup.findTenantDbByCatalogName(cat) match
+                case None     => Nil
+                case Some(td) =>
+                  sup.getTenantById(td.tenantId) match
+                    case None    => Nil
+                    case Some(t) =>
+                      val reader = catalogReaderCache.computeIfAbsent(
+                        (t.displayName, td.name),
+                        { case (tn, dn) => DuckLakeCatalogReader(sup.effectiveMetastoreFor(tn, dn)) }
+                      )
+                      reader.columnNames(sch, tab)
+            },
+          instruments = Some(stmtInstruments)
+        )
       val columnPolicyRewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(columnCatalog)
 
       val fsRouter = new FlightSqlRouter(

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -57,7 +57,6 @@ import pureconfig._
 import pureconfig.generic.ProductHint
 import pureconfig.generic.semiauto.deriveReader
 
-
 object Main extends IOApp with LazyLogging:
 
   // Match the camelCase keys used in application.conf rather than pureconfig's
@@ -189,7 +188,7 @@ object Main extends IOApp with LazyLogging:
     // directly is refused here because every secret resolved through it
     // would crash at handshake time -- caller's mistake should fail at
     // boot, not in production.
-    val UnimplementedSingleBackends = Set("aws-sm", "gcp-sm", "azure-kv", "vault")
+    val UnimplementedSingleBackends    = Set("aws-sm", "gcp-sm", "azure-kv", "vault")
     val secretResolver: SecretResolver = mgrCfg.federation.secretStore match {
       case "dispatch" | "auto" =>
         new DispatchingSecretResolver(
@@ -200,8 +199,8 @@ object Main extends IOApp with LazyLogging:
           azureKv = new AzureSecretsManagerResolver,
           vault = new VaultSecretResolver
         )
-      case "postgres" => new PostgresSecretResolver
-      case "env"      => new EnvSecretResolver()
+      case "postgres"                                   => new PostgresSecretResolver
+      case "env"                                        => new EnvSecretResolver()
       case s if UnimplementedSingleBackends.contains(s) =>
         sys.error(
           s"federation.secretStore = '$s' is not implemented (the resolver is a stub). " +
@@ -281,8 +280,8 @@ object Main extends IOApp with LazyLogging:
     // to the manager-wide `quack-flightsql.auth.google` block.
     val tenantOidcRegistry = new ai.starlake.quack.edge.auth.TenantOidcRegistry(
       loadTenant = id => sup.getTenantById(id),
-      secrets    = ai.starlake.quack.secrets.SecretRefResolver.default,
-      roleClaim  = authCfg.roleClaim
+      secrets = ai.starlake.quack.secrets.SecretRefResolver.default,
+      roleClaim = authCfg.roleClaim
     )
     val authService = new AuthenticationService(
       authCfg,
@@ -320,15 +319,14 @@ object Main extends IOApp with LazyLogging:
           "manager beyond localhost."
       )
     val sessionTokens = new SessionTokenStore(
-      secret      = mgrCfg.auth.management.sessionJwtSecret,
+      secret = mgrCfg.auth.management.sessionJwtSecret,
       maxLifetime = scala.concurrent.duration.DurationInt(mgrCfg.sessionIdleTtlSec).seconds
     )
     val identitySource = ManagementIdentitySource.fromConfig(mgrCfg.auth.management.identitySource)
     val authUserStore: Option[UserStore] =
       Some(UserStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap))
     val grantsForIdentity: GrantsLookup =
-      (identity, email) =>
-        authUserStore.map(_.grantsForIdentity(identity, email)).getOrElse(Nil)
+      (identity, email) => authUserStore.map(_.grantsForIdentity(identity, email)).getOrElse(Nil)
     // 'auto' -> None (handler derives Secure from X-Forwarded-Proto per request); 'true' / 'false'
     // -> explicit override. Unknown values fall back to auto with a warning so a typo in the env
     // var doesn't accidentally weaken the cookie.
@@ -344,12 +342,12 @@ object Main extends IOApp with LazyLogging:
           )
           None
     val authHandlers = new AuthHandlers(
-      authService          = authService,
-      tokens               = sessionTokens,
-      identitySource       = identitySource,
-      grantsForIdentity    = grantsForIdentity,
+      authService = authService,
+      tokens = sessionTokens,
+      identitySource = identitySource,
+      grantsForIdentity = grantsForIdentity,
       cookieSecureOverride = cookieSecureOverride,
-      cookiePath           = mgrCfg.auth.management.sessionCookiePath
+      cookiePath = mgrCfg.auth.management.sessionCookiePath
     )
     val stmtHistory     = new ai.starlake.quack.edge.StatementHistoryStore()
     val historyHandlers = new StatementHistoryHandlers(stmtHistory, sup)
@@ -379,16 +377,17 @@ object Main extends IOApp with LazyLogging:
         )
         new PostgresAclValidator(
           defaultDatabase = defaultDb,
-          defaultSchema   = defaultSchema,
-          dialect         = aclCfg.dialect,
+          defaultSchema = defaultSchema,
+          dialect = aclCfg.dialect,
           // Scope wildcard catalog grants to the session's tenant. Maps
           // qodstate_tenant.id -> the set of tenant_db.name's the tenant
           // owns; the validator's `catalogMatch` consults this to decide
           // whether `*.*.*` admits a referenced catalog. Empty set = no
           // catalog matches via wildcard (fail-closed). Explicit named
           // grants bypass this and still cross tenants on purpose.
-          tenantCatalogs  = tenantId =>
-            sup.getTenantById(tenantId)
+          tenantCatalogs = tenantId =>
+            sup
+              .getTenantById(tenantId)
               .map(t => sup.listTenantDbsByTenant(t.displayName).map(_.name).toSet)
               .getOrElse(Set.empty)
         )
@@ -443,11 +442,11 @@ object Main extends IOApp with LazyLogging:
       val classifierRoot =
         com.typesafe.config.ConfigFactory.load().getConfig("quack-on-demand.statementClassifier")
       val classifierCfg = StatementClassifierConfig(
-        select   = StatementClassifierConfig.parseCsv(classifierRoot.getString("select")),
-        dml      = StatementClassifierConfig.parseCsv(classifierRoot.getString("dml")),
-        ddl      = StatementClassifierConfig.parseCsv(classifierRoot.getString("ddl")),
-        begin    = StatementClassifierConfig.parseCsv(classifierRoot.getString("begin")),
-        commit   = StatementClassifierConfig.parseCsv(classifierRoot.getString("commit")),
+        select = StatementClassifierConfig.parseCsv(classifierRoot.getString("select")),
+        dml = StatementClassifierConfig.parseCsv(classifierRoot.getString("dml")),
+        ddl = StatementClassifierConfig.parseCsv(classifierRoot.getString("ddl")),
+        begin = StatementClassifierConfig.parseCsv(classifierRoot.getString("begin")),
+        commit = StatementClassifierConfig.parseCsv(classifierRoot.getString("commit")),
         rollback = StatementClassifierConfig.parseCsv(classifierRoot.getString("rollback"))
       )
       val classifier = new StatementClassifier(classifierCfg)
@@ -481,14 +480,16 @@ object Main extends IOApp with LazyLogging:
                     case Some(t) =>
                       val reader = catalogReaderCache.computeIfAbsent(
                         (t.displayName, td.name),
-                        { case (tn, dn) => DuckLakeCatalogReader(sup.effectiveMetastoreFor(tn, dn)) }
+                        { case (tn, dn) =>
+                          DuckLakeCatalogReader(sup.effectiveMetastoreFor(tn, dn))
+                        }
                       )
                       reader.columnNames(sch, tab)
             },
           instruments = Some(stmtInstruments)
         )
       val columnPolicyRewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
-        catalog        = columnCatalog,
+        catalog = columnCatalog,
         unresolvedMode = unresolvedTableMode
       )
 
@@ -565,7 +566,7 @@ object Main extends IOApp with LazyLogging:
       // and the in-memory RbacResolver cache stay in lockstep. The user
       // handler is built first because role / group / pool-permission
       // handlers share its DTO mappers.
-      val userStoreForRbac   = UserStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
+      val userStoreForRbac     = UserStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
       val userHandlers         = new UserHandlers(sup, userStoreForRbac)
       val roleHandlers         = new RoleHandlers(sup, userHandlers)
       val groupHandlers        = new GroupHandlers(sup, userHandlers)
@@ -651,15 +652,17 @@ object Main extends IOApp with LazyLogging:
       // those pools and can spawn nodes. Inverting the order leaves the
       // REST/UI reading from an empty cache after a fresh boot.
       DemoBootstrapHook.run(
-        env      = sys.env.get,
+        env = sys.env.get,
         readFile = path =>
           if path.startsWith("classpath:") then
             val resource = path.stripPrefix("classpath:")
             scala.util.Try {
               val stream = Option(getClass.getClassLoader.getResourceAsStream(resource))
-                .getOrElse(throw new java.io.FileNotFoundException(
-                  s"classpath resource not found: $resource"
-                ))
+                .getOrElse(
+                  throw new java.io.FileNotFoundException(
+                    s"classpath resource not found: $resource"
+                  )
+                )
               scala.util.Using.resource(stream)(s =>
                 scala.io.Source.fromInputStream(s, "UTF-8").getLines().mkString("\n")
               )
@@ -667,8 +670,9 @@ object Main extends IOApp with LazyLogging:
           else
             scala.util.Using(
               scala.io.Source.fromFile(path)(using scala.io.Codec.UTF8)
-            )(_.getLines().mkString("\n")),
-        store    = store,
+            )(_.getLines().mkString("\n"))
+        ,
+        store = store,
         fedStore = manifestFedStore
       ) *>
         IO.delay(sup.restore()) *>
@@ -695,15 +699,15 @@ object Main extends IOApp with LazyLogging:
                   catch case _: Throwable => ()
                   try backend.cleanup().unsafeRunSync()
                   catch case _: Throwable => ()
-                  // Drain the JDBC connection pools. Both close()s are
-                  // idempotent + no-op if already closed.
+                    // Drain the JDBC connection pools. Both close()s are
+                    // idempotent + no-op if already closed.
                   try store.close()
                   catch case _: Throwable => ()
                   try authUserStore.foreach(_.close())
                   catch case _: Throwable => ()
-                  // Close every cached catalog reader's Hikari pool. The
-                  // map shouldn't see new entries past this point because
-                  // serve() has already returned, but iterate defensively.
+                    // Close every cached catalog reader's Hikari pool. The
+                    // map shouldn't see new entries past this point because
+                    // serve() has already returned, but iterate defensively.
                   val it = catalogReaderCache.values.iterator()
                   while it.hasNext do
                     val r = it.next()

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -452,6 +452,19 @@ object Main extends IOApp with LazyLogging:
       )
       val classifier = new StatementClassifier(classifierCfg)
 
+      val unresolvedTableMode: ai.starlake.quack.edge.cls.UnresolvedMode =
+        com.typesafe.config.ConfigFactory
+          .load()
+          .getString("quack-on-demand.cls.unresolvedTable")
+          .toLowerCase match
+          case "deny"        => ai.starlake.quack.edge.cls.UnresolvedMode.Deny
+          case "passthrough" => ai.starlake.quack.edge.cls.UnresolvedMode.Passthrough
+          case other         =>
+            logger.warn(
+              s"unknown quack-on-demand.cls.unresolvedTable='$other', defaulting to passthrough"
+            )
+            ai.starlake.quack.edge.cls.UnresolvedMode.Passthrough
+
       // Resolve a DuckDB-side catalog name to its DuckLakeCatalogReader by looking up the
       // tenant-db owning that catalog and reusing the cache populated by `catalogHandlers`.
       // Returns Nil for unknown catalogs; the rewriter's unresolvedMode then decides whether
@@ -474,7 +487,10 @@ object Main extends IOApp with LazyLogging:
             },
           instruments = Some(stmtInstruments)
         )
-      val columnPolicyRewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(columnCatalog)
+      val columnPolicyRewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
+        catalog        = columnCatalog,
+        unresolvedMode = unresolvedTableMode
+      )
 
       val fsRouter = new FlightSqlRouter(
         sup,

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -457,13 +457,13 @@ object Main extends IOApp with LazyLogging:
           .load()
           .getString("quack-on-demand.cls.unresolvedTable")
           .toLowerCase match
-          case "deny"        => ai.starlake.quack.edge.cls.UnresolvedMode.Deny
-          case "passthrough" => ai.starlake.quack.edge.cls.UnresolvedMode.Passthrough
-          case other         =>
+          case "deny" => ai.starlake.quack.edge.cls.UnresolvedMode.Deny
+          case "pass" => ai.starlake.quack.edge.cls.UnresolvedMode.Pass
+          case other  =>
             logger.warn(
-              s"unknown quack-on-demand.cls.unresolvedTable='$other', defaulting to passthrough"
+              s"unknown quack-on-demand.cls.unresolvedTable='$other', defaulting to pass"
             )
-            ai.starlake.quack.edge.cls.UnresolvedMode.Passthrough
+            ai.starlake.quack.edge.cls.UnresolvedMode.Pass
 
       // Resolve a DuckDB-side catalog name to its DuckLakeCatalogReader by looking up the
       // tenant-db owning that catalog and reusing the cache populated by `catalogHandlers`.

--- a/src/main/scala/ai/starlake/quack/edge/FlightSqlRouter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/FlightSqlRouter.scala
@@ -167,11 +167,25 @@ final class FlightSqlRouter(
           case ai.starlake.quack.edge.cls.ColumnPolicyRewriter.Passthrough =>
             stmtInstruments.recordColumnPolicyRewrite(poolKey.tenant, poolKey.pool, "passthrough")
             sql
+          case ai.starlake.quack.edge.cls.ColumnPolicyRewriter.PassthroughParseFailed =>
+            // Inner rewriter couldn't parse - emit a distinct tag so dashboards can split
+            // "rewriter blind" from "no policy applied", then route the original SQL like
+            // a regular Passthrough.
+            stmtInstruments.recordColumnPolicyRewrite(poolKey.tenant, poolKey.pool, "parse_failed")
+            sql
           case ai.starlake.quack.edge.cls.ColumnPolicyRewriter.Rewritten(s) =>
             stmtInstruments.recordColumnPolicyRewrite(poolKey.tenant, poolKey.pool, "rewritten")
             s
           case ai.starlake.quack.edge.cls.ColumnPolicyRewriter.Denied(reason) =>
             stmtInstruments.recordColumnPolicyRewrite(poolKey.tenant, poolKey.pool, "denied")
+            maybeRecord(nodeId = "-", durationMs = 0, status = "denied", error = Some(reason))
+            return IO.pure(Left(s"access denied: $reason"))
+          case ai.starlake.quack.edge.cls.ColumnPolicyRewriter.DeniedUnresolvedTable =>
+            // Deny path where the cause was an unresolved table/schema/catalog coordinate
+            // rather than a policy match. Same wire error as Denied but tagged separately.
+            stmtInstruments
+              .recordColumnPolicyRewrite(poolKey.tenant, poolKey.pool, "unresolved_deny")
+            val reason = "unresolved table"
             maybeRecord(nodeId = "-", durationMs = 0, status = "denied", error = Some(reason))
             return IO.pure(Left(s"access denied: $reason"))
 

--- a/src/main/scala/ai/starlake/quack/edge/FlightSqlRouter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/FlightSqlRouter.scala
@@ -84,13 +84,13 @@ final class FlightSqlRouter(
     * Used by the FlightSQL prepared-statement path to keep Prepare + Execute on the same Quack
     * process so DuckDB-side caches stay warm across the two halves of one client `execute()`.
     *
-    * `recordExecution=false` suppresses the in-memory history + metrics emission for this call.
-    * The FlightSQL Prepare-time LIMIT-0 probe uses this so the UI shows ONE history row per
+    * `recordExecution=false` suppresses the in-memory history + metrics emission for this call. The
+    * FlightSQL Prepare-time LIMIT-0 probe uses this so the UI shows ONE history row per
     * user-visible query instead of two; the probe's duration is then attached to the matching
     * Execute record via [[prepareDurationMs]] so operators can still see it.
     *
-    * `prepareDurationMs` is folded into the resulting [[StatementRecord]] so the UI can render
-    * it as subtext under the Execute duration ("57 ms / prep 28 ms").
+    * `prepareDurationMs` is folded into the resulting [[StatementRecord]] so the UI can render it
+    * as subtext under the Execute duration ("57 ms / prep 28 ms").
     */
   def execute(
       connectionId: String,
@@ -152,15 +152,15 @@ final class FlightSqlRouter(
     // Column-level security: enforce per-column policies before routing.
     val schemaCtx = ai.starlake.quack.edge.cls.SchemaContext(
       defaultDatabase = ctx.defaultDatabase,
-      defaultSchema   = ctx.defaultSchema
+      defaultSchema = ctx.defaultSchema
     )
     import cats.effect.unsafe.implicits.global
     val rewrittenSql: String = effectiveSet match
       case None =>
         sql // no RBAC principal bound; rewriter would deny anything tenant-scoped
       case Some(eff) =>
-        val t0      = System.nanoTime()
-        val outcome = columnPolicyRewriter.rewrite(sql, kind, eff, schemaCtx).unsafeRunSync()
+        val t0        = System.nanoTime()
+        val outcome   = columnPolicyRewriter.rewrite(sql, kind, eff, schemaCtx).unsafeRunSync()
         val elapsedMs = (System.nanoTime() - t0) / 1_000_000L
         stmtInstruments.recordColumnPolicyRewriteDuration(poolKey.tenant, poolKey.pool, elapsedMs)
         outcome match
@@ -197,7 +197,7 @@ final class FlightSqlRouter(
       case Some(snap) =>
         // Tx pin wins; otherwise honor the soft preferredNode if it still exists in the
         // current snapshot; otherwise None lets Router.pick run its load-aware choice.
-        val txPin = s.pinnedNodeId.filter(_ => s.txOpen)
+        val txPin  = s.pinnedNodeId.filter(_ => s.txOpen)
         val pinned = txPin.orElse(preferredNode.filter(id => snap.nodes.exists(_.nodeId == id)))
         // Each quack_query lands in a fresh DuckDB session on the remote, so
         // an unqualified `SELECT * FROM customer` would 404 - we wrap the user

--- a/src/main/scala/ai/starlake/quack/edge/auth/GoogleGroupsLookup.scala
+++ b/src/main/scala/ai/starlake/quack/edge/auth/GoogleGroupsLookup.scala
@@ -31,9 +31,17 @@ class GoogleGroupsLookup(
 ) extends AutoCloseable,
       LazyLogging:
 
-  private case class CachedGroups(groups: Set[String], fetchedAt: Instant)
-
-  private val groupsCache = new java.util.concurrent.ConcurrentHashMap[String, CachedGroups]()
+  /** Caffeine-backed cache of resolved Google group memberships per user email. Caffeine handles
+    * the TTL (`expireAfterWrite`) and bounds memory (`maximumSize`) so historical users
+    * accumulated over the manager's lifetime can't leak. The previous hand-rolled
+    * ConcurrentHashMap + fetchedAt form did neither.
+    */
+  private val groupsCache: com.github.benmanes.caffeine.cache.Cache[String, Set[String]] =
+    com.github.benmanes.caffeine.cache.Caffeine
+      .newBuilder()
+      .expireAfterWrite(java.time.Duration.ofSeconds(cacheTtlSeconds))
+      .maximumSize(10_000L)
+      .build[String, Set[String]]()
 
   private val httpClient = HttpClient
     .newBuilder()
@@ -49,16 +57,13 @@ class GoogleGroupsLookup(
     * cacheTtlSeconds. Returns an empty set on failure (non-blocking).
     */
   def getGroupsForUser(userEmail: String): Set[String] =
-    val key = userEmail.toLowerCase
-    val now = Instant.now()
-
-    Option(groupsCache.get(key)) match
-      case Some(cached) if now.isBefore(cached.fetchedAt.plusSeconds(cacheTtlSeconds)) =>
-        cached.groups
-      case _ =>
-        val groups = fetchGroups(key)
-        groupsCache.put(key, CachedGroups(groups, now))
-        groups
+    val key    = userEmail.toLowerCase
+    val cached = groupsCache.getIfPresent(key)
+    if cached != null then cached
+    else
+      val groups = fetchGroups(key)
+      groupsCache.put(key, groups)
+      groups
 
   private def fetchGroups(userEmail: String): Set[String] =
     try

--- a/src/main/scala/ai/starlake/quack/edge/cls/ColumnCatalog.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/ColumnCatalog.scala
@@ -12,8 +12,9 @@ trait ColumnCatalog:
 
 object ColumnCatalog:
 
-  /** Test-only static catalog. Construct with the (catalog, schema, table) -> column-list map
-    * you want. Not cached; tests run synchronously. */
+  /** Test-only static catalog. Construct with the (catalog, schema, table) -> column-list map you
+    * want. Not cached; tests run synchronously.
+    */
   final class MapCatalog(rows: Map[(String, String, String), List[String]]) extends ColumnCatalog:
     def columnsOf(c: String, s: String, t: String): IO[List[String]] =
       IO.pure(rows.getOrElse((c, s, t), Nil))

--- a/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
@@ -5,9 +5,7 @@ import ai.starlake.quack.ondemand.rbac.EffectiveSet
 import cats.effect.IO
 import cats.syntax.traverse._
 import net.sf.jsqlparser.parser.CCJSqlParserUtil
-import net.sf.jsqlparser.statement.select.{
-  ParenthesedSelect, PlainSelect, Select, SetOperationList
-}
+import net.sf.jsqlparser.statement.select.{ParenthesedSelect, PlainSelect, Select, SetOperationList}
 
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -17,14 +15,14 @@ import scala.util.{Failure, Success, Try}
   */
 final case class SchemaContext(
     defaultDatabase: Option[String],
-    defaultSchema:   Option[String]
+    defaultSchema: Option[String]
 )
 
 object ColumnPolicyRewriter:
   sealed trait Outcome
   final case class Rewritten(sql: String) extends Outcome
   final case class Denied(reason: String) extends Outcome
-  case object Passthrough                  extends Outcome
+  case object Passthrough                 extends Outcome
 
   /** Inner rewriter could not parse the SQL. Routed identically to [[Passthrough]] (the original
     * SQL is forwarded to the node) but tagged separately on the `column_policy_rewrites_total`
@@ -46,37 +44,37 @@ object ColumnPolicyRewriter:
     val r = reason.toLowerCase
     r.contains("not found") || r.contains("not declared") || r.contains("unknown")
 
-/** Thin facade around a [[SchemaAwareSqlRewriter]]. Handles the IO surface (catalog lookups for
-  * the FROM-item tables) plus the early-exit conditions (superuser, non-SELECT, no policies) and
+/** Thin facade around a [[SchemaAwareSqlRewriter]]. Handles the IO surface (catalog lookups for the
+  * FROM-item tables) plus the early-exit conditions (superuser, non-SELECT, no policies) and
   * delegates the actual SQL walk to the inner rewriter.
   */
 final class ColumnPolicyRewriter(
-    catalog:        ColumnCatalog,
-    inner:          SchemaAwareSqlRewriter = new JsqltranspilerRewriter,
-    unresolvedMode: UnresolvedMode         = UnresolvedMode.Pass
+    catalog: ColumnCatalog,
+    inner: SchemaAwareSqlRewriter = new JsqltranspilerRewriter,
+    unresolvedMode: UnresolvedMode = UnresolvedMode.Pass
 ):
   import ColumnPolicyRewriter._
 
   def rewrite(
-      sql:  String,
+      sql: String,
       kind: StatementKind,
-      eff:  EffectiveSet,
-      ctx:  SchemaContext
+      eff: EffectiveSet,
+      ctx: SchemaContext
   ): IO[Outcome] =
-    if eff.user.tenant.isEmpty            then IO.pure(Passthrough)
-    else if kind != StatementKind.Select  then IO.pure(Passthrough)
-    else if eff.columnPolicies.isEmpty    then IO.pure(Passthrough)
+    if eff.user.tenant.isEmpty then IO.pure(Passthrough)
+    else if kind != StatementKind.Select then IO.pure(Passthrough)
+    else if eff.columnPolicies.isEmpty then IO.pure(Passthrough)
     else
       buildSchema(sql, ctx).map { schema =>
         inner.rewrite(
-          sql            = sql,
-          schema         = schema,
-          policies       = eff.columnPolicies,
+          sql = sql,
+          schema = schema,
+          policies = eff.columnPolicies,
           defaultCatalog = ctx.defaultDatabase,
-          defaultSchema  = ctx.defaultSchema,
+          defaultSchema = ctx.defaultSchema,
           unresolvedMode = unresolvedMode
         ) match
-          case RewriteOutcome.Rewritten(s) => Rewritten(s)
+          case RewriteOutcome.Rewritten(s)   => Rewritten(s)
           case RewriteOutcome.Denied(reason) =>
             if looksUnresolvedTable(reason) then DeniedUnresolvedTable else Denied(reason)
           case RewriteOutcome.Passthrough => Passthrough
@@ -89,7 +87,7 @@ final class ColumnPolicyRewriter(
     */
   private def buildSchema(sql: String, ctx: SchemaContext): IO[Map[String, List[String]]] =
     Try(CCJSqlParserUtil.parse(sql)) match
-      case Failure(_) => IO.pure(Map.empty)
+      case Failure(_)            => IO.pure(Map.empty)
       case Success(stmt: Select) =>
         val tables = schemaKeys(collectTables(stmt, ctx))
         tables.toList
@@ -101,7 +99,7 @@ final class ColumnPolicyRewriter(
 
   private def collectTables(
       stmt: Select,
-      ctx:  SchemaContext
+      ctx: SchemaContext
   ): Map[String, (String, String, String)] =
     val acc = scala.collection.mutable.Map.empty[String, (String, String, String)]
     def visitSel(sel: Select): Unit = sel match
@@ -109,31 +107,31 @@ final class ColumnPolicyRewriter(
         Option(ps.getFromItem).foreach {
           case t: net.sf.jsqlparser.schema.Table => indexTable(t, ctx, acc)
           case sub: ParenthesedSelect            => visitSel(sub.getSelect)
-          case _                                  => ()
+          case _                                 => ()
         }
         Option(ps.getJoins).foreach(_.asScala.foreach { j =>
           Option(j.getRightItem).foreach {
             case t: net.sf.jsqlparser.schema.Table => indexTable(t, ctx, acc)
             case sub: ParenthesedSelect            => visitSel(sub.getSelect)
-            case _                                  => ()
+            case _                                 => ()
           }
         })
-      case ps: ParenthesedSelect  => visitSel(ps.getSelect)
+      case ps: ParenthesedSelect => visitSel(ps.getSelect)
       case sol: SetOperationList =>
         Option(sol.getSelects).foreach(_.asScala.foreach(visitSel))
       case _ => ()
     Option(stmt.getWithItemsList).foreach(_.asScala.foreach { wi =>
       Option(wi.getParenthesedStatement).foreach {
         case ps: ParenthesedSelect => visitSel(ps.getSelect)
-        case _                      => ()
+        case _                     => ()
       }
     })
     visitSel(stmt)
     acc.toMap
 
   /** Key the schema map by the raw table name AND by each alias pointing at it, so the resolver
-    * accepts both `SELECT * FROM customer` and `SELECT c.* FROM customer c`. JSQLColumResolver
-    * uses the row's first element as the table-name match key.
+    * accepts both `SELECT * FROM customer` and `SELECT c.* FROM customer c`. JSQLColumResolver uses
+    * the row's first element as the table-name match key.
     */
   private def schemaKeys(
       tables: Map[String, (String, String, String)]
@@ -145,13 +143,14 @@ final class ColumnPolicyRewriter(
     tables.values.map { case (cat, sch, tab) => tab -> (cat, sch, tab) }.toMap
 
   private def indexTable(
-      t:   net.sf.jsqlparser.schema.Table,
+      t: net.sf.jsqlparser.schema.Table,
       ctx: SchemaContext,
       acc: scala.collection.mutable.Map[String, (String, String, String)]
   ): Unit =
     val rawName    = t.getName
     val schemaName = Option(t.getSchemaName).getOrElse(ctx.defaultSchema.getOrElse(""))
-    val catalog    = Option(t.getDatabase).flatMap(d => Option(d.getDatabaseName))
-                       .getOrElse(ctx.defaultDatabase.getOrElse(""))
-    val key        = Option(t.getAlias).map(_.getName).getOrElse(rawName)
+    val catalog    = Option(t.getDatabase)
+      .flatMap(d => Option(d.getDatabaseName))
+      .getOrElse(ctx.defaultDatabase.getOrElse(""))
+    val key = Option(t.getAlias).map(_.getName).getOrElse(rawName)
     acc(key) = (catalog, schemaName, rawName)

--- a/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
@@ -2,15 +2,11 @@ package ai.starlake.quack.edge.cls
 
 import ai.starlake.quack.model.StatementKind
 import ai.starlake.quack.ondemand.rbac.EffectiveSet
-import ai.starlake.quack.ondemand.state.RoleColumnPolicy
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
-import net.sf.jsqlparser.expression.Expression
-import net.sf.jsqlparser.expression.operators.relational.ExpressionList
+import cats.syntax.traverse._
 import net.sf.jsqlparser.parser.CCJSqlParserUtil
 import net.sf.jsqlparser.statement.select.{
-  AllColumns, AllTableColumns, ParenthesedSelect, PlainSelect, Select, SelectItem,
-  SetOperationList, WithItem
+  ParenthesedSelect, PlainSelect, Select, SetOperationList
 }
 
 import scala.jdk.CollectionConverters._
@@ -30,15 +26,15 @@ object ColumnPolicyRewriter:
   final case class Denied(reason: String) extends Outcome
   case object Passthrough                  extends Outcome
 
-/** Rewrites SELECT statements to enforce column-level policies carried in the caller's
-  * [[EffectiveSet]]. Non-SELECT statements, superusers, users with no column policies, and
-  * unparseable SQL all pass through unchanged (the query will succeed or fail on its own merit).
-  *
-  * Handles flat projection rewriting and recursive descent through every nested SELECT:
-  * subqueries in the projection, FROM-item subqueries, CTE bodies via WITH, and
-  * UNION / INTERSECT / EXCEPT arms via SetOperationList.
+/** Thin facade around a [[SchemaAwareSqlRewriter]]. Handles the IO surface (catalog lookups for
+  * the FROM-item tables) plus the early-exit conditions (superuser, non-SELECT, no policies) and
+  * delegates the actual SQL walk to the inner rewriter.
   */
-final class ColumnPolicyRewriter(catalog: ColumnCatalog):
+final class ColumnPolicyRewriter(
+    catalog:        ColumnCatalog,
+    inner:          SchemaAwareSqlRewriter = new JsqltranspilerRewriter,
+    unresolvedMode: UnresolvedMode         = UnresolvedMode.Passthrough
+):
   import ColumnPolicyRewriter._
 
   def rewrite(
@@ -46,188 +42,86 @@ final class ColumnPolicyRewriter(catalog: ColumnCatalog):
       kind: StatementKind,
       eff:  EffectiveSet,
       ctx:  SchemaContext
-  ): IO[Outcome] = IO.defer {
+  ): IO[Outcome] =
     if eff.user.tenant.isEmpty            then IO.pure(Passthrough)
     else if kind != StatementKind.Select  then IO.pure(Passthrough)
     else if eff.columnPolicies.isEmpty    then IO.pure(Passthrough)
     else
-      Try(CCJSqlParserUtil.parse(sql)) match
-        case Failure(_)            => IO.pure(Passthrough)
-        case Success(stmt: Select) => IO.delay(applyToStatement(stmt, eff, ctx))
-        case Success(_)            => IO.pure(Passthrough)
-  }
+      buildSchema(sql, ctx).map { schema =>
+        inner.rewrite(
+          sql            = sql,
+          schema         = schema,
+          policies       = eff.columnPolicies,
+          defaultCatalog = ctx.defaultDatabase,
+          defaultSchema  = ctx.defaultSchema,
+          unresolvedMode = unresolvedMode
+        ) match
+          case RewriteOutcome.Rewritten(s)   => Rewritten(s)
+          case RewriteOutcome.Denied(reason) => Denied(reason)
+          case RewriteOutcome.Passthrough    => Passthrough
+          case RewriteOutcome.ParseFailed    => Passthrough
+      }
 
-  private final case class DenyException(reason: String) extends RuntimeException(reason)
-
-  /** Top-level coordinator. Walks the entire statement tree calling per-PlainSelect logic. */
-  private def applyToStatement(stmt: Select, eff: EffectiveSet, ctx: SchemaContext): Outcome =
-    val changed = new java.util.concurrent.atomic.AtomicBoolean(false)
-    try
-      // CTEs declared on the top-level Select.
-      Option(stmt.getWithItemsList).foreach(_.asScala.foreach { wi =>
-        applyToWithItem(wi, eff, ctx, changed)
-      })
-      // The Select body (PlainSelect, SetOperationList, ParenthesedSelect, ...).
-      applyToSelectBody(stmt, eff, ctx, changed)
-      if changed.get then Rewritten(stmt.toString) else Passthrough
-    catch
-      case e: DenyException => Denied(e.reason)
-
-  /** Dispatch helper: recurses into the appropriate kind of select node. */
-  private def applyToSelectBody(
-      sel:     Select,
-      eff:     EffectiveSet,
-      ctx:     SchemaContext,
-      changed: java.util.concurrent.atomic.AtomicBoolean
-  ): Unit =
-    sel match
-      case ps: PlainSelect =>
-        applyToPlainSelect(ps, eff, ctx, changed)
-      case ps: ParenthesedSelect =>
-        // A ParenthesedSelect may carry its own WITH clause.
-        Option(ps.getWithItemsList).foreach(_.asScala.foreach { wi =>
-          applyToWithItem(wi, eff, ctx, changed)
-        })
-        applyToSelectBody(ps.getSelect, eff, ctx, changed)
-      case sol: SetOperationList =>
-        Option(sol.getSelects).foreach(_.asScala.foreach { arm =>
-          applyToSelectBody(arm, eff, ctx, changed)
-        })
-      case _ => ()
-
-  /** Handle a CTE body. In JSqlParser 5.x, WithItem carries the body as a ParenthesedStatement
-    * (accessible via getParenthesedStatement()), which at runtime is a ParenthesedSelect.
+  /** Pre-parse to enumerate FROM-item tables and fetch their column lists from the catalog.
+    * Failures (unparseable SQL, missing catalog entry) silently omit the table - the resolver's
+    * `unresolvedMode` then decides what to do.
     */
-  private def applyToWithItem(
-      wi:      WithItem[?],
-      eff:     EffectiveSet,
-      ctx:     SchemaContext,
-      changed: java.util.concurrent.atomic.AtomicBoolean
-  ): Unit =
-    Option(wi.getParenthesedStatement).foreach {
-      case ps: ParenthesedSelect => applyToSelectBody(ps, eff, ctx, changed)
-      case _                     => ()
-    }
+  private def buildSchema(sql: String, ctx: SchemaContext): IO[Map[String, List[String]]] =
+    Try(CCJSqlParserUtil.parse(sql)) match
+      case Failure(_) => IO.pure(Map.empty)
+      case Success(stmt: Select) =>
+        val tables = schemaKeys(collectTables(stmt, ctx))
+        tables.toList
+          .traverse { case (key, (cat, sch, tab)) =>
+            catalog.columnsOf(cat, sch, tab).map(cols => key -> cols)
+          }
+          .map(_.toMap)
+      case Success(_) => IO.pure(Map.empty)
 
-  /** Wraps a Column in a SelectItem (no alias). */
-  private def buildSelectItem(col: net.sf.jsqlparser.schema.Column): SelectItem[?] =
-    new SelectItem(col)
-
-  /** Rewrite the projection items of a PlainSelect and recurse into FROM-item subqueries. */
-  private def applyToPlainSelect(
-      ps:      PlainSelect,
-      eff:     EffectiveSet,
-      ctx:     SchemaContext,
-      changed: java.util.concurrent.atomic.AtomicBoolean
-  ): Unit =
-    val tableMap = resolveTables(ps, ctx)
-
-    // (1) STAR EXPANSION: expand `*` and `t.*` via the catalog BEFORE the projection walk.
-    //     Build a replacement list; bail out (leaving items unchanged) if the catalog has no
-    //     entry or the table cannot be resolved unambiguously.
-    val rawItems = ps.getSelectItems
-    if rawItems != null && !rawItems.isEmpty then
-      val expanded = new java.util.ArrayList[SelectItem[?]](rawItems.size)
-      var sawStar  = false
-      var bail     = false
-      val it0 = rawItems.iterator()
-      while it0.hasNext && !bail do
-        val si  = it0.next()
-        val ex  = si.getExpression
-        ex match
-          case atc: AllTableColumns =>
-            // `t.*` - look up the alias / table name in tableMap
-            sawStar = true
-            val key = Option(atc.getTable).map(_.getName).getOrElse("")
-            tableMap.get(key) match
-              case Some((cat, sch, tab)) =>
-                val cols = catalog.columnsOf(cat, sch, tab).unsafeRunSync()
-                if cols.isEmpty then bail = true
-                else cols.foreach { name =>
-                  val col = new net.sf.jsqlparser.schema.Column(
-                    new net.sf.jsqlparser.schema.Table(key), name
-                  )
-                  expanded.add(buildSelectItem(col))
-                }
-              case None => bail = true
-          case _: AllColumns =>
-            // Unqualified `*` - only expand when there is exactly one FROM table
-            sawStar = true
-            if tableMap.size != 1 then bail = true
-            else
-              val (cat, sch, tab) = tableMap.values.head
-              val cols = catalog.columnsOf(cat, sch, tab).unsafeRunSync()
-              if cols.isEmpty then bail = true
-              else cols.foreach { name =>
-                expanded.add(buildSelectItem(new net.sf.jsqlparser.schema.Column(name)))
-              }
-          case _ =>
-            expanded.add(si)
-
-      // Only swap in the expanded list when we actually saw a star AND the expansion succeeded.
-      if bail then return    // caller sees no changed.set(true) and ends up with Passthrough
-      if sawStar then
-        ps.setSelectItems(expanded.asInstanceOf[java.util.List[SelectItem[?]]])
-        changed.set(true)
-    // END STAR EXPANSION
-
-    // (2) Recurse into FROM-item subqueries before walking the projection.
-    Option(ps.getFromItem).foreach {
-      case sub: ParenthesedSelect => applyToSelectBody(sub, eff, ctx, changed)
-      case _                      => ()
-    }
-    Option(ps.getJoins).foreach(_.asScala.foreach { j =>
-      Option(j.getRightItem).foreach {
-        case sub: ParenthesedSelect => applyToSelectBody(sub, eff, ctx, changed)
+  private def collectTables(
+      stmt: Select,
+      ctx:  SchemaContext
+  ): Map[String, (String, String, String)] =
+    val acc = scala.collection.mutable.Map.empty[String, (String, String, String)]
+    def visitSel(sel: Select): Unit = sel match
+      case ps: PlainSelect =>
+        Option(ps.getFromItem).foreach {
+          case t: net.sf.jsqlparser.schema.Table => indexTable(t, ctx, acc)
+          case sub: ParenthesedSelect            => visitSel(sub.getSelect)
+          case _                                  => ()
+        }
+        Option(ps.getJoins).foreach(_.asScala.foreach { j =>
+          Option(j.getRightItem).foreach {
+            case t: net.sf.jsqlparser.schema.Table => indexTable(t, ctx, acc)
+            case sub: ParenthesedSelect            => visitSel(sub.getSelect)
+            case _                                  => ()
+          }
+        })
+      case ps: ParenthesedSelect  => visitSel(ps.getSelect)
+      case sol: SetOperationList =>
+        Option(sol.getSelects).foreach(_.asScala.foreach(visitSel))
+      case _ => ()
+    Option(stmt.getWithItemsList).foreach(_.asScala.foreach { wi =>
+      Option(wi.getParenthesedStatement).foreach {
+        case ps: ParenthesedSelect => visitSel(ps.getSelect)
         case _                      => ()
       }
     })
-
-    // (3) WHERE clause.
-    Option(ps.getWhere).foreach { w =>
-      val local = new java.util.concurrent.atomic.AtomicBoolean(false)
-      val rewritten = walkAndReplace(w, tableMap, eff, ctx, local, changed)
-      if local.get then ps.setWhere(rewritten)
-    }
-
-    // (4) HAVING clause.
-    Option(ps.getHaving).foreach { h =>
-      val local = new java.util.concurrent.atomic.AtomicBoolean(false)
-      val rewritten = walkAndReplace(h, tableMap, eff, ctx, local, changed)
-      if local.get then ps.setHaving(rewritten)
-    }
-
-    // (5) Walk projection items (now fully expanded - no stars remain).
-    val items = ps.getSelectItems
-    if items != null && !items.isEmpty then
-      val it = items.listIterator()
-      while it.hasNext do
-        val si   = it.next()
-        val expr = si.getExpression
-        rewriteExpression(expr, tableMap, eff, ctx, changed) match
-          case Some(newExpr) =>
-            // SelectItem<T>.setExpression(T) - erase the wildcard via asInstanceOf.
-            si.asInstanceOf[SelectItem[Expression]].setExpression(newExpr)
-            changed.set(true)
-          case None => ()
-
-  /** Build alias -> (catalog, schema, table) from FROM + JOINs. Defaults come from ctx. */
-  private def resolveTables(
-      ps:  PlainSelect,
-      ctx: SchemaContext
-  ): Map[String, (String, String, String)] =
-    val acc = scala.collection.mutable.Map.empty[String, (String, String, String)]
-    Option(ps.getFromItem).foreach {
-      case t: net.sf.jsqlparser.schema.Table => indexTable(t, ctx, acc)
-      case _                                 => ()
-    }
-    Option(ps.getJoins).foreach(_.asScala.foreach { j =>
-      Option(j.getRightItem).foreach {
-        case t: net.sf.jsqlparser.schema.Table => indexTable(t, ctx, acc)
-        case _                                 => ()
-      }
-    })
+    visitSel(stmt)
     acc.toMap
+
+  /** Key the schema map by the raw table name AND by each alias pointing at it, so the resolver
+    * accepts both `SELECT * FROM customer` and `SELECT c.* FROM customer c`. JSQLColumResolver
+    * uses the row's first element as the table-name match key.
+    */
+  private def schemaKeys(
+      tables: Map[String, (String, String, String)]
+  ): Map[String, (String, String, String)] =
+    // We seed the map with raw table names so the resolver's expansion of `c.*` finds
+    // the column list under the base table name. Alias-keyed entries are dropped because
+    // they would duplicate the same column list under a key that is just an alias, and the
+    // resolver only matches by table identifier.
+    tables.values.map { case (cat, sch, tab) => tab -> (cat, sch, tab) }.toMap
 
   private def indexTable(
       t:   net.sf.jsqlparser.schema.Table,
@@ -240,106 +134,3 @@ final class ColumnPolicyRewriter(catalog: ColumnCatalog):
                        .getOrElse(ctx.defaultDatabase.getOrElse(""))
     val key        = Option(t.getAlias).map(_.getName).getOrElse(rawName)
     acc(key) = (catalog, schemaName, rawName)
-
-  /** Replace the expression if it resolves to a covered column.
-    * Returns Some(newExpr) if anything changed, None if nothing did.
-    * Throws DenyException on deny. If the expression contains a ParenthesedSelect,
-    * recurses into it and reports changed if any inner rewrite happened.
-    */
-  private def rewriteExpression(
-      expr:     Expression,
-      tableMap: Map[String, (String, String, String)],
-      eff:      EffectiveSet,
-      ctx:      SchemaContext,
-      changed:  java.util.concurrent.atomic.AtomicBoolean
-  ): Option[Expression] =
-    expr match
-      case col: net.sf.jsqlparser.schema.Column =>
-        matchingPolicy(col, tableMap, eff) match
-          case Some(p) if p.action == "deny" =>
-            throw DenyException(s"column ${formatColumn(col)} is denied")
-          case Some(p) =>
-            Some(CCJSqlParserUtil.parseExpression(p.transformSql.get))
-          case None => None
-      case sub: ParenthesedSelect =>
-        val before = changed.get
-        applyToSelectBody(sub, eff, ctx, changed)
-        if changed.get && !before then Some(sub) else None
-      case _ =>
-        val local = new java.util.concurrent.atomic.AtomicBoolean(false)
-        walkAndReplace(expr, tableMap, eff, ctx, local, changed)
-        if local.get then Some(expr) else None
-
-  private def walkAndReplace(
-      expr:    Expression,
-      tableMap: Map[String, (String, String, String)],
-      eff:     EffectiveSet,
-      ctx:     SchemaContext,
-      local:   java.util.concurrent.atomic.AtomicBoolean,
-      changed: java.util.concurrent.atomic.AtomicBoolean
-  ): Expression =
-    expr match
-      case col: net.sf.jsqlparser.schema.Column =>
-        matchingPolicy(col, tableMap, eff) match
-          case Some(p) if p.action == "deny" =>
-            throw DenyException(s"column ${formatColumn(col)} is denied")
-          case Some(p) =>
-            local.set(true)
-            changed.set(true)
-            CCJSqlParserUtil.parseExpression(p.transformSql.get)
-          case None => col
-      case sub: ParenthesedSelect =>
-        applyToSelectBody(sub, eff, ctx, changed)
-        sub
-      case fn: net.sf.jsqlparser.expression.Function =>
-        Option(fn.getParameters).foreach { params =>
-          val rawList = params.asInstanceOf[ExpressionList[Expression]]
-          val it = rawList.listIterator()
-          while it.hasNext do
-            val cur = it.next()
-            val nxt = walkAndReplace(cur, tableMap, eff, ctx, local, changed)
-            if nxt ne cur then it.set(nxt)
-        }
-        fn
-      case b: net.sf.jsqlparser.expression.BinaryExpression =>
-        b.setLeftExpression(walkAndReplace(b.getLeftExpression, tableMap, eff, ctx, local, changed))
-        b.setRightExpression(walkAndReplace(b.getRightExpression, tableMap, eff, ctx, local, changed))
-        b
-      case p: net.sf.jsqlparser.expression.Parenthesis =>
-        p.setExpression(walkAndReplace(p.getExpression, tableMap, eff, ctx, local, changed))
-        p
-      case other => other
-
-  private def matchingPolicy(
-      col:      net.sf.jsqlparser.schema.Column,
-      tableMap: Map[String, (String, String, String)],
-      eff:      EffectiveSet
-  ): Option[RoleColumnPolicy] =
-    val colName  = Option(col.getColumnName).getOrElse("").toLowerCase
-    val tableKey = Option(col.getTable).map(_.getName).getOrElse {
-      // When there is exactly one FROM item treat it as the implicit table source.
-      if tableMap.size == 1 then tableMap.keys.head else ""
-    }
-    val (cat, sch, tab) = tableMap.getOrElse(tableKey, ("", "", ""))
-    // Primary lookup: match on fully-resolved (catalog, schema, table) coordinates.
-    val direct = eff.columnPolicies.find { p =>
-      matchWildcard(p.catalogName, cat) &&
-      matchWildcard(p.schemaName,  sch) &&
-      matchWildcard(p.tableName,   tab) &&
-      p.columnName.equalsIgnoreCase(colName)
-    }
-    if direct.isDefined then direct
-    // Fallback for columns in derived-table contexts where the base table cannot be resolved
-    // (e.g. outer query referencing a column produced by a subquery alias). Apply masking by
-    // column name alone when the column has no explicit table qualifier and no base-table
-    // coordinates could be inferred.  This is conservative: if ANY policy covers this column
-    // name we mask it, preventing a masked column from leaking through a derived table.
-    else if tableKey.isEmpty || tab.isEmpty then
-      eff.columnPolicies.find { p => p.columnName.equalsIgnoreCase(colName) }
-    else None
-
-  private def matchWildcard(grant: String, ref: String): Boolean =
-    grant == RoleColumnPolicy.Wildcard || grant.equalsIgnoreCase(ref)
-
-  private def formatColumn(col: net.sf.jsqlparser.schema.Column): String =
-    Option(col.getTable).map(_.getName + "." + col.getColumnName).getOrElse(col.getColumnName)

--- a/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
@@ -45,13 +45,21 @@ object ColumnPolicyRewriter:
     r.contains("not found") || r.contains("not declared") || r.contains("unknown")
 
 /** Thin facade around a [[SchemaAwareSqlRewriter]]. Handles the IO surface (catalog lookups for the
-  * FROM-item tables) plus the early-exit conditions (superuser, non-SELECT, no policies) and
-  * delegates the actual SQL walk to the inner rewriter.
+  * FROM-item tables) plus the early-exit conditions (feature disabled, superuser, non-SELECT, no
+  * policies) and delegates the actual SQL walk to the inner rewriter.
+  *
+  * `enabled` is the kill switch. When false (the default), every call short-circuits to
+  * [[Passthrough]] without touching the catalog or the inner rewriter. Column-level security is
+  * EXPERIMENTAL: operators must opt in via `quack-on-demand.cls.enabled = true` (or
+  * `QOD_CLS_ENABLED=true`). Defaulting off avoids surprising existing deployments and lets us
+  * harden the rewriter against federated-source / LateralSubSelect / TableFunction edges in
+  * follow-up releases.
   */
 final class ColumnPolicyRewriter(
     catalog: ColumnCatalog,
     inner: SchemaAwareSqlRewriter = new JsqltranspilerRewriter,
-    unresolvedMode: UnresolvedMode = UnresolvedMode.Pass
+    unresolvedMode: UnresolvedMode = UnresolvedMode.Pass,
+    enabled: Boolean = false
 ):
   import ColumnPolicyRewriter._
 
@@ -61,7 +69,8 @@ final class ColumnPolicyRewriter(
       eff: EffectiveSet,
       ctx: SchemaContext
   ): IO[Outcome] =
-    if eff.user.tenant.isEmpty then IO.pure(Passthrough)
+    if !enabled then IO.pure(Passthrough)
+    else if eff.user.tenant.isEmpty then IO.pure(Passthrough)
     else if kind != StatementKind.Select then IO.pure(Passthrough)
     else if eff.columnPolicies.isEmpty then IO.pure(Passthrough)
     else

--- a/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
@@ -53,7 +53,7 @@ object ColumnPolicyRewriter:
 final class ColumnPolicyRewriter(
     catalog:        ColumnCatalog,
     inner:          SchemaAwareSqlRewriter = new JsqltranspilerRewriter,
-    unresolvedMode: UnresolvedMode         = UnresolvedMode.Passthrough
+    unresolvedMode: UnresolvedMode         = UnresolvedMode.Pass
 ):
   import ColumnPolicyRewriter._
 

--- a/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriter.scala
@@ -26,6 +26,26 @@ object ColumnPolicyRewriter:
   final case class Denied(reason: String) extends Outcome
   case object Passthrough                  extends Outcome
 
+  /** Inner rewriter could not parse the SQL. Routed identically to [[Passthrough]] (the original
+    * SQL is forwarded to the node) but tagged separately on the `column_policy_rewrites_total`
+    * counter so dashboards can distinguish "no policy applied" from "rewriter blind".
+    */
+  case object PassthroughParseFailed extends Outcome
+
+  /** Inner rewriter raised a deny because the table/schema/catalog could not be resolved, not
+    * because a policy matched. Same wire-level error as [[Denied]] but tagged separately so
+    * dashboards can split policy denies from missing-coordinate denies.
+    */
+  case object DeniedUnresolvedTable extends Outcome
+
+  /** Heuristic for spotting a deny that originated from jsqltranspiler's
+    * Table/Schema/Catalog/ColumnNotFound* exceptions: their messages contain "not found", "not
+    * declared", or "unknown". Anything else falls through to a regular policy-driven [[Denied]].
+    */
+  private[cls] def looksUnresolvedTable(reason: String): Boolean =
+    val r = reason.toLowerCase
+    r.contains("not found") || r.contains("not declared") || r.contains("unknown")
+
 /** Thin facade around a [[SchemaAwareSqlRewriter]]. Handles the IO surface (catalog lookups for
   * the FROM-item tables) plus the early-exit conditions (superuser, non-SELECT, no policies) and
   * delegates the actual SQL walk to the inner rewriter.
@@ -56,10 +76,11 @@ final class ColumnPolicyRewriter(
           defaultSchema  = ctx.defaultSchema,
           unresolvedMode = unresolvedMode
         ) match
-          case RewriteOutcome.Rewritten(s)   => Rewritten(s)
-          case RewriteOutcome.Denied(reason) => Denied(reason)
-          case RewriteOutcome.Passthrough    => Passthrough
-          case RewriteOutcome.ParseFailed    => Passthrough
+          case RewriteOutcome.Rewritten(s) => Rewritten(s)
+          case RewriteOutcome.Denied(reason) =>
+            if looksUnresolvedTable(reason) then DeniedUnresolvedTable else Denied(reason)
+          case RewriteOutcome.Passthrough => Passthrough
+          case RewriteOutcome.ParseFailed => PassthroughParseFailed
       }
 
   /** Pre-parse to enumerate FROM-item tables and fetch their column lists from the catalog.

--- a/src/main/scala/ai/starlake/quack/edge/cls/DuckLakeColumnCatalog.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/DuckLakeColumnCatalog.scala
@@ -6,16 +6,16 @@ import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 
 import java.time.Duration
 
-/** Backed by an injected `fetch` function so we don't bind to a concrete `DuckLakeCatalogReader`
-  * in this file (Task 15 wires the production fetcher in `Main.scala`). Caches at 5-second TTL
-  * keyed by (catalog, schema, table) -- same TTL the catalog-browser endpoint uses (consistent
-  * operator mental model). Failures cache as `Nil` for a tick so a broken federated source doesn't
-  * pin a slow path forever.
+/** Backed by an injected `fetch` function so we don't bind to a concrete `DuckLakeCatalogReader` in
+  * this file (Task 15 wires the production fetcher in `Main.scala`). Caches at 5-second TTL keyed
+  * by (catalog, schema, table) -- same TTL the catalog-browser endpoint uses (consistent operator
+  * mental model). Failures cache as `Nil` for a tick so a broken federated source doesn't pin a
+  * slow path forever.
   *
   * `instruments` is optional so existing test wiring that constructs `DuckLakeColumnCatalog`
   * directly keeps compiling without changes. When provided, cache hits/misses/errors are recorded
-  * under `column_policy_catalog_lookups_total` with `tenant=""` / `pool=""` placeholder tags;
-  * a follow-up task will thread per-statement (tenant, pool) context once it is available here.
+  * under `column_policy_catalog_lookups_total` with `tenant=""` / `pool=""` placeholder tags; a
+  * follow-up task will thread per-statement (tenant, pool) context once it is available here.
   */
 final class DuckLakeColumnCatalog(
     fetch: (String, String, String) => IO[List[String]],
@@ -23,7 +23,8 @@ final class DuckLakeColumnCatalog(
 ) extends ColumnCatalog:
 
   private val cache: Cache[(String, String, String), List[String]] =
-    Caffeine.newBuilder()
+    Caffeine
+      .newBuilder()
       .expireAfterWrite(Duration.ofSeconds(5))
       .maximumSize(4096)
       .build()
@@ -35,8 +36,7 @@ final class DuckLakeColumnCatalog(
         instruments.foreach(_.recordColumnPolicyCatalogLookup("", "", "hit"))
         IO.pure(cached)
       case None =>
-        fetch(catalog, schemaName, tableName)
-          .attempt
+        fetch(catalog, schemaName, tableName).attempt
           .map {
             case Right(cols) =>
               cache.put(key, cols)

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -87,8 +87,15 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       policies: List[RoleColumnPolicy]
   ): (Boolean, Select) =
     val changed = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val visitor = new PolicyVisitor(policies, changed)
+
     sel match
       case ps: PlainSelect =>
+        // FROM-tables of this select (key -> table). Single-table case lets the visitor resolve
+        // an unqualified column reference to the implicit table. Used inside composite expressions
+        // (function args, BETWEEN bounds, CASE arms, etc.) where the resolver doesn't expand the
+        // qualifier.
+        visitor.fromTables = collectFromTables(ps)
         val items = ps.getSelectItems
         if items != null then
           val it  = items.listIterator()
@@ -96,17 +103,105 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           while it.hasNext do
             val si           = it.next()
             val (table, col) = if origins.indices.contains(idx) then origins(idx) else ("", "")
-            matchingPolicy(table, col, policies) match
-              case Some(p) if p.action == RoleColumnPolicy.ActionDeny =>
-                throw DenyException(s"column $table.$col is denied")
-              case Some(p) =>
-                val replacement = CCJSqlParserUtil.parseExpression(p.transformSql.get)
-                si.asInstanceOf[SelectItem[Expression]].setExpression(replacement)
-                changed.set(true)
-              case None => ()
+            // Top-level column origin override: the resolver knows the physical lineage of the
+            // projection slot even if the expression at that slot is itself a Column whose name
+            // is an alias of another column.
+            visitor.topLevelOverride = Some((table, col))
+            val expr     = si.getExpression
+            val replaced = visitor.visit(expr)
+            if (replaced ne expr) then
+              si.asInstanceOf[SelectItem[Expression]].setExpression(replaced)
+              changed.set(true)
+            visitor.topLevelOverride = None
             idx += 1
       case _ => ()
     (changed.get, sel)
+
+  /** Build a list of (alias -> rawTableName) for the FROM + JOINs of a PlainSelect. */
+  private def collectFromTables(ps: PlainSelect): List[(String, String)] =
+    val buf = scala.collection.mutable.ListBuffer.empty[(String, String)]
+    def add(t: net.sf.jsqlparser.schema.Table): Unit =
+      val raw = t.getName
+      val key = Option(t.getAlias).map(_.getName).getOrElse(raw)
+      buf += (key -> raw)
+    Option(ps.getFromItem).foreach {
+      case t: net.sf.jsqlparser.schema.Table => add(t)
+      case _                                 => ()
+    }
+    Option(ps.getJoins).foreach { joins =>
+      val it = joins.iterator()
+      while it.hasNext do
+        Option(it.next().getRightItem).foreach {
+          case t: net.sf.jsqlparser.schema.Table => add(t)
+          case _                                 => ()
+        }
+    }
+    buf.toList
+
+  private final class PolicyVisitor(
+      policies: List[RoleColumnPolicy],
+      changed: java.util.concurrent.atomic.AtomicBoolean
+  ):
+    var topLevelOverride: Option[(String, String)] = None
+    var fromTables: List[(String, String)]         = Nil
+
+    /** Resolve the physical table for a Column reference. */
+    private def resolveTable(col: net.sf.jsqlparser.schema.Column): String =
+      Option(col.getTable).map(_.getName) match
+        case Some(key) =>
+          // Alias or table-name qualifier - look up the base table behind the alias.
+          fromTables.find(_._1.equalsIgnoreCase(key)).map(_._2).getOrElse(key)
+        case None =>
+          // Unqualified - fall back to the single FROM item if there is exactly one.
+          if fromTables.size == 1 then fromTables.head._2 else ""
+
+    /** Walk `expr` and return its replacement (same instance if nothing changed). */
+    def visit(expr: Expression): Expression =
+      expr match
+        case col: net.sf.jsqlparser.schema.Column =>
+          val (tableName, columnName) = topLevelOverride.getOrElse {
+            (resolveTable(col), col.getColumnName)
+          }
+          matchingPolicy(tableName, columnName, policies) match
+            case Some(p) if p.action == RoleColumnPolicy.ActionDeny =>
+              throw DenyException(s"column $tableName.$columnName is denied")
+            case Some(p) =>
+              changed.set(true)
+              CCJSqlParserUtil.parseExpression(p.transformSql.get)
+            case None => col
+
+        case fn: net.sf.jsqlparser.expression.Function =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          Option(fn.getParameters).foreach { params =>
+            val list = params.asInstanceOf[
+              net.sf.jsqlparser.expression.operators.relational.ExpressionList[Expression]
+            ]
+            val it = list.listIterator()
+            while it.hasNext do
+              val cur = it.next()
+              val nxt = visit(cur)
+              if nxt ne cur then it.set(nxt)
+          }
+          topLevelOverride = saved
+          fn
+
+        case b: net.sf.jsqlparser.expression.BinaryExpression =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          b.setLeftExpression(visit(b.getLeftExpression))
+          b.setRightExpression(visit(b.getRightExpression))
+          topLevelOverride = saved
+          b
+
+        case p: net.sf.jsqlparser.expression.Parenthesis =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          p.setExpression(visit(p.getExpression))
+          topLevelOverride = saved
+          p
+
+        case other => other
 
   private def matchingPolicy(
       table: String,

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -225,6 +225,18 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           topLevelOverride = saved
           p
 
+        case bt: net.sf.jsqlparser.expression.operators.relational.Between =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          val l = visit(bt.getLeftExpression)
+          if l ne bt.getLeftExpression then bt.setLeftExpression(l)
+          val s = visit(bt.getBetweenExpressionStart)
+          if s ne bt.getBetweenExpressionStart then bt.setBetweenExpressionStart(s)
+          val e = visit(bt.getBetweenExpressionEnd)
+          if e ne bt.getBetweenExpressionEnd then bt.setBetweenExpressionEnd(e)
+          topLevelOverride = saved
+          bt
+
         case ix: net.sf.jsqlparser.expression.operators.relational.InExpression =>
           val saved = topLevelOverride
           topLevelOverride = None

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -201,6 +201,14 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           topLevelOverride = saved
           p
 
+        case cx: net.sf.jsqlparser.expression.CastExpression =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          val nxt = visit(cx.getLeftExpression)
+          if nxt ne cx.getLeftExpression then cx.setLeftExpression(nxt)
+          topLevelOverride = saved
+          cx
+
         case ce: net.sf.jsqlparser.expression.CaseExpression =>
           val saved = topLevelOverride
           topLevelOverride = None

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -105,12 +105,51 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
     }
 
     sel match
+      case sol: net.sf.jsqlparser.statement.select.SetOperationList =>
+        // UNION / INTERSECT / EXCEPT: recurse into every arm. Each arm has its own FROM clause
+        // and its own per-column policy lookup; outer-query origins don't apply.
+        Option(sol.getSelects).foreach(_.forEach { arm =>
+          val (armChanged, _) = applyPolicies(arm, IndexedSeq.empty, policies)
+          if armChanged then changed.set(true)
+        })
+      case wrap: net.sf.jsqlparser.statement.select.ParenthesedSelect =>
+        // Top-level parenthesized SELECT: unwrap and recurse.
+        val (innerChanged, _) = applyPolicies(wrap.getSelect, IndexedSeq.empty, policies)
+        if innerChanged then changed.set(true)
       case ps: PlainSelect =>
         // FROM-tables of this select (key -> table). Single-table case lets the visitor resolve
         // an unqualified column reference to the implicit table. Used inside composite expressions
         // (function args, BETWEEN bounds, CASE arms, etc.) where the resolver doesn't expand the
         // qualifier.
         visitor.fromTables = collectFromTables(ps)
+        // FROM-item subquery: recurse so policies apply inside `FROM (SELECT ... FROM customer)`.
+        // The outer projection still references the subquery via its alias and the projected name.
+        // Before recursion (which would mutate inner Columns into transform literals) we snapshot
+        // the inner SELECT's exposed covered columns and synthesize transient policies so the outer
+        // projection masks `sub.c_email` too. The resolver's ResultSet lineage stops at the FROM
+        // boundary in jsqltranspiler 1.9, so we trace it ourselves.
+        val derivedPolicies = scala.collection.mutable.ListBuffer.empty[RoleColumnPolicy]
+        Option(ps.getFromItem).foreach {
+          case sub: net.sf.jsqlparser.statement.select.ParenthesedSelect =>
+            derivedPolicies ++= deriveOuterPolicies(sub, policies)
+            val (innerChanged, _) = applyPolicies(sub.getSelect, IndexedSeq.empty, policies)
+            if innerChanged then changed.set(true)
+          case _ => ()
+        }
+        Option(ps.getJoins).foreach(_.forEach { j =>
+          Option(j.getRightItem).foreach {
+            case sub: net.sf.jsqlparser.statement.select.ParenthesedSelect =>
+              derivedPolicies ++= deriveOuterPolicies(sub, policies)
+              val (innerChanged, _) = applyPolicies(sub.getSelect, IndexedSeq.empty, policies)
+              if innerChanged then changed.set(true)
+            case _ => ()
+          }
+        })
+        // Augment the visitor's policies with any synthesized ones so the outer projection sees
+        // `sub.c_email` (or alias.colalias) as covered. The synthesized policies use the FROM-item
+        // alias as the tableName, so resolveTable's alias-equality fallback can match them.
+        if derivedPolicies.nonEmpty then
+          visitor.extraPolicies = derivedPolicies.toList
         val items = ps.getSelectItems
         if items != null then
           val it  = items.listIterator()
@@ -158,26 +197,72 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       case _ => ()
     (changed.get, sel)
 
-  /** Build a list of (alias -> rawTableName) for the FROM + JOINs of a PlainSelect. */
+  /** Build a list of (alias -> rawTableName) for the FROM + JOINs of a PlainSelect. FROM-item
+    * subqueries are recorded as (alias -> alias) so synthetic policies keyed on the alias can be
+    * matched by the visitor's resolveTable fallback (single-FROM unqualified column case).
+    */
   private def collectFromTables(ps: PlainSelect): List[(String, String)] =
     val buf = scala.collection.mutable.ListBuffer.empty[(String, String)]
     def add(t: net.sf.jsqlparser.schema.Table): Unit =
       val raw = t.getName
       val key = Option(t.getAlias).map(_.getName).getOrElse(raw)
       buf += (key -> raw)
+    def addSub(sub: net.sf.jsqlparser.statement.select.ParenthesedSelect): Unit =
+      Option(sub.getAlias).map(_.getName).foreach(name => buf += (name -> name))
     Option(ps.getFromItem).foreach {
-      case t: net.sf.jsqlparser.schema.Table => add(t)
-      case _                                 => ()
+      case t: net.sf.jsqlparser.schema.Table                          => add(t)
+      case s: net.sf.jsqlparser.statement.select.ParenthesedSelect    => addSub(s)
+      case _                                                          => ()
     }
     Option(ps.getJoins).foreach { joins =>
       val it = joins.iterator()
       while it.hasNext do
         Option(it.next().getRightItem).foreach {
-          case t: net.sf.jsqlparser.schema.Table => add(t)
-          case _                                 => ()
+          case t: net.sf.jsqlparser.schema.Table                       => add(t)
+          case s: net.sf.jsqlparser.statement.select.ParenthesedSelect => addSub(s)
+          case _                                                       => ()
         }
     }
     buf.toList
+
+  /** Pre-scan a FROM-item subquery and synthesize policies for the outer scope. For each inner
+    * SelectItem whose source column is covered by a base-table policy, emit a transient policy
+    * keyed on `(subqueryAlias, projectedName)` so the outer projection masks `sub.x` references.
+    * The projectedName is the user-supplied alias if any, else the inner Column's name. Items
+    * that are not bare Columns (functions, expressions) are skipped - those don't expose a
+    * cleanly maskable identity to the outer scope.
+    */
+  private def deriveOuterPolicies(
+      sub: net.sf.jsqlparser.statement.select.ParenthesedSelect,
+      policies: List[RoleColumnPolicy]
+  ): List[RoleColumnPolicy] =
+    val subAlias = Option(sub.getAlias).map(_.getName).getOrElse("")
+    if subAlias.isEmpty then return Nil
+    val inner = sub.getSelect
+    inner match
+      case ips: PlainSelect =>
+        val innerFromTables = collectFromTables(ips)
+        val items           = Option(ips.getSelectItems).getOrElse(return Nil)
+        val buf             = scala.collection.mutable.ListBuffer.empty[RoleColumnPolicy]
+        val it              = items.iterator()
+        while it.hasNext do
+          val si = it.next()
+          si.getExpression match
+            case col: net.sf.jsqlparser.schema.Column =>
+              val baseTable = Option(col.getTable).map(_.getName) match
+                case Some(key) =>
+                  innerFromTables.find(_._1.equalsIgnoreCase(key)).map(_._2).getOrElse(key)
+                case None =>
+                  if innerFromTables.size == 1 then innerFromTables.head._2 else ""
+              val baseCol = col.getColumnName
+              val exposedName =
+                Option(si.getAlias).map(_.getName).getOrElse(baseCol)
+              matchingPolicy(baseTable, baseCol, policies).foreach { p =>
+                buf += p.copy(tableName = subAlias, columnName = exposedName)
+              }
+            case _ => ()
+        buf.toList
+      case _ => Nil
 
   private final class PolicyVisitor(
       policies: List[RoleColumnPolicy],
@@ -185,6 +270,8 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
   ):
     var topLevelOverride: Option[(String, String)] = None
     var fromTables: List[(String, String)]         = Nil
+    var extraPolicies: List[RoleColumnPolicy]      = Nil
+    private def allPolicies: List[RoleColumnPolicy] = extraPolicies ::: policies
 
     /** Resolve the physical table for a Column reference. */
     private def resolveTable(col: net.sf.jsqlparser.schema.Column): String =
@@ -203,7 +290,7 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           val (tableName, columnName) = topLevelOverride.getOrElse {
             (resolveTable(col), col.getColumnName)
           }
-          matchingPolicy(tableName, columnName, policies) match
+          matchingPolicy(tableName, columnName, allPolicies) match
             case Some(p) if p.action == RoleColumnPolicy.ActionDeny =>
               throw DenyException(s"column $tableName.$columnName is denied")
             case Some(p) =>
@@ -351,6 +438,18 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           }
           topLevelOverride = saved
           ce
+
+        case ps: net.sf.jsqlparser.statement.select.ParenthesedSelect =>
+          // Scalar subquery in expression position, e.g. `SELECT (SELECT c_email FROM customer)`.
+          // JSqlParser 5.x represents this as a ParenthesedSelect inside the expression tree.
+          // Select extends Expression in 5.x; the inner FROM clause and per-column policy lookup
+          // belong to the subquery itself, so the outer origins don't apply.
+          val saved = topLevelOverride
+          topLevelOverride = None
+          val (innerChanged, _) = applyPolicies(ps.getSelect, IndexedSeq.empty, policies)
+          if innerChanged then changed.set(true)
+          topLevelOverride = saved
+          ps
 
         case other => other
 

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -89,6 +89,21 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
     val changed = new java.util.concurrent.atomic.AtomicBoolean(false)
     val visitor = new PolicyVisitor(policies, changed)
 
+    // Recurse into CTE bodies first. Top-level lineage doesn't apply inside the CTE body, so pass
+    // empty origins; the visitor will fall back to each Column's own (table, column) qualifier
+    // resolved via the inner PlainSelect's FROM clause.
+    Option(sel.getWithItemsList).foreach { wis =>
+      val it = wis.iterator()
+      while it.hasNext do
+        val wi = it.next()
+        Option(wi.getParenthesedStatement).foreach {
+          case ps: net.sf.jsqlparser.statement.select.ParenthesedSelect =>
+            val (innerChanged, _) = applyPolicies(ps.getSelect, IndexedSeq.empty, policies)
+            if innerChanged then changed.set(true)
+          case _ => ()
+        }
+    }
+
     sel match
       case ps: PlainSelect =>
         // FROM-tables of this select (key -> table). Single-table case lets the visitor resolve
@@ -101,12 +116,14 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           val it  = items.listIterator()
           var idx = 0
           while it.hasNext do
-            val si           = it.next()
-            val (table, col) = if origins.indices.contains(idx) then origins(idx) else ("", "")
+            val si = it.next()
             // Top-level column origin override: the resolver knows the physical lineage of the
             // projection slot even if the expression at that slot is itself a Column whose name
-            // is an alias of another column.
-            visitor.topLevelOverride = Some((table, col))
+            // is an alias of another column. Only meaningful when origins are available (top-level
+            // call); inside recursion (e.g. CTE body) origins is empty and the visitor falls back
+            // to each Column's own (table, column) qualifier.
+            visitor.topLevelOverride =
+              if origins.indices.contains(idx) then Some(origins(idx)) else None
             val expr     = si.getExpression
             val replaced = visitor.visit(expr)
             if (replaced ne expr) then

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -225,6 +225,14 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           topLevelOverride = saved
           p
 
+        case ex: net.sf.jsqlparser.expression.ExtractExpression =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          val nxt = visit(ex.getExpression)
+          if nxt ne ex.getExpression then ex.setExpression(nxt)
+          topLevelOverride = saved
+          ex
+
         case bt: net.sf.jsqlparser.expression.operators.relational.Between =>
           val saved = topLevelOverride
           topLevelOverride = None

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -225,6 +225,34 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           topLevelOverride = saved
           p
 
+        case ae: net.sf.jsqlparser.expression.AnalyticExpression =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          Option(ae.getExpression).foreach { e =>
+            val nxt = visit(e)
+            if nxt ne e then ae.setExpression(nxt)
+          }
+          Option(ae.getPartitionExpressionList).foreach { lst =>
+            val typed = lst
+              .asInstanceOf[net.sf.jsqlparser.expression.operators.relational.ExpressionList[
+                Expression
+              ]]
+            val it = typed.listIterator()
+            while it.hasNext do
+              val cur = it.next()
+              val nxt = visit(cur)
+              if nxt ne cur then it.set(nxt)
+          }
+          Option(ae.getOrderByElements).foreach { obs =>
+            val it = obs.iterator()
+            while it.hasNext do
+              val ob  = it.next()
+              val nxt = visit(ob.getExpression)
+              if nxt ne ob.getExpression then ob.setExpression(nxt)
+          }
+          topLevelOverride = saved
+          ae
+
         case ex: net.sf.jsqlparser.expression.ExtractExpression =>
           val saved = topLevelOverride
           topLevelOverride = None

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -27,7 +27,15 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       (tableKey +: cols).toArray
     }
 
-    val resolver = new JSQLColumResolver(schemaDef)
+    // Use the 3-arg constructor so SQL schema qualifiers (e.g. `tpch1.customer`) match the
+    // schemaless rows in `schemaDef`. The 1-arg form leaves currentSchema="" and silently
+    // mismatches every schema-qualified table ref. defaultCatalog/defaultSchema come from the
+    // caller's SchemaContext (the session-defaults pinned at handshake time).
+    val resolver = new JSQLColumResolver(
+      defaultCatalog.getOrElse(""),
+      defaultSchema.getOrElse(""),
+      schemaDef
+    )
     resolver.setErrorMode(unresolvedMode match
       case UnresolvedMode.Deny        => JdbcMetaData.ErrorMode.STRICT
       case UnresolvedMode.Passthrough => JdbcMetaData.ErrorMode.LENIENT)

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -201,6 +201,29 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           topLevelOverride = saved
           p
 
+        case ce: net.sf.jsqlparser.expression.CaseExpression =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          Option(ce.getSwitchExpression).foreach { sw =>
+            val nxt = visit(sw)
+            if nxt ne sw then ce.setSwitchExpression(nxt)
+          }
+          Option(ce.getWhenClauses).foreach { clauses =>
+            val it = clauses.iterator()
+            while it.hasNext do
+              val wc = it.next()
+              val w  = visit(wc.getWhenExpression)
+              if w ne wc.getWhenExpression then wc.setWhenExpression(w)
+              val t  = visit(wc.getThenExpression)
+              if t ne wc.getThenExpression then wc.setThenExpression(t)
+          }
+          Option(ce.getElseExpression).foreach { el =>
+            val nxt = visit(el)
+            if nxt ne el then ce.setElseExpression(nxt)
+          }
+          topLevelOverride = saved
+          ce
+
         case other => other
 
   private def matchingPolicy(

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -21,61 +21,67 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       defaultSchema: Option[String],
       unresolvedMode: UnresolvedMode = UnresolvedMode.Deny
   ): RewriteOutcome =
-    if policies.isEmpty then return Passthrough
-
-    val schemaDef: Array[Array[String]] = schema.toArray.map { case (tableKey, cols) =>
-      (tableKey +: cols).toArray
-    }
-
-    // Use the 3-arg constructor so SQL schema qualifiers (e.g. `tpch1.customer`) match the
-    // schemaless rows in `schemaDef`. The 1-arg form leaves currentSchema="" and silently
-    // mismatches every schema-qualified table ref. defaultCatalog/defaultSchema come from the
-    // caller's SchemaContext (the session-defaults pinned at handshake time).
-    val resolver = new JSQLColumResolver(
-      defaultCatalog.getOrElse(""),
-      defaultSchema.getOrElse(""),
-      schemaDef
-    )
-    resolver.setErrorMode(unresolvedMode match
-      case UnresolvedMode.Deny => JdbcMetaData.ErrorMode.STRICT
-      case UnresolvedMode.Pass => JdbcMetaData.ErrorMode.LENIENT)
-
-    val resolvedText: String =
-      try resolver.getResolvedStatementText(sql)
-      catch
-        // jsqltranspiler 1.9 does NOT ship a single `JSQLDataException` umbrella; it raises one
-        // of the table/column/schema/catalog-not-found exceptions under `ai.starlake.transpiler.*`.
-        // Treat any of these as the "unknown coordinate" case the spec calls out, and let the
-        // unresolvedMode arm decide deny vs passthrough.
-        case e: ai.starlake.transpiler.TableNotFoundException    => return Denied(e.getMessage)
-        case e: ai.starlake.transpiler.TableNotDeclaredException => return Denied(e.getMessage)
-        case e: ai.starlake.transpiler.ColumnNotFoundException   => return Denied(e.getMessage)
-        case e: ai.starlake.transpiler.SchemaNotFoundException   => return Denied(e.getMessage)
-        case e: ai.starlake.transpiler.CatalogNotFoundException  => return Denied(e.getMessage)
-        case _: net.sf.jsqlparser.JSQLParserException            => return ParseFailed
-        case _: Throwable                                        => return ParseFailed
-
-    val rsMeta                                          = resolver.getResultSetMetaData(sql)
-    val projectionOrigins: IndexedSeq[(String, String)] =
-      (1 to rsMeta.getColumnCount).toIndexedSeq.map { i =>
-        (
-          Option(rsMeta.getTableName(i)).getOrElse(""),
-          Option(rsMeta.getColumnName(i)).getOrElse("")
-        )
+    if policies.isEmpty then Passthrough
+    else
+      val schemaDef: Array[Array[String]] = schema.toArray.map { case (tableKey, cols) =>
+        (tableKey +: cols).toArray
       }
 
-    val parsed =
-      try CCJSqlParserUtil.parse(resolvedText)
-      catch case _: Throwable => return ParseFailed
+      // Use the 3-arg constructor so SQL schema qualifiers (e.g. `tpch1.customer`) match the
+      // schemaless rows in `schemaDef`. The 1-arg form leaves currentSchema="" and silently
+      // mismatches every schema-qualified table ref. defaultCatalog/defaultSchema come from the
+      // caller's SchemaContext (the session-defaults pinned at handshake time).
+      val resolver = new JSQLColumResolver(
+        defaultCatalog.getOrElse(""),
+        defaultSchema.getOrElse(""),
+        schemaDef
+      )
+      resolver.setErrorMode(unresolvedMode match
+        case UnresolvedMode.Deny => JdbcMetaData.ErrorMode.STRICT
+        case UnresolvedMode.Pass => JdbcMetaData.ErrorMode.LENIENT)
 
-    parsed match
-      case sel: Select =>
-        try
-          val (changed, _) = applyPolicies(sel, projectionOrigins, policies)
-          if changed then Rewritten(sel.toString) else Passthrough
-        catch case e: DenyException => Denied(e.reason)
-      case _ =>
-        Passthrough
+      // Capture try/catch outcomes as Either so the early-exit flows through a structured
+      // match instead of an exception. jsqltranspiler 1.9 does NOT ship a single
+      // `JSQLDataException` umbrella; it raises one of the table/column/schema/catalog-not-
+      // found exceptions under `ai.starlake.transpiler.*`.
+      val resolveAttempt: Either[RewriteOutcome, String] =
+        try Right(resolver.getResolvedStatementText(sql))
+        catch
+          case e: ai.starlake.transpiler.TableNotFoundException    => Left(Denied(e.getMessage))
+          case e: ai.starlake.transpiler.TableNotDeclaredException => Left(Denied(e.getMessage))
+          case e: ai.starlake.transpiler.ColumnNotFoundException   => Left(Denied(e.getMessage))
+          case e: ai.starlake.transpiler.SchemaNotFoundException   => Left(Denied(e.getMessage))
+          case e: ai.starlake.transpiler.CatalogNotFoundException  => Left(Denied(e.getMessage))
+          case _: net.sf.jsqlparser.JSQLParserException            => Left(ParseFailed)
+          case _: Throwable                                        => Left(ParseFailed)
+
+      resolveAttempt match
+        case Left(failure)      => failure
+        case Right(resolvedText) =>
+          val rsMeta                                          = resolver.getResultSetMetaData(sql)
+          val projectionOrigins: IndexedSeq[(String, String)] =
+            (1 to rsMeta.getColumnCount).toIndexedSeq.map { i =>
+              (
+                Option(rsMeta.getTableName(i)).getOrElse(""),
+                Option(rsMeta.getColumnName(i)).getOrElse("")
+              )
+            }
+
+          val parseAttempt: Either[RewriteOutcome, net.sf.jsqlparser.statement.Statement] =
+            try Right(CCJSqlParserUtil.parse(resolvedText))
+            catch case _: Throwable => Left(ParseFailed)
+
+          parseAttempt match
+            case Left(failure)  => failure
+            case Right(parsed) =>
+              parsed match
+                case sel: Select =>
+                  try
+                    val (changed, _) = applyPolicies(sel, projectionOrigins, policies)
+                    if changed then Rewritten(sel.toString) else Passthrough
+                  catch case e: DenyException => Denied(e.reason)
+                case _ =>
+                  Passthrough
 
   /** Walk the resolved statement's projection items and replace any Column whose physical (table,
     * column) lineage matches a policy. Full visitor surface (CASE / CAST / OVER / IN / BETWEEN /
@@ -236,32 +242,34 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       policies: List[RoleColumnPolicy]
   ): List[RoleColumnPolicy] =
     val subAlias = Option(sub.getAlias).map(_.getName).getOrElse("")
-    if subAlias.isEmpty then return Nil
-    val inner = sub.getSelect
-    inner match
-      case ips: PlainSelect =>
-        val innerFromTables = collectFromTables(ips)
-        val items           = Option(ips.getSelectItems).getOrElse(return Nil)
-        val buf             = scala.collection.mutable.ListBuffer.empty[RoleColumnPolicy]
-        val it              = items.iterator()
-        while it.hasNext do
-          val si = it.next()
-          si.getExpression match
-            case col: net.sf.jsqlparser.schema.Column =>
-              val baseTable = Option(col.getTable).map(_.getName) match
-                case Some(key) =>
-                  innerFromTables.find(_._1.equalsIgnoreCase(key)).map(_._2).getOrElse(key)
-                case None =>
-                  if innerFromTables.size == 1 then innerFromTables.head._2 else ""
-              val baseCol     = col.getColumnName
-              val exposedName =
-                Option(si.getAlias).map(_.getName).getOrElse(baseCol)
-              matchingPolicy(baseTable, baseCol, policies).foreach { p =>
-                buf += p.copy(tableName = subAlias, columnName = exposedName)
-              }
-            case _ => ()
-        buf.toList
-      case _ => Nil
+    if subAlias.isEmpty then Nil
+    else
+      sub.getSelect match
+        case ips: PlainSelect =>
+          Option(ips.getSelectItems) match
+            case None        => Nil
+            case Some(items) =>
+              val innerFromTables = collectFromTables(ips)
+              val buf             = scala.collection.mutable.ListBuffer.empty[RoleColumnPolicy]
+              val it              = items.iterator()
+              while it.hasNext do
+                val si = it.next()
+                si.getExpression match
+                  case col: net.sf.jsqlparser.schema.Column =>
+                    val baseTable = Option(col.getTable).map(_.getName) match
+                      case Some(key) =>
+                        innerFromTables.find(_._1.equalsIgnoreCase(key)).map(_._2).getOrElse(key)
+                      case None =>
+                        if innerFromTables.size == 1 then innerFromTables.head._2 else ""
+                    val baseCol     = col.getColumnName
+                    val exposedName =
+                      Option(si.getAlias).map(_.getName).getOrElse(baseCol)
+                    matchingPolicy(baseTable, baseCol, policies).foreach { p =>
+                      buf += p.copy(tableName = subAlias, columnName = exposedName)
+                    }
+                  case _ => ()
+              buf.toList
+        case _ => Nil
 
   private final class PolicyVisitor(
       policies: List[RoleColumnPolicy],

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -37,8 +37,8 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       schemaDef
     )
     resolver.setErrorMode(unresolvedMode match
-      case UnresolvedMode.Deny        => JdbcMetaData.ErrorMode.STRICT
-      case UnresolvedMode.Pass        => JdbcMetaData.ErrorMode.LENIENT)
+      case UnresolvedMode.Deny => JdbcMetaData.ErrorMode.STRICT
+      case UnresolvedMode.Pass => JdbcMetaData.ErrorMode.LENIENT)
 
     val resolvedText: String =
       try resolver.getResolvedStatementText(sql)
@@ -148,8 +148,7 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
         // Augment the visitor's policies with any synthesized ones so the outer projection sees
         // `sub.c_email` (or alias.colalias) as covered. The synthesized policies use the FROM-item
         // alias as the tableName, so resolveTable's alias-equality fallback can match them.
-        if derivedPolicies.nonEmpty then
-          visitor.extraPolicies = derivedPolicies.toList
+        if derivedPolicies.nonEmpty then visitor.extraPolicies = derivedPolicies.toList
         val items = ps.getSelectItems
         if items != null then
           val it  = items.listIterator()
@@ -165,7 +164,7 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
               if origins.indices.contains(idx) then Some(origins(idx)) else None
             val expr     = si.getExpression
             val replaced = visitor.visit(expr)
-            if (replaced ne expr) then
+            if replaced ne expr then
               si.asInstanceOf[SelectItem[Expression]].setExpression(replaced)
               changed.set(true)
             visitor.topLevelOverride = None
@@ -210,9 +209,9 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
     def addSub(sub: net.sf.jsqlparser.statement.select.ParenthesedSelect): Unit =
       Option(sub.getAlias).map(_.getName).foreach(name => buf += (name -> name))
     Option(ps.getFromItem).foreach {
-      case t: net.sf.jsqlparser.schema.Table                          => add(t)
-      case s: net.sf.jsqlparser.statement.select.ParenthesedSelect    => addSub(s)
-      case _                                                          => ()
+      case t: net.sf.jsqlparser.schema.Table                       => add(t)
+      case s: net.sf.jsqlparser.statement.select.ParenthesedSelect => addSub(s)
+      case _                                                       => ()
     }
     Option(ps.getJoins).foreach { joins =>
       val it = joins.iterator()
@@ -228,9 +227,9 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
   /** Pre-scan a FROM-item subquery and synthesize policies for the outer scope. For each inner
     * SelectItem whose source column is covered by a base-table policy, emit a transient policy
     * keyed on `(subqueryAlias, projectedName)` so the outer projection masks `sub.x` references.
-    * The projectedName is the user-supplied alias if any, else the inner Column's name. Items
-    * that are not bare Columns (functions, expressions) are skipped - those don't expose a
-    * cleanly maskable identity to the outer scope.
+    * The projectedName is the user-supplied alias if any, else the inner Column's name. Items that
+    * are not bare Columns (functions, expressions) are skipped - those don't expose a cleanly
+    * maskable identity to the outer scope.
     */
   private def deriveOuterPolicies(
       sub: net.sf.jsqlparser.statement.select.ParenthesedSelect,
@@ -254,7 +253,7 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
                   innerFromTables.find(_._1.equalsIgnoreCase(key)).map(_._2).getOrElse(key)
                 case None =>
                   if innerFromTables.size == 1 then innerFromTables.head._2 else ""
-              val baseCol = col.getColumnName
+              val baseCol     = col.getColumnName
               val exposedName =
                 Option(si.getAlias).map(_.getName).getOrElse(baseCol)
               matchingPolicy(baseTable, baseCol, policies).foreach { p =>
@@ -268,9 +267,9 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
       policies: List[RoleColumnPolicy],
       changed: java.util.concurrent.atomic.AtomicBoolean
   ):
-    var topLevelOverride: Option[(String, String)] = None
-    var fromTables: List[(String, String)]         = Nil
-    var extraPolicies: List[RoleColumnPolicy]      = Nil
+    var topLevelOverride: Option[(String, String)]  = None
+    var fromTables: List[(String, String)]          = Nil
+    var extraPolicies: List[RoleColumnPolicy]       = Nil
     private def allPolicies: List[RoleColumnPolicy] = extraPolicies ::: policies
 
     /** Resolve the physical table for a Column reference. */
@@ -429,7 +428,7 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
               val wc = it.next()
               val w  = visit(wc.getWhenExpression)
               if w ne wc.getWhenExpression then wc.setWhenExpression(w)
-              val t  = visit(wc.getThenExpression)
+              val t = visit(wc.getThenExpression)
               if t ne wc.getThenExpression then wc.setThenExpression(t)
           }
           Option(ce.getElseExpression).foreach { el =>

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -1,0 +1,111 @@
+package ai.starlake.quack.edge.cls
+
+import ai.starlake.quack.ondemand.state.RoleColumnPolicy
+import ai.starlake.transpiler.JSQLColumResolver
+import ai.starlake.transpiler.schema.JdbcMetaData
+import net.sf.jsqlparser.expression.Expression
+import net.sf.jsqlparser.parser.CCJSqlParserUtil
+import net.sf.jsqlparser.statement.select.{PlainSelect, Select, SelectItem}
+
+final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
+
+  import RewriteOutcome._
+
+  private final case class DenyException(reason: String) extends RuntimeException(reason)
+
+  def rewrite(
+      sql: String,
+      schema: Map[String, List[String]],
+      policies: List[RoleColumnPolicy],
+      defaultCatalog: Option[String],
+      defaultSchema: Option[String],
+      unresolvedMode: UnresolvedMode = UnresolvedMode.Deny
+  ): RewriteOutcome =
+    if policies.isEmpty then return Passthrough
+
+    val schemaDef: Array[Array[String]] = schema.toArray.map { case (tableKey, cols) =>
+      (tableKey +: cols).toArray
+    }
+
+    val resolver = new JSQLColumResolver(schemaDef)
+    resolver.setErrorMode(unresolvedMode match
+      case UnresolvedMode.Deny        => JdbcMetaData.ErrorMode.STRICT
+      case UnresolvedMode.Passthrough => JdbcMetaData.ErrorMode.LENIENT)
+
+    val resolvedText: String =
+      try resolver.getResolvedStatementText(sql)
+      catch
+        // jsqltranspiler 1.9 does NOT ship a single `JSQLDataException` umbrella; it raises one
+        // of the table/column/schema/catalog-not-found exceptions under `ai.starlake.transpiler.*`.
+        // Treat any of these as the "unknown coordinate" case the spec calls out, and let the
+        // unresolvedMode arm decide deny vs passthrough.
+        case e: ai.starlake.transpiler.TableNotFoundException    => return Denied(e.getMessage)
+        case e: ai.starlake.transpiler.TableNotDeclaredException => return Denied(e.getMessage)
+        case e: ai.starlake.transpiler.ColumnNotFoundException   => return Denied(e.getMessage)
+        case e: ai.starlake.transpiler.SchemaNotFoundException   => return Denied(e.getMessage)
+        case e: ai.starlake.transpiler.CatalogNotFoundException  => return Denied(e.getMessage)
+        case _: net.sf.jsqlparser.JSQLParserException            => return ParseFailed
+        case _: Throwable                                        => return ParseFailed
+
+    val rsMeta                                          = resolver.getResultSetMetaData(sql)
+    val projectionOrigins: IndexedSeq[(String, String)] =
+      (1 to rsMeta.getColumnCount).toIndexedSeq.map { i =>
+        (
+          Option(rsMeta.getTableName(i)).getOrElse(""),
+          Option(rsMeta.getColumnName(i)).getOrElse("")
+        )
+      }
+
+    val parsed =
+      try CCJSqlParserUtil.parse(resolvedText)
+      catch case _: Throwable => return ParseFailed
+
+    parsed match
+      case sel: Select =>
+        try
+          val (changed, _) = applyPolicies(sel, projectionOrigins, policies)
+          if changed then Rewritten(sel.toString) else Passthrough
+        catch case e: DenyException => Denied(e.reason)
+      case _ =>
+        Passthrough
+
+  /** Walk the resolved statement's projection items and replace any Column whose physical (table,
+    * column) lineage matches a policy. Full visitor surface (CASE / CAST / OVER / IN / BETWEEN /
+    * EXTRACT / WHERE / HAVING / GROUP / ORDER) is added in Task 5.
+    */
+  private def applyPolicies(
+      sel: Select,
+      origins: IndexedSeq[(String, String)],
+      policies: List[RoleColumnPolicy]
+  ): (Boolean, Select) =
+    val changed = new java.util.concurrent.atomic.AtomicBoolean(false)
+    sel match
+      case ps: PlainSelect =>
+        val items = ps.getSelectItems
+        if items != null then
+          val it  = items.listIterator()
+          var idx = 0
+          while it.hasNext do
+            val si           = it.next()
+            val (table, col) = if origins.indices.contains(idx) then origins(idx) else ("", "")
+            matchingPolicy(table, col, policies) match
+              case Some(p) if p.action == RoleColumnPolicy.ActionDeny =>
+                throw DenyException(s"column $table.$col is denied")
+              case Some(p) =>
+                val replacement = CCJSqlParserUtil.parseExpression(p.transformSql.get)
+                si.asInstanceOf[SelectItem[Expression]].setExpression(replacement)
+                changed.set(true)
+              case None => ()
+            idx += 1
+      case _ => ()
+    (changed.get, sel)
+
+  private def matchingPolicy(
+      table: String,
+      column: String,
+      policies: List[RoleColumnPolicy]
+  ): Option[RoleColumnPolicy] =
+    policies.find { p =>
+      (p.tableName == RoleColumnPolicy.Wildcard || p.tableName.equalsIgnoreCase(table)) &&
+      p.columnName.equalsIgnoreCase(column)
+    }

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -114,6 +114,30 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
               changed.set(true)
             visitor.topLevelOverride = None
             idx += 1
+        Option(ps.getWhere).foreach { w =>
+          val nxt = visitor.visit(w)
+          if nxt ne w then { ps.setWhere(nxt); changed.set(true) }
+        }
+        Option(ps.getHaving).foreach { h =>
+          val nxt = visitor.visit(h)
+          if nxt ne h then { ps.setHaving(nxt); changed.set(true) }
+        }
+        Option(ps.getGroupBy).foreach { gb =>
+          val gbList = gb.getGroupByExpressionList
+          if gbList != null then
+            val it = gbList.listIterator()
+            while it.hasNext do
+              val cur = it.next()
+              val nxt = visitor.visit(cur)
+              if nxt ne cur then { it.set(nxt); changed.set(true) }
+        }
+        Option(ps.getOrderByElements).foreach { obs =>
+          val it = obs.iterator()
+          while it.hasNext do
+            val ob  = it.next()
+            val nxt = visitor.visit(ob.getExpression)
+            if nxt ne ob.getExpression then { ob.setExpression(nxt); changed.set(true) }
+        }
       case _ => ()
     (changed.get, sel)
 
@@ -200,6 +224,24 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           p.setExpression(visit(p.getExpression))
           topLevelOverride = saved
           p
+
+        case ix: net.sf.jsqlparser.expression.operators.relational.InExpression =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          val l = visit(ix.getLeftExpression)
+          if l ne ix.getLeftExpression then ix.setLeftExpression(l)
+          ix.getRightExpression match
+            case el: net.sf.jsqlparser.expression.operators.relational.ExpressionList[
+                  Expression
+                ] @unchecked =>
+              val it = el.listIterator()
+              while it.hasNext do
+                val cur = it.next()
+                val nxt = visit(cur)
+                if nxt ne cur then it.set(nxt)
+            case _ => ()
+          topLevelOverride = saved
+          ix
 
         case cx: net.sf.jsqlparser.expression.CastExpression =>
           val saved = topLevelOverride

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -225,6 +225,19 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
           topLevelOverride = saved
           p
 
+        case el: net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList[
+              Expression
+            ] @unchecked =>
+          val saved = topLevelOverride
+          topLevelOverride = None
+          val it = el.listIterator()
+          while it.hasNext do
+            val cur = it.next()
+            val nxt = visit(cur)
+            if nxt ne cur then it.set(nxt)
+          topLevelOverride = saved
+          el
+
         case ae: net.sf.jsqlparser.expression.AnalyticExpression =>
           val saved = topLevelOverride
           topLevelOverride = None

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -38,7 +38,7 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
     )
     resolver.setErrorMode(unresolvedMode match
       case UnresolvedMode.Deny        => JdbcMetaData.ErrorMode.STRICT
-      case UnresolvedMode.Passthrough => JdbcMetaData.ErrorMode.LENIENT)
+      case UnresolvedMode.Pass        => JdbcMetaData.ErrorMode.LENIENT)
 
     val resolvedText: String =
       try resolver.getResolvedStatementText(sql)

--- a/src/main/scala/ai/starlake/quack/edge/cls/SchemaAwareSqlRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/SchemaAwareSqlRewriter.scala
@@ -12,7 +12,7 @@ enum RewriteOutcome:
 /** How the rewriter handles a table the SQL references that the schema map does not cover. */
 enum UnresolvedMode:
   case Deny
-  case Passthrough
+  case Pass
 
 /** Rewrites a SQL statement so every reference to a covered column is replaced with its mask
   * transform, or refuses with `Denied` if any reference matches a deny policy. The trait is pure

--- a/src/main/scala/ai/starlake/quack/edge/cls/SchemaAwareSqlRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/SchemaAwareSqlRewriter.scala
@@ -1,0 +1,38 @@
+package ai.starlake.quack.edge.cls
+
+import ai.starlake.quack.ondemand.state.RoleColumnPolicy
+
+/** Outcome of a schema-aware rewrite attempt. */
+enum RewriteOutcome:
+  case Rewritten(sql: String)
+  case Denied(reason: String)
+  case Passthrough
+  case ParseFailed
+
+/** How the rewriter handles a table the SQL references that the schema map does not cover. */
+enum UnresolvedMode:
+  case Deny
+  case Passthrough
+
+/** Rewrites a SQL statement so every reference to a covered column is replaced with its mask
+  * transform, or refuses with `Denied` if any reference matches a deny policy. The trait is pure
+  * (no I/O): all schema lookups have already been done by the caller and handed in via `schema`.
+  *
+  * `schema` maps each FROM-item alias OR base table name the SQL references to its column list.
+  * Empty list means "table exists but no columns known"; missing key means "table not in
+  * catalog at all" and triggers `unresolvedMode`.
+  *
+  * `policies` is the EffectiveSet's columnPolicies list, already filtered to the session tenant.
+  *
+  * `defaultCatalog` / `defaultSchema` provide qualification defaults for bare table refs
+  * (`customer` -> `acme_tpch.tpch1.customer`).
+  */
+trait SchemaAwareSqlRewriter:
+  def rewrite(
+      sql:            String,
+      schema:         Map[String, List[String]],
+      policies:       List[RoleColumnPolicy],
+      defaultCatalog: Option[String],
+      defaultSchema:  Option[String],
+      unresolvedMode: UnresolvedMode = UnresolvedMode.Deny
+  ): RewriteOutcome

--- a/src/main/scala/ai/starlake/quack/edge/cls/SchemaAwareSqlRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/SchemaAwareSqlRewriter.scala
@@ -19,8 +19,8 @@ enum UnresolvedMode:
   * (no I/O): all schema lookups have already been done by the caller and handed in via `schema`.
   *
   * `schema` maps each FROM-item alias OR base table name the SQL references to its column list.
-  * Empty list means "table exists but no columns known"; missing key means "table not in
-  * catalog at all" and triggers `unresolvedMode`.
+  * Empty list means "table exists but no columns known"; missing key means "table not in catalog at
+  * all" and triggers `unresolvedMode`.
   *
   * `policies` is the EffectiveSet's columnPolicies list, already filtered to the session tenant.
   *
@@ -29,10 +29,10 @@ enum UnresolvedMode:
   */
 trait SchemaAwareSqlRewriter:
   def rewrite(
-      sql:            String,
-      schema:         Map[String, List[String]],
-      policies:       List[RoleColumnPolicy],
+      sql: String,
+      schema: Map[String, List[String]],
+      policies: List[RoleColumnPolicy],
       defaultCatalog: Option[String],
-      defaultSchema:  Option[String],
+      defaultSchema: Option[String],
       unresolvedMode: UnresolvedMode = UnresolvedMode.Deny
   ): RewriteOutcome

--- a/src/main/scala/ai/starlake/quack/edge/cls/TransformSqlValidator.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/TransformSqlValidator.scala
@@ -9,8 +9,8 @@ import net.sf.jsqlparser.statement.select.Select
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-/** Strict-containment validator for free-form transform expressions on column policies.
-  * Runs once at policy create/update time. Pure (no I/O, no DuckDB connection).
+/** Strict-containment validator for free-form transform expressions on column policies. Runs once
+  * at policy create/update time. Pure (no I/O, no DuckDB connection).
   *
   * A `transform_sql` value must be ONE scalar DuckDB expression that:
   *   1. Parses via JSqlParser's `parseExpression` entry point.
@@ -29,11 +29,22 @@ object TransformSqlValidator:
   private val MaxLen = 1024
 
   private val Denylist: Set[String] = Set(
-    "read_csv", "read_csv_auto", "read_parquet", "read_json", "read_json_auto",
-    "query", "sql",
-    "attach", "detach", "install", "load", "system",
-    "current_setting", "set_setting",
-    "pg_read_server_files", "pg_read_binary_file"
+    "read_csv",
+    "read_csv_auto",
+    "read_parquet",
+    "read_json",
+    "read_json_auto",
+    "query",
+    "sql",
+    "attach",
+    "detach",
+    "install",
+    "load",
+    "system",
+    "current_setting",
+    "set_setting",
+    "pg_read_server_files",
+    "pg_read_binary_file"
   )
 
   def validate(transformSql: String, protectedColumn: String): Result =
@@ -87,8 +98,7 @@ object TransformSqlValidator:
       if visit.isDefinedAt(node) then visit(node)
       node match
         case fn: SqlFunction =>
-          if fn.getParameters != null then
-            fn.getParameters.asScala.foreach(stack.push)
+          if fn.getParameters != null then fn.getParameters.asScala.foreach(stack.push)
         case b: net.sf.jsqlparser.expression.BinaryExpression =>
           stack.push(b.getLeftExpression); stack.push(b.getRightExpression)
         case u: net.sf.jsqlparser.expression.SignedExpression =>
@@ -97,8 +107,8 @@ object TransformSqlValidator:
           stack.push(p.getExpression)
         case c: net.sf.jsqlparser.expression.CaseExpression =>
           if c.getSwitchExpression != null then stack.push(c.getSwitchExpression)
-          if c.getElseExpression   != null then stack.push(c.getElseExpression)
-          if c.getWhenClauses      != null then
+          if c.getElseExpression != null then stack.push(c.getElseExpression)
+          if c.getWhenClauses != null then
             c.getWhenClauses.asScala.foreach { w =>
               stack.push(w.getWhenExpression)
               stack.push(w.getThenExpression)

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -50,8 +50,8 @@ final class PoolSupervisor(
     dbAdmin: DbAdmin = NoopDbAdmin,
     federationBlobOf: String => IO[Option[String]] = _ => IO.pure(None),
     /** Callback fired immediately after a tenant-db row is removed (either via [[deleteTenantDb]]
-      * or cascaded through [[deleteTenant]]). The default is a no-op; `Main` wires it to evict
-      * the [[ai.starlake.quack.ondemand.catalog.DuckLakeCatalogReader]] cache so the per-tenant-db
+      * or cascaded through [[deleteTenant]]). The default is a no-op; `Main` wires it to evict the
+      * [[ai.starlake.quack.ondemand.catalog.DuckLakeCatalogReader]] cache so the per-tenant-db
       * Hikari pool releases its connections + heap on delete.
       */
     onTenantDbDeleted: (String, String) => Unit = (_, _) => ()
@@ -82,8 +82,8 @@ final class PoolSupervisor(
     * collapses N handshakes' worth of work into 1. Invalidated wholesale on every RBAC mutation
     * (the graph cache that backs it is small + cheap to rebuild) and on `restore()`.
     *
-    * Cache key bakes in the JWT fingerprint so a JWT role/group claim flip is reflected
-    * immediately even within the TTL.
+    * Cache key bakes in the JWT fingerprint so a JWT role/group claim flip is reflected immediately
+    * even within the TTL.
     */
   private final case class EffectiveCacheKey(userId: String, jwtRolesHash: Int, jwtGroupsHash: Int)
   private final case class EffectiveCacheEntry(
@@ -102,14 +102,15 @@ final class PoolSupervisor(
 
   // ---------- Bootstrap / replay ----------
 
-  /** Per-tenant-db naming convention, applied ONLY to `kind=ducklake` because that's the kind
-    * where each tenant-db IS its own Postgres database (named after `td.name`) with parquet stored
+  /** Per-tenant-db naming convention, applied ONLY to `kind=ducklake` because that's the kind where
+    * each tenant-db IS its own Postgres database (named after `td.name`) with parquet stored
     * alongside it at `parent(defaultDataPath)/td.name`. Operators can override either by setting
     * `dbName`/`dataPath` in `td.metastore` or `td.dataPath` explicitly. Mirrors what the deleted
     * programmatic bootstrap did at create time and what the LOAD_TPC loader scripts write to.
     *
     * For `duckdb-file` and `memory` kinds the convention does not apply: those persistence layouts
-    * are operator-defined and we fall through to the plain `defaultMetastore ++ td.metastore` merge.
+    * are operator-defined and we fall through to the plain `defaultMetastore ++ td.metastore`
+    * merge.
     */
   private def effectiveMetastoreFor(td: TenantDb): Map[String, String] =
     val merged = defaultMetastore ++ td.metastore
@@ -117,7 +118,7 @@ final class PoolSupervisor(
     else
       val withDb   = merged.updated("dbName", td.metastore.getOrElse("dbName", td.name))
       val rootData = defaultMetastore.getOrElse("dataPath", "")
-      val tdData =
+      val tdData   =
         if td.dataPath.nonEmpty then td.dataPath
         else if td.metastore.contains("dataPath") then td.metastore("dataPath")
         else if rootData.isEmpty then ""
@@ -164,9 +165,9 @@ final class PoolSupervisor(
     * `ducklake_metadata` CREATE TABLE in Postgres. Idempotent.
     *
     * Intended to run after [[restore]] (so the tenant-dbs cache is populated) and BEFORE
-    * [[reconcile]] (so newly spawned nodes find a fully-initialized catalog). The YAML import
-    * path persists tenant-dbs directly via `ManifestImporter` without per-row bootstrap, so a
-    * fresh boot needs this dedicated init pass.
+    * [[reconcile]] (so newly spawned nodes find a fully-initialized catalog). The YAML import path
+    * persists tenant-dbs directly via `ManifestImporter` without per-row bootstrap, so a fresh boot
+    * needs this dedicated init pass.
     */
   def ensureDuckLakeInitialized(): IO[Unit] = IO.blocking {
     tenantDbs.values.toList.foreach { td =>
@@ -202,51 +203,52 @@ final class PoolSupervisor(
     else
       state.nodes
         .foldLeft(IO.pure(List.empty[RunningNode])) { (acc, n) =>
-        acc.flatMap { kept =>
-          if isReachable(n) then backend.adopt(n).as(kept :+ n)
-          else
-            logger.warn(
-              s"reconcile: $key/${n.nodeId} (pid=${n.pid.getOrElse("?")} port=${n.port}) " +
-                "is dead; respawning"
-            )
-            IO.delay(tracker.remove(n.nodeId)) *>
-              backend
-                .start(
-                  NodeSpec(
-                    poolKey = key,
-                    nodeId = n.nodeId,
-                    role = n.role,
-                    metastore = state.metastore,
-                    s3 = state.s3,
-                    maxConcurrent = n.maxConcurrent,
-                    kindWire = state.kindWire,
-                    // initSql + federation blob concatenated fresh.
-                    extraSetupSql = PoolSupervisor.joinInitAndBlob(state.initSql, state.extraSetupSql),
-                    // Recover the original cohort placement from the node's
-                    // 1-based suffix index. Falls back to no placement when
-                    // the pool was created without explicit cohorts or when
-                    // the id is in an unexpected shape.
-                    placement = placementForNodeId(key, n.nodeId)
+          acc.flatMap { kept =>
+            if isReachable(n) then backend.adopt(n).as(kept :+ n)
+            else
+              logger.warn(
+                s"reconcile: $key/${n.nodeId} (pid=${n.pid.getOrElse("?")} port=${n.port}) " +
+                  "is dead; respawning"
+              )
+              IO.delay(tracker.remove(n.nodeId)) *>
+                backend
+                  .start(
+                    NodeSpec(
+                      poolKey = key,
+                      nodeId = n.nodeId,
+                      role = n.role,
+                      metastore = state.metastore,
+                      s3 = state.s3,
+                      maxConcurrent = n.maxConcurrent,
+                      kindWire = state.kindWire,
+                      // initSql + federation blob concatenated fresh.
+                      extraSetupSql =
+                        PoolSupervisor.joinInitAndBlob(state.initSql, state.extraSetupSql),
+                      // Recover the original cohort placement from the node's
+                      // 1-based suffix index. Falls back to no placement when
+                      // the pool was created without explicit cohorts or when
+                      // the id is in an unexpected shape.
+                      placement = placementForNodeId(key, n.nodeId)
+                    )
                   )
-                )
-                .flatMap { fresh =>
-                  poolIdByKey.get(key) match
-                    case Some(pid) => IO.blocking(store.upsertNode(fresh, pid)).as(kept :+ fresh)
-                    case None      => IO.pure(kept :+ fresh)
-                }
+                  .flatMap { fresh =>
+                    poolIdByKey.get(key) match
+                      case Some(pid) => IO.blocking(store.upsertNode(fresh, pid)).as(kept :+ fresh)
+                      case None      => IO.pure(kept :+ fresh)
+                  }
+          }
         }
-      }
-      .flatMap { newNodes =>
-        if newNodes.zip(state.nodes).exists((a, b) => a ne b) then
-          val updated = state.copy(nodes = newNodes)
-          IO.delay(pools.put(key, updated)).as(updated)
-        else IO.pure(state)
-      }
+        .flatMap { newNodes =>
+          if newNodes.zip(state.nodes).exists((a, b) => a ne b) then
+            val updated = state.copy(nodes = newNodes)
+            IO.delay(pools.put(key, updated)).as(updated)
+          else IO.pure(state)
+        }
 
-  /** Spawn the full distribution for a pool whose persisted state has no nodes yet.
-    * Mirrors createPool's spawn block but operates on an existing PoolState rather than
-    * persisting a fresh Pool entity. Cohort placement is recovered from the pool's
-    * authored cohorts (via poolRows) when present; otherwise nodes spawn placement-less.
+  /** Spawn the full distribution for a pool whose persisted state has no nodes yet. Mirrors
+    * createPool's spawn block but operates on an existing PoolState rather than persisting a fresh
+    * Pool entity. Cohort placement is recovered from the pool's authored cohorts (via poolRows)
+    * when present; otherwise nodes spawn placement-less.
     */
   private def spawnFromDistribution(key: PoolKey, state: PoolState): IO[PoolState] =
     val poolEntity = poolIdByKey.get(key).flatMap(poolRows.get)
@@ -256,7 +258,7 @@ final class PoolSupervisor(
       case None =>
         state.distribution.asRoleList.map(r => (r, NodePlacement.empty))
     val nodeExtra = PoolSupervisor.joinInitAndBlob(state.initSql, state.extraSetupSql)
-    val specs = plan.zipWithIndex.map { case ((role, placement), i) =>
+    val specs     = plan.zipWithIndex.map { case ((role, placement), i) =>
       NodeSpec(
         key,
         PoolSupervisor.nodeId(key, i + 1),
@@ -271,9 +273,7 @@ final class PoolSupervisor(
     }
     specs
       .foldLeft(IO.pure(List.empty[RunningNode])) { (acc, spec) =>
-        acc.flatMap(rs =>
-          IO.delay(tracker.remove(spec.nodeId)) *> backend.start(spec).map(rs :+ _)
-        )
+        acc.flatMap(rs => IO.delay(tracker.remove(spec.nodeId)) *> backend.start(spec).map(rs :+ _))
       }
       .flatMap { running =>
         val updated = state.copy(nodes = running)
@@ -358,8 +358,9 @@ final class PoolSupervisor(
     val n = name.toLowerCase
     tenants.values.find(_.displayName == n)
 
-  /** Lookup by surrogate id (`qodstate_tenant.id`, e.g. `t-02d0e86e`). The
-    * internal `tenants` map is already keyed by id, so this is a direct hit. */
+  /** Lookup by surrogate id (`qodstate_tenant.id`, e.g. `t-02d0e86e`). The internal `tenants` map
+    * is already keyed by id, so this is a direct hit.
+    */
   def getTenantById(id: String): Option[Tenant] = tenants.get(id)
 
   def listPoolsOfTenant(name: String): List[String] =
@@ -401,8 +402,8 @@ final class PoolSupervisor(
     pools.keys.find(k => k.tenant == t && k.pool == poolName)
 
   /** Effective metastore for a tenant-db: global defaults overlaid with the tenant-db's own params,
-    * then the per-tenant-db naming convention (dbName=td.name, dataPath alongside the root).
-    * Used by the catalog browser.
+    * then the per-tenant-db naming convention (dbName=td.name, dataPath alongside the root). Used
+    * by the catalog browser.
     */
   def effectiveMetastoreFor(tenantName: String, tenantDbName: String): Map[String, String] =
     findTenantDb(tenantName, tenantDbName)
@@ -709,81 +710,81 @@ final class PoolSupervisor(
         val merged   = effectiveMetastoreFor(td)
         val kindWire = td.kind.wireValue
         federationBlobOf(td.id).flatMap { blobOpt =>
-        // initSql runs first so PRAGMAs/INSTALL land before the federation
-        // blob's ATTACHes; both get shipped via NodeSpec.extraSetupSql.
-        val fedBlob   = blobOpt.getOrElse("")
-        // What the node actually gets at spawn = initSql + "\n" + federation blob.
-        // `state.extraSetupSql` keeps the federation blob ONLY so a manager
-        // restart that re-projects PoolState from persisted rows still has the
-        // operator-authored initSql available separately (and respawn can
-        // re-concatenate without double-prepending).
-        val nodeExtra = PoolSupervisor.joinInitAndBlob(initSql, fedBlob)
-        val poolEntity = Pool(
-          id = newId("p"),
-          tenantId = td.tenantId,
-          tenantDbId = td.id,
-          name = key.pool,
-          size = size,
-          distribution = dist,
-          maxConcurrentPerNode = maxConcurrentPerNode,
-          disabled = disabled,
-          cohorts = cohorts,
-          initSql = initSql
-        )
-        IO.blocking(store.upsertPool(poolEntity)) *> IO.delay {
-          poolRows.put(poolEntity.id, poolEntity)
-          poolIdByKey.put(key, poolEntity.id)
-        } *> {
-          // Walk cohorts in order; each role gets the cohort's placement.
-          // Empty `cohorts` falls back to a single placement-less cohort
-          // carrying `dist`, matching pre-cohort behavior exactly.
-          val plan: List[(ai.starlake.quack.model.Role, NodePlacement)] =
-            poolEntity.effectiveCohorts.flatMap { c =>
-              c.distribution.asRoleList.map(role => (role, c.placement))
-            }
-          val specs = plan.zipWithIndex.map { case ((role, placement), i) =>
-            NodeSpec(
-              key,
-              PoolSupervisor.nodeId(key, i + 1),
-              role,
-              merged,
-              td.objectStore,
-              maxConcurrent = maxConcurrentPerNode,
-              kindWire = kindWire,
-              extraSetupSql = nodeExtra,
-              placement = placement
-            )
-          }
-          specs
-            .foldLeft(IO.pure(List.empty[RunningNode])) { (acc, spec) =>
-              acc.flatMap(rs =>
-                IO.delay(tracker.remove(spec.nodeId)) *> backend.start(spec).map(rs :+ _)
-              )
-            }
-            .flatMap { running =>
-              val state = PoolState(
+          // initSql runs first so PRAGMAs/INSTALL land before the federation
+          // blob's ATTACHes; both get shipped via NodeSpec.extraSetupSql.
+          val fedBlob = blobOpt.getOrElse("")
+          // What the node actually gets at spawn = initSql + "\n" + federation blob.
+          // `state.extraSetupSql` keeps the federation blob ONLY so a manager
+          // restart that re-projects PoolState from persisted rows still has the
+          // operator-authored initSql available separately (and respawn can
+          // re-concatenate without double-prepending).
+          val nodeExtra  = PoolSupervisor.joinInitAndBlob(initSql, fedBlob)
+          val poolEntity = Pool(
+            id = newId("p"),
+            tenantId = td.tenantId,
+            tenantDbId = td.id,
+            name = key.pool,
+            size = size,
+            distribution = dist,
+            maxConcurrentPerNode = maxConcurrentPerNode,
+            disabled = disabled,
+            cohorts = cohorts,
+            initSql = initSql
+          )
+          IO.blocking(store.upsertPool(poolEntity)) *> IO.delay {
+            poolRows.put(poolEntity.id, poolEntity)
+            poolIdByKey.put(key, poolEntity.id)
+          } *> {
+            // Walk cohorts in order; each role gets the cohort's placement.
+            // Empty `cohorts` falls back to a single placement-less cohort
+            // carrying `dist`, matching pre-cohort behavior exactly.
+            val plan: List[(ai.starlake.quack.model.Role, NodePlacement)] =
+              poolEntity.effectiveCohorts.flatMap { c =>
+                c.distribution.asRoleList.map(role => (role, c.placement))
+              }
+            val specs = plan.zipWithIndex.map { case ((role, placement), i) =>
+              NodeSpec(
                 key,
-                running,
-                dist,
+                PoolSupervisor.nodeId(key, i + 1),
+                role,
                 merged,
                 td.objectStore,
-                maxConcurrentPerNode,
-                disabled = disabled,
+                maxConcurrent = maxConcurrentPerNode,
                 kindWire = kindWire,
-                // Federation blob only; respawn concatenates with initSql fresh.
-                extraSetupSql = fedBlob,
-                initSql = initSql,
-                defaultDatabase = td.defaultDatabase,
-                defaultSchema = td.defaultSchema
+                extraSetupSql = nodeExtra,
+                placement = placement
               )
-              pools.put(key, state)
-              running
-                .foldLeft(IO.unit)((acc, n) =>
-                  acc *> IO.blocking(store.upsertNode(n, poolEntity.id))
-                )
-                .as(running)
             }
-        }
+            specs
+              .foldLeft(IO.pure(List.empty[RunningNode])) { (acc, spec) =>
+                acc.flatMap(rs =>
+                  IO.delay(tracker.remove(spec.nodeId)) *> backend.start(spec).map(rs :+ _)
+                )
+              }
+              .flatMap { running =>
+                val state = PoolState(
+                  key,
+                  running,
+                  dist,
+                  merged,
+                  td.objectStore,
+                  maxConcurrentPerNode,
+                  disabled = disabled,
+                  kindWire = kindWire,
+                  // Federation blob only; respawn concatenates with initSql fresh.
+                  extraSetupSql = fedBlob,
+                  initSql = initSql,
+                  defaultDatabase = td.defaultDatabase,
+                  defaultSchema = td.defaultSchema
+                )
+                pools.put(key, state)
+                running
+                  .foldLeft(IO.unit)((acc, n) =>
+                    acc *> IO.blocking(store.upsertNode(n, poolEntity.id))
+                  )
+                  .as(running)
+              }
+          }
         }
   }
 
@@ -825,10 +826,10 @@ final class PoolSupervisor(
       case Some(state) =>
         val poolId = poolIdByKey.getOrElse(key, "")
         if targetSize > state.size then
-          val toAdd = targetSize - state.size
-          val roles = newDist.asRoleList.drop(state.size).take(toAdd)
+          val toAdd     = targetSize - state.size
+          val roles     = newDist.asRoleList.drop(state.size).take(toAdd)
           val nodeExtra = PoolSupervisor.joinInitAndBlob(state.initSql, state.extraSetupSql)
-          val specs = roles.zipWithIndex.map { case (role, i) =>
+          val specs     = roles.zipWithIndex.map { case (role, i) =>
             NodeSpec(
               key,
               PoolSupervisor.nodeId(key, state.size + i + 1),
@@ -1026,18 +1027,19 @@ final class PoolSupervisor(
 
   // ---------- RBAC: column policies ----------
 
-  /** Resolve a column-policy id to its owning tenant via the parent role.
-    * Used by `TenantScopeCheck` to refuse cross-tenant calls without a separate join. */
+  /** Resolve a column-policy id to its owning tenant via the parent role. Used by
+    * `TenantScopeCheck` to refuse cross-tenant calls without a separate join.
+    */
   def tenantForColumnPolicy(id: String): Option[String] =
     store.getColumnPolicy(id).flatMap(p => rbacResolver.role(p.roleId).map(_.tenantId))
 
   def createColumnPolicy(
-      roleId:       String,
-      catalogName:  String,
-      schemaName:   String,
-      tableName:    String,
-      columnName:   String,
-      action:       String,
+      roleId: String,
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      columnName: String,
+      action: String,
       transformSql: Option[String]
   ): IO[Either[String, state.RoleColumnPolicy]] = IO.blocking {
     val normalisedTransform = transformSql.map(_.trim).filter(_.nonEmpty)
@@ -1061,16 +1063,16 @@ final class PoolSupervisor(
           }
         else Right(None)
       validatedTransform match
-        case Left(err) => Left(err)
+        case Left(err)             => Left(err)
         case Right(canonTransform) =>
           val p = state.RoleColumnPolicy(
-            id           = newId("cp"),
-            roleId       = roleId,
-            catalogName  = catalogName,
-            schemaName   = schemaName,
-            tableName    = tableName,
-            columnName   = columnName,
-            action       = action,
+            id = newId("cp"),
+            roleId = roleId,
+            catalogName = catalogName,
+            schemaName = schemaName,
+            tableName = tableName,
+            columnName = columnName,
+            action = action,
             transformSql = canonTransform
           )
           val persisted = store.insertColumnPolicy(p)
@@ -1079,8 +1081,8 @@ final class PoolSupervisor(
   }
 
   def updateColumnPolicy(
-      id:           String,
-      action:       String,
+      id: String,
+      action: String,
       transformSql: Option[String]
   ): IO[Either[String, Unit]] = IO.blocking {
     val normalisedTransform = transformSql.map(_.trim).filter(_.nonEmpty)
@@ -1096,9 +1098,10 @@ final class PoolSupervisor(
           normalisedTransform.toRight("transformSql is required when action='mask'").flatMap { raw =>
             // updateColumnPolicy does not know the columnName; fetch it from the store to validate.
             store.getColumnPolicy(id) match
-              case None => Left(s"column policy $id not found")
+              case None           => Left(s"column policy $id not found")
               case Some(existing) =>
-                ai.starlake.quack.edge.cls.TransformSqlValidator.validate(raw, existing.columnName) match
+                ai.starlake.quack.edge.cls.TransformSqlValidator
+                  .validate(raw, existing.columnName) match
                   case ai.starlake.quack.edge.cls.TransformSqlValidator.Invalid(reason) =>
                     Left(s"invalid transformSql: $reason")
                   case ai.starlake.quack.edge.cls.TransformSqlValidator.Valid(canon) =>
@@ -1106,7 +1109,7 @@ final class PoolSupervisor(
           }
         else Right(None)
       validatedTransform match
-        case Left(err) => Left(err)
+        case Left(err)             => Left(err)
         case Right(canonTransform) =>
           val ok = store.updateColumnPolicy(id, action, canonTransform)
           if ok then { invalidateEffectiveCache(); Right(()) }
@@ -1284,11 +1287,10 @@ final class PoolSupervisor(
     *   1. resolve `(tenant, pool) -> PoolKey` + tenant/pool kill switches
     *   2. lookup the user via [[ControlPlaneStore.findUserForLogin]] -- this query also enforces
     *      the tenant scope: it returns rows where `tenant IS NULL` (superuser) OR
-    *      `tenant = <tenantId>`. Any user returned here is therefore already scoped correctly,
-    *      so we do NOT re-check `user.tenant == tenantRow.id` at the application layer.
-    *      If [[ControlPlaneStore.findUserForLogin]] is ever refactored to drop the tenant
-    *      filter (e.g. moving to a global-username model), reinstate the scope check between
-    *      gates 2 and 3.
+    *      `tenant = <tenantId>`. Any user returned here is therefore already scoped correctly, so
+    *      we do NOT re-check `user.tenant == tenantRow.id` at the application layer. If
+    *      [[ControlPlaneStore.findUserForLogin]] is ever refactored to drop the tenant filter (e.g.
+    *      moving to a global-username model), reinstate the scope check between gates 2 and 3.
     *   3. compute the effective set (groups, roles, permissions, pool grants)
     *   4. pool-access check (skipped for superusers): the effective pool grants must cover the
     *      addressed pool (pool_id NULL = "every pool in this tenant")
@@ -1374,17 +1376,18 @@ final class PoolSupervisor(
       jwtRoles: Set[String] = Set.empty,
       jwtGroups: Set[String] = Set.empty
   ): Option[ai.starlake.quack.ondemand.rbac.EffectiveSet] =
-    val key = EffectiveCacheKey(userId, jwtRoles.hashCode, jwtGroups.hashCode)
-    val now = java.time.Instant.now()
+    val key    = EffectiveCacheKey(userId, jwtRoles.hashCode, jwtGroups.hashCode)
+    val now    = java.time.Instant.now()
     val cached = effectiveCache.get(key)
     if cached != null && cached.expiresAt.isAfter(now) then Some(cached.value)
-    else computeEffectiveSetForUser(userId, jwtRoles, jwtGroups).map { computed =>
-      effectiveCache.put(
-        key,
-        EffectiveCacheEntry(now.plusSeconds(EffectiveCacheTtl.toSeconds), computed)
-      )
-      computed
-    }
+    else
+      computeEffectiveSetForUser(userId, jwtRoles, jwtGroups).map { computed =>
+        effectiveCache.put(
+          key,
+          EffectiveCacheEntry(now.plusSeconds(EffectiveCacheTtl.toSeconds), computed)
+        )
+        computed
+      }
 
   private def computeEffectiveSetForUser(
       userId: String,
@@ -1400,15 +1403,15 @@ final class PoolSupervisor(
       val jwtRoleIds  = u.tenant.toSet.flatMap(t => rbacResolver.rolesByNamesInTenant(t, jwtRoles))
       val jwtGroupIds =
         u.tenant.toSet.flatMap(t => rbacResolver.groupsByNamesInTenant(t, jwtGroups))
-      val directRoleIds = directRoleIdsLocal ++ jwtRoleIds
-      val groupIds      = groupIdsLocal ++ jwtGroupIds
-      val viaGroups     = groupIds.flatMap(rbacResolver.rolesForGroup)
-      val allRoleIds    = directRoleIds ++ viaGroups
-      val effRoles      = allRoleIds.flatMap(rbacResolver.role).toList.sortBy(_.name)
-      val effGroups     = groupIds.flatMap(rbacResolver.group).toList.sortBy(_.name)
-      val effPerms      = rbacResolver.permissionsForRoles(allRoleIds)
-      val directPools   = store.listPoolPermissionsForUser(u.id)
-      val viaGroupPools = groupIds.toList.flatMap(rbacResolver.poolPermissionsForGroup)
+      val directRoleIds  = directRoleIdsLocal ++ jwtRoleIds
+      val groupIds       = groupIdsLocal ++ jwtGroupIds
+      val viaGroups      = groupIds.flatMap(rbacResolver.rolesForGroup)
+      val allRoleIds     = directRoleIds ++ viaGroups
+      val effRoles       = allRoleIds.flatMap(rbacResolver.role).toList.sortBy(_.name)
+      val effGroups      = groupIds.flatMap(rbacResolver.group).toList.sortBy(_.name)
+      val effPerms       = rbacResolver.permissionsForRoles(allRoleIds)
+      val directPools    = store.listPoolPermissionsForUser(u.id)
+      val viaGroupPools  = groupIds.toList.flatMap(rbacResolver.poolPermissionsForGroup)
       val columnPolicies = allRoleIds.toList.flatMap(store.listColumnPolicies)
       ai.starlake.quack.ondemand.rbac.EffectiveSet(
         u,
@@ -1475,18 +1478,18 @@ object PoolSupervisor:
     * Order: `initSql` FIRST (so PRAGMAs / SET / INSTALL land before any federation ATTACH that
     * depends on them), federation blob SECOND. A trailing newline is forced between the two
     * non-empty fragments because spawn-quack-node.sh echoes the value verbatim into a `duckdb`
-    * pipe, and DuckDB needs the statement terminator to parse them as separate statements.
-    * Empty fragments are dropped so the resulting string contains no leading / trailing blank
-    * lines (cleaner UI display + simpler tests).
+    * pipe, and DuckDB needs the statement terminator to parse them as separate statements. Empty
+    * fragments are dropped so the resulting string contains no leading / trailing blank lines
+    * (cleaner UI display + simpler tests).
     */
   def joinInitAndBlob(initSql: String, federationBlob: String): String =
     val a = Option(initSql).getOrElse("").trim
     val b = Option(federationBlob).getOrElse("").trim
     (a, b) match
-      case ("", "")    => ""
-      case (i, "")     => i
-      case ("", f)     => f
-      case (i, f)      => s"$i\n$f"
+      case ("", "") => ""
+      case (i, "")  => i
+      case ("", f)  => f
+      case (i, f)   => s"$i\n$f"
 
   /** Compose a node id that is safe as a Kubernetes pod + service name.
     *
@@ -1501,15 +1504,13 @@ object PoolSupervisor:
 
   /** Replace the last segment of a dataPath with `newSegment`, used to derive a per-tenant-db
     * dataPath alongside the configured root. URI-style paths (`<scheme>://...`) are handled with
-    * string operations so we don't let `java.nio.file.Paths.get` collapse the scheme's `//` to
-    * `/` (which DuckLake's `__ducklake_metadata.data_path` check then rejects on re-ATTACH).
-    * Filesystem paths fall through to NIO so portability behavior is unchanged.
+    * string operations so we don't let `java.nio.file.Paths.get` collapse the scheme's `//` to `/`
+    * (which DuckLake's `__ducklake_metadata.data_path` check then rejects on re-ATTACH). Filesystem
+    * paths fall through to NIO so portability behavior is unchanged.
     *
-    * Examples (root + newSegment -> result):
-    *   ./ducklake/tpch          + acme_tpch -> ./ducklake/acme_tpch
-    *   /var/data/tpch           + acme_tpch -> /var/data/acme_tpch
-    *   s3://qod-ducklake/tpch   + acme_tpch -> s3://qod-ducklake/acme_tpch
-    *   gs://bucket/tpch         + acme_tpch -> gs://bucket/acme_tpch
+    * Examples (root + newSegment -> result): ./ducklake/tpch + acme_tpch -> ./ducklake/acme_tpch
+    * /var/data/tpch + acme_tpch -> /var/data/acme_tpch s3://qod-ducklake/tpch + acme_tpch ->
+    * s3://qod-ducklake/acme_tpch gs://bucket/tpch + acme_tpch -> gs://bucket/acme_tpch
     */
   private[ondemand] def replaceLastSegment(path: String, newSegment: String): String =
     // Strict URI scheme: a leading letter then letters/digits/+/-/. then `://`.

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -376,6 +376,21 @@ final class PoolSupervisor(
       tenantDbs.values.find(td => td.tenantId == t.id && td.name == nm)
     }
 
+  /** Find the (tenant, tenantDb) pair whose DuckDB-side catalog name (the composed Postgres
+    * `dbName` = `${tenant}_${tenantDb}`, lowercased) matches `catalog`. Used by the CLS rewriter's
+    * column-catalog fetcher to route a DuckDB catalog reference back to its tenant-db.
+    *
+    * The composed name is what `Names.normalizeTenantDbName` produces and is persisted into
+    * `TenantDb.name` (always lowercase via `Names.normalizeOrError`); matching against `td.name`
+    * with `equalsIgnoreCase` keeps this in sync with the SAME formula `spawn-quack-node.sh` /
+    * `effectiveMetastoreFor` use to spawn the node, with no risk of drift.
+    *
+    * Returns `None` if no matching tenant-db is registered.
+    */
+  def findTenantDbByCatalogName(catalog: String): Option[TenantDb] =
+    if catalog == null || catalog.isEmpty then None
+    else tenantDbs.values.find(_.name.equalsIgnoreCase(catalog))
+
   /** Resolve `(tenant, poolName) -> PoolKey` so the FlightSQL edge can route a connection that
     * addresses only `tenant` + `pool`. Pool names are unique within a tenant (enforced both by
     * `createPool` and the `qodstate_pool_tenant_name_unique` constraint), so at most one match

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -86,19 +86,28 @@ final class PoolSupervisor(
     * even within the TTL.
     */
   private final case class EffectiveCacheKey(userId: String, jwtRolesHash: Int, jwtGroupsHash: Int)
-  private final case class EffectiveCacheEntry(
-      expiresAt: java.time.Instant,
-      value: ai.starlake.quack.ondemand.rbac.EffectiveSet
-  )
-  private val effectiveCache =
-    new java.util.concurrent.ConcurrentHashMap[EffectiveCacheKey, EffectiveCacheEntry]()
   private val EffectiveCacheTtl: scala.concurrent.duration.FiniteDuration =
     scala.concurrent.duration.DurationInt(60).seconds
+
+  /** Caffeine-backed cache of resolved EffectiveSets. Caffeine handles the TTL
+    * (`expireAfterWrite`) and bounds memory (`maximumSize`) so distinct (userId, jwtRolesHash,
+    * jwtGroupsHash) combinations accumulated over the manager's lifetime can't leak. The previous
+    * hand-rolled `ConcurrentHashMap + expiresAt` form did neither.
+    */
+  private val effectiveCache: com.github.benmanes.caffeine.cache.Cache[
+    EffectiveCacheKey,
+    ai.starlake.quack.ondemand.rbac.EffectiveSet
+  ] =
+    com.github.benmanes.caffeine.cache.Caffeine
+      .newBuilder()
+      .expireAfterWrite(java.time.Duration.ofSeconds(EffectiveCacheTtl.toSeconds))
+      .maximumSize(10_000L)
+      .build[EffectiveCacheKey, ai.starlake.quack.ondemand.rbac.EffectiveSet]()
 
   /** Drop every cached `EffectiveSet`. Called from every RBAC mutator so a freshly-granted role or
     * pool permission takes effect on the next handshake, not after a TTL window.
     */
-  private def invalidateEffectiveCache(): Unit = effectiveCache.clear()
+  private def invalidateEffectiveCache(): Unit = effectiveCache.invalidateAll()
 
   // ---------- Bootstrap / replay ----------
 
@@ -1377,15 +1386,11 @@ final class PoolSupervisor(
       jwtGroups: Set[String] = Set.empty
   ): Option[ai.starlake.quack.ondemand.rbac.EffectiveSet] =
     val key    = EffectiveCacheKey(userId, jwtRoles.hashCode, jwtGroups.hashCode)
-    val now    = java.time.Instant.now()
-    val cached = effectiveCache.get(key)
-    if cached != null && cached.expiresAt.isAfter(now) then Some(cached.value)
+    val cached = effectiveCache.getIfPresent(key)
+    if cached != null then Some(cached)
     else
       computeEffectiveSetForUser(userId, jwtRoles, jwtGroups).map { computed =>
-        effectiveCache.put(
-          key,
-          EffectiveCacheEntry(now.plusSeconds(EffectiveCacheTtl.toSeconds), computed)
-        )
+        effectiveCache.put(key, computed)
         computed
       }
 

--- a/src/main/scala/ai/starlake/quack/ondemand/catalog/DuckLakeCatalogReader.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/catalog/DuckLakeCatalogReader.scala
@@ -94,7 +94,14 @@ class DuckLakeCatalogReader(private val ds: HikariDataSource):
       )
     }
 
-  private def listColumns(schema: String, table: String): List[CatalogColumnEntry] =
+  /** Returns just the column names for (schema, table), in declaration order. Used by the
+    * column-level-security rewriter to expand `SELECT *`. Reuses the same metadata query as
+    * `listColumns` but skips the type / nullable fields.
+    */
+  def columnNames(schema: String, table: String): List[String] =
+    listColumns(schema, table).map(_.name)
+
+  def listColumns(schema: String, table: String): List[CatalogColumnEntry] =
     // DuckLake (as of v0.3, DuckDB 1.5.x) doesn't ship a
     // `ducklake_table_constraint` table - PRIMARY KEY / UNIQUE constraints
     // are rejected at CREATE TABLE time. Until the metadata schema gains a

--- a/src/test/scala/ai/starlake/quack/edge/FlightSqlRouterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/FlightSqlRouterSpec.scala
@@ -413,7 +413,9 @@ class FlightSqlRouterSpec extends AnyFlatSpec with Matchers:
       "cp-1", "r-1", "*", "main", "customer", "c_email", "mask", Some("'***'")
     ))
     val rewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
-      new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(Map.empty)
+      new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(
+        Map(("memory", "main", "customer") -> List("c_id", "c_email"))
+      )
     )
     val (router, capturedSql, _) = setupWithRewriter(rewriter)
     val out = router.execute(
@@ -449,7 +451,9 @@ class FlightSqlRouterSpec extends AnyFlatSpec with Matchers:
       "cp-3", "r-1", "*", "main", "customer", "c_ssn", "deny", None
     ))
     val rewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
-      new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(Map.empty)
+      new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(
+        Map(("memory", "main", "customer") -> List("c_id", "c_ssn"))
+      )
     )
     val (router, _, _) = setupWithRewriter(rewriter)
     val out = router.execute(

--- a/src/test/scala/ai/starlake/quack/edge/FlightSqlRouterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/FlightSqlRouterSpec.scala
@@ -415,7 +415,8 @@ class FlightSqlRouterSpec extends AnyFlatSpec with Matchers:
     val rewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
       new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(
         Map(("memory", "main", "customer") -> List("c_id", "c_email"))
-      )
+      ),
+      enabled = true
     )
     val (router, capturedSql, _) = setupWithRewriter(rewriter)
     val out = router.execute(
@@ -433,7 +434,8 @@ class FlightSqlRouterSpec extends AnyFlatSpec with Matchers:
     val rewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
       new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(
         Map(("memory", "main", "customer") -> List("c_id", "c_email"))
-      )
+      ),
+      enabled = true
     )
     val (router, capturedSql, _) = setupWithRewriter(rewriter)
     val out = router.execute(
@@ -453,7 +455,8 @@ class FlightSqlRouterSpec extends AnyFlatSpec with Matchers:
     val rewriter = new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
       new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(
         Map(("memory", "main", "customer") -> List("c_id", "c_ssn"))
-      )
+      ),
+      enabled = true
     )
     val (router, _, _) = setupWithRewriter(rewriter)
     val out = router.execute(

--- a/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
@@ -90,41 +90,33 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   // -------- nested SELECTs --------
 
   it should "rewrite the inner SELECT of a scalar subquery in the projection" in {
-    // v2 limitation: JsqltranspilerRewriter does not yet recurse into scalar subqueries in
-    // projection items. Documenting current behavior — the outer SELECT carries no covered
-    // column, so the rewrite is a passthrough. Tightening this is tracked as future work.
     val out = rw.rewrite(
       "SELECT (SELECT c_email FROM tpch1.customer LIMIT 1) AS e FROM tpch1.customer",
       StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
-      case Passthrough    => succeed
       case Rewritten(sql) => sql should include ("'***'")
-      case other          => fail(s"unexpected outcome: $other")
+      case other          => fail(s"expected Rewritten, got $other")
   }
 
   it should "rewrite a subquery used as a FROM item" in {
-    // v2 limitation: the resolver does not expose the inner SELECT of a FROM-item subquery as
-    // its own rewrite target. The outer projection still sees the unresolved alias and currently
-    // passes through. Tracked as future work.
     val out = rw.rewrite(
       "SELECT c_email FROM (SELECT c_email FROM tpch1.customer) sub",
       StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
-      case Passthrough    => succeed
-      case Rewritten(sql) => sql should include ("'***'")
-      case other          => fail(s"unexpected outcome: $other")
+      case Rewritten(sql) =>
+        // Both the outer projection and the inner projection should now reference the mask.
+        sql.split("'\\*\\*\\*'").length - 1 should be >= 2
+      case other => fail(s"expected Rewritten, got $other")
   }
 
   it should "rewrite each arm of a UNION" in {
-    // v2 limitation: SetOperationList is not yet walked arm-by-arm. Documenting current
-    // behavior — both arms reference c_email but neither is rewritten. Tracked as future work.
     val out = rw.rewrite(
       "SELECT c_email FROM tpch1.customer UNION SELECT c_email FROM tpch1.customer",
       StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
-      case Passthrough    => succeed
-      case Rewritten(sql) => sql should include ("'***'")
-      case other          => fail(s"unexpected outcome: $other")
+      case Rewritten(sql) =>
+        sql.split("'\\*\\*\\*'").length - 1 should be >= 2
+      case other => fail(s"expected Rewritten, got $other")
   }
 
   it should "rewrite a CTE body" in {

--- a/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
@@ -46,11 +46,11 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
     rw.rewrite("BEGIN",                        StatementKind.Begin, effSet, ctx).unsafeRunSync() shouldBe Passthrough
   }
 
-  it should "passthrough when the SQL fails to parse" in {
+  it should "emit PassthroughParseFailed (distinct from Passthrough) when the SQL fails to parse" in {
     val policies = List(RoleColumnPolicy("cp-1", "r-1", "*", "tpch1", "customer",
                                           "c_email", "mask", Some("'***'")))
     rw.rewrite("SELEC' WRONG", StatementKind.Select, eff(tenantUser, policies), ctx)
-      .unsafeRunSync() shouldBe Passthrough
+      .unsafeRunSync() shouldBe PassthroughParseFailed
   }
 
   private val maskEmail = RoleColumnPolicy("cp-1", "r-1", "*", "tpch1", "customer",
@@ -157,9 +157,13 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "passthrough SELECT * when the catalog has no entry for the table" in {
+    // With UnresolvedMode.Passthrough (the rewriter's default) plus an empty catalog, the inner
+    // jsqltranspiler can't resolve `tpch1.customer` and falls into the LENIENT/parse-failed arm.
+    // The rewriter surfaces this as PassthroughParseFailed (distinct from Passthrough since
+    // Task 9 split the metric tag); both are routed the same way - original SQL forwarded.
     val r = new ColumnPolicyRewriter(new ColumnCatalog.MapCatalog(Map.empty))
     r.rewrite("SELECT * FROM tpch1.customer",
-              StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync() shouldBe Passthrough
+              StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync() shouldBe PassthroughParseFailed
   }
 
   // -------- deny semantics --------
@@ -203,4 +207,27 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
         sql.toLowerCase should include ("length")
         sql             should include ("'***'")
       case other => fail(s"expected Rewritten, got $other")
+  }
+
+  // -------- outcome refinement: unresolved-table deny vs regular deny --------
+
+  it should "emit DeniedUnresolvedTable when the resolver can't find the table" in {
+    // Empty catalog + Deny mode forces a TableNotFoundException / TableNotDeclaredException from
+    // jsqltranspiler, whose message contains the "not found" / "not declared" heuristic marker.
+    val r = new ColumnPolicyRewriter(
+      catalog        = new ColumnCatalog.MapCatalog(Map.empty),
+      unresolvedMode = UnresolvedMode.Deny
+    )
+    val out = r.rewrite("SELECT c_email FROM tpch1.unknown_table",
+                        StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
+    out shouldBe DeniedUnresolvedTable
+  }
+
+  it should "still emit Denied (not DeniedUnresolvedTable) for a policy-based deny" in {
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")))
+    val out = r.rewrite("SELECT c_ssn FROM tpch1.customer",
+                        StatementKind.Select, eff(tenantUser, List(denySsn)), ctx).unsafeRunSync()
+    out match
+      case Denied(reason) => reason.toLowerCase should include ("c_ssn")
+      case other          => fail(s"expected Denied, got $other")
   }

--- a/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
@@ -157,7 +157,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "passthrough SELECT * when the catalog has no entry for the table" in {
-    // With UnresolvedMode.Passthrough (the rewriter's default) plus an empty catalog, the inner
+    // With UnresolvedMode.Pass (the rewriter's default) plus an empty catalog, the inner
     // jsqltranspiler can't resolve `tpch1.customer` and falls into the LENIENT/parse-failed arm.
     // The rewriter surfaces this as PassthroughParseFailed (distinct from Passthrough since
     // Task 9 split the metric tag); both are routed the same way - original SQL forwarded.

--- a/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
@@ -24,10 +24,18 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
     new ColumnCatalog.MapCatalog(
       Map(("acme_tpch", "tpch1", "customer") -> List("c_id", "c_email", "c_phone", "c_ssn"))
     )
-  private def rw: ColumnPolicyRewriter = new ColumnPolicyRewriter(defaultCat)
+  private def rw: ColumnPolicyRewriter = new ColumnPolicyRewriter(defaultCat, enabled = true)
   private val ctx = SchemaContext(defaultDatabase = Some("acme_tpch"), defaultSchema = Some("tpch1"))
 
-  "rewrite" should "passthrough for superusers" in {
+  "rewrite" should "passthrough when the feature is disabled" in {
+    val policies = List(RoleColumnPolicy("cp-1", "r-1", "*", "tpch1", "customer",
+                                          "c_email", "mask", Some("'***'")))
+    val disabled = new ColumnPolicyRewriter(defaultCat, enabled = false)
+    disabled.rewrite("SELECT c_email FROM tpch1.customer", StatementKind.Select,
+                     eff(tenantUser, policies), ctx).unsafeRunSync() shouldBe Passthrough
+  }
+
+  it should "passthrough for superusers" in {
     rw.rewrite("SELECT c_email FROM customer", StatementKind.Select, eff(superuser), ctx)
       .unsafeRunSync() shouldBe Passthrough
   }
@@ -134,7 +142,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
     new ColumnCatalog.MapCatalog(Map(("acme_tpch", "tpch1", "customer") -> cols))
 
   it should "expand SELECT * via the column catalog and mask covered columns" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email", "c_phone")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email", "c_phone")), enabled = true)
     val out = r.rewrite("SELECT * FROM tpch1.customer",
                         StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
@@ -146,7 +154,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "expand a qualified t.* against the catalog" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email")), enabled = true)
     val out = r.rewrite("SELECT c.* FROM tpch1.customer c",
                         StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
@@ -161,7 +169,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
     // jsqltranspiler can't resolve `tpch1.customer` and falls into the LENIENT/parse-failed arm.
     // The rewriter surfaces this as PassthroughParseFailed (distinct from Passthrough since
     // Task 9 split the metric tag); both are routed the same way - original SQL forwarded.
-    val r = new ColumnPolicyRewriter(new ColumnCatalog.MapCatalog(Map.empty))
+    val r = new ColumnPolicyRewriter(new ColumnCatalog.MapCatalog(Map.empty), enabled = true)
     r.rewrite("SELECT * FROM tpch1.customer",
               StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync() shouldBe PassthroughParseFailed
   }
@@ -172,7 +180,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
                                           "c_ssn", "deny", None)
 
   it should "deny SELECT c_ssn FROM customer when the policy is deny" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")), enabled = true)
     val out = r.rewrite("SELECT c_ssn FROM tpch1.customer",
                         StatementKind.Select, eff(tenantUser, List(denySsn)), ctx).unsafeRunSync()
     out match
@@ -181,7 +189,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "deny SELECT * when expansion uncovers a denied column" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")), enabled = true)
     val out = r.rewrite("SELECT * FROM tpch1.customer",
                         StatementKind.Select, eff(tenantUser, List(denySsn)), ctx).unsafeRunSync()
     out match
@@ -190,7 +198,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "rewrite a covered column inside a WHERE predicate" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email")), enabled = true)
     val out = r.rewrite("SELECT c_id FROM tpch1.customer WHERE c_email LIKE '%@acme.com'",
                         StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
@@ -199,7 +207,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "rewrite covered columns inside composite expressions in projection" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_email")), enabled = true)
     val out = r.rewrite("SELECT length(c_email) FROM tpch1.customer",
                         StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
@@ -216,7 +224,8 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
     // jsqltranspiler, whose message contains the "not found" / "not declared" heuristic marker.
     val r = new ColumnPolicyRewriter(
       catalog        = new ColumnCatalog.MapCatalog(Map.empty),
-      unresolvedMode = UnresolvedMode.Deny
+      unresolvedMode = UnresolvedMode.Deny,
+      enabled        = true
     )
     val out = r.rewrite("SELECT c_email FROM tpch1.unknown_table",
                         StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
@@ -224,7 +233,7 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "still emit Denied (not DeniedUnresolvedTable) for a policy-based deny" in {
-    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")))
+    val r = new ColumnPolicyRewriter(catWithCustomer(List("c_id", "c_ssn")), enabled = true)
     val out = r.rewrite("SELECT c_ssn FROM tpch1.customer",
                         StatementKind.Select, eff(tenantUser, List(denySsn)), ctx).unsafeRunSync()
     out match

--- a/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/ColumnPolicyRewriterSpec.scala
@@ -16,8 +16,15 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   private def eff(user: RbacUser, policies: List[RoleColumnPolicy] = Nil): EffectiveSet =
     EffectiveSet(user, Nil, Nil, Nil, Nil, policies)
 
-  private val emptyCat: ColumnCatalog = new ColumnCatalog.MapCatalog(Map.empty)
-  private def rw: ColumnPolicyRewriter = new ColumnPolicyRewriter(emptyCat)
+  // v2 needs schema info for the resolver to walk column references. The default catalog
+  // covers `customer` with the columns referenced by the masking-exercising tests below.
+  // The `Map.empty` case is still tested explicitly via `passthrough SELECT * when the catalog
+  // has no entry for the table` which constructs its own rewriter.
+  private val defaultCat: ColumnCatalog =
+    new ColumnCatalog.MapCatalog(
+      Map(("acme_tpch", "tpch1", "customer") -> List("c_id", "c_email", "c_phone", "c_ssn"))
+    )
+  private def rw: ColumnPolicyRewriter = new ColumnPolicyRewriter(defaultCat)
   private val ctx = SchemaContext(defaultDatabase = Some("acme_tpch"), defaultSchema = Some("tpch1"))
 
   "rewrite" should "passthrough for superusers" in {
@@ -83,33 +90,41 @@ class ColumnPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   // -------- nested SELECTs --------
 
   it should "rewrite the inner SELECT of a scalar subquery in the projection" in {
+    // v2 limitation: JsqltranspilerRewriter does not yet recurse into scalar subqueries in
+    // projection items. Documenting current behavior — the outer SELECT carries no covered
+    // column, so the rewrite is a passthrough. Tightening this is tracked as future work.
     val out = rw.rewrite(
       "SELECT (SELECT c_email FROM tpch1.customer LIMIT 1) AS e FROM tpch1.customer",
       StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
+      case Passthrough    => succeed
       case Rewritten(sql) => sql should include ("'***'")
-      case other          => fail(s"expected Rewritten, got $other")
+      case other          => fail(s"unexpected outcome: $other")
   }
 
   it should "rewrite a subquery used as a FROM item" in {
+    // v2 limitation: the resolver does not expose the inner SELECT of a FROM-item subquery as
+    // its own rewrite target. The outer projection still sees the unresolved alias and currently
+    // passes through. Tracked as future work.
     val out = rw.rewrite(
       "SELECT c_email FROM (SELECT c_email FROM tpch1.customer) sub",
       StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
-      case Rewritten(sql) =>
-        // Both the outer projection and the inner projection should now reference the mask.
-        sql.split("'\\*\\*\\*'").length - 1 should be >= 2
-      case other => fail(s"expected Rewritten, got $other")
+      case Passthrough    => succeed
+      case Rewritten(sql) => sql should include ("'***'")
+      case other          => fail(s"unexpected outcome: $other")
   }
 
   it should "rewrite each arm of a UNION" in {
+    // v2 limitation: SetOperationList is not yet walked arm-by-arm. Documenting current
+    // behavior — both arms reference c_email but neither is rewritten. Tracked as future work.
     val out = rw.rewrite(
       "SELECT c_email FROM tpch1.customer UNION SELECT c_email FROM tpch1.customer",
       StatementKind.Select, eff(tenantUser, List(maskEmail)), ctx).unsafeRunSync()
     out match
-      case Rewritten(sql) =>
-        sql.split("'\\*\\*\\*'").length - 1 should be >= 2
-      case other => fail(s"expected Rewritten, got $other")
+      case Passthrough    => succeed
+      case Rewritten(sql) => sql should include ("'***'")
+      case other          => fail(s"unexpected outcome: $other")
   }
 
   it should "rewrite a CTE body" in {

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -88,3 +88,16 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside EXTRACT" in {
+    // EXTRACT semantically expects a date/time, but the parser doesn't enforce that. Use it as a
+    // smoke test that the visitor descends into the inner expression.
+    val out = rw.rewrite(
+      "SELECT EXTRACT(YEAR FROM c_email) FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -77,3 +77,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside BETWEEN" in {
+    val out = rw.rewrite(
+      "SELECT c_id FROM customer WHERE c_email BETWEEN 'a' AND 'z'",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -147,3 +147,20 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "expand multi-table SELECT * and mask per-table" in {
+    val multi = Map(
+      "customer" -> List("c_id", "c_email"),
+      "orders"   -> List("o_id", "o_customer")
+    )
+    val out = rw.rewrite(
+      "SELECT * FROM customer c JOIN orders o ON c.c_id = o.o_customer",
+      multi, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) =>
+        sql should include ("'***'")
+        sql.toLowerCase should include ("o_id")
+      case other => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -66,3 +66,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside IN list" in {
+    val out = rw.rewrite(
+      "SELECT c_id FROM customer WHERE c_email IN ('a@x', 'b@x')",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -218,3 +218,19 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Passthrough => succeed
       case other                      => fail(s"expected Passthrough, got $other")
   }
+
+  it should "not mask a same-named column on a table the policy doesn't target" in {
+    val multi = Map("other_table" -> List("c_id", "c_email"))
+    val out = rw.rewrite(
+      "SELECT c_email FROM other_table",
+      multi,
+      // Policy targets customer.c_email, not other_table.c_email
+      List(maskEmail.copy(tableName = "customer")),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Passthrough    => succeed
+      case RewriteOutcome.Rewritten(sql) =>
+        fail(s"v1 over-mask regression: policy on customer.c_email leaked to other_table.c_email: $sql")
+      case other                          => fail(s"expected Passthrough, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -179,3 +179,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "resolve CTE column c_email to the base table" in {
+    val out = rw.rewrite(
+      "WITH x AS (SELECT c_email FROM customer) SELECT c_email FROM x",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -136,3 +136,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside row constructor" in {
+    val out = rw.rewrite(
+      "SELECT (c_id, c_email) FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -1,0 +1,35 @@
+package ai.starlake.quack.edge.cls
+
+import ai.starlake.quack.ondemand.state.RoleColumnPolicy
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
+
+  private val rw = new JsqltranspilerRewriter
+
+  private val maskEmail = RoleColumnPolicy(
+    id            = "cp-1",
+    roleId        = "r-1",
+    catalogName   = "*",
+    schemaName    = "tpch1",
+    tableName     = "customer",
+    columnName    = "c_email",
+    action        = "mask",
+    transformSql  = Some("'***'")
+  )
+
+  private val schema = Map("customer" -> List("c_id", "c_email", "c_phone"))
+
+  "rewrite" should "mask a directly-projected covered column" in {
+    val out = rw.rewrite(
+      sql            = "SELECT c_email FROM customer",
+      schema         = schema,
+      policies       = List(maskEmail),
+      defaultCatalog = Some("acme_tpch"),
+      defaultSchema  = Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -101,3 +101,27 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside window PARTITION BY" in {
+    // jsqltranspiler 1.9's resolver throws NPE on AnalyticExpression with no inner expression
+    // (e.g. row_number()), so use sum(c_id) which has an arg the resolver can walk.
+    val out = rw.rewrite(
+      "SELECT sum(c_id) OVER (PARTITION BY c_email) FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }
+
+  it should "mask c_email inside window ORDER BY" in {
+    val out = rw.rewrite(
+      "SELECT sum(c_id) OVER (ORDER BY c_email) FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -44,3 +44,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside CASE WHEN arms" in {
+    val out = rw.rewrite(
+      "SELECT CASE WHEN c_id > 0 THEN c_email ELSE 'fallback' END FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -210,7 +210,7 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       policies       = List(maskEmail),
       defaultCatalog = Some("acme_tpch"),
       defaultSchema  = Some("tpch1"),
-      unresolvedMode = UnresolvedMode.Passthrough
+      unresolvedMode = UnresolvedMode.Pass
     )
     out match
       case RewriteOutcome.Passthrough => succeed

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -190,3 +190,31 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "deny SELECT against an unknown table in STRICT mode" in {
+    val out = rw.rewrite(
+      sql            = "SELECT c_email FROM unknown_table",
+      schema         = Map.empty, // resolver has no entry for unknown_table
+      policies       = List(maskEmail),
+      defaultCatalog = Some("acme_tpch"),
+      defaultSchema  = Some("tpch1"),
+      unresolvedMode = UnresolvedMode.Deny
+    )
+    out match
+      case RewriteOutcome.Denied(_) => succeed
+      case other                    => fail(s"expected Denied, got $other")
+  }
+
+  it should "pass through SELECT against an unknown table in LENIENT mode" in {
+    val out = rw.rewrite(
+      sql            = "SELECT c_email FROM unknown_table",
+      schema         = Map.empty,
+      policies       = List(maskEmail),
+      defaultCatalog = Some("acme_tpch"),
+      defaultSchema  = Some("tpch1"),
+      unresolvedMode = UnresolvedMode.Passthrough
+    )
+    out match
+      case RewriteOutcome.Passthrough => succeed
+      case other                      => fail(s"expected Passthrough, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -33,3 +33,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside a function call in the projection" in {
+    val out = rw.rewrite(
+      "SELECT length(c_email) FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -103,10 +103,8 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
   }
 
   it should "mask c_email inside window PARTITION BY" in {
-    // jsqltranspiler 1.9's resolver throws NPE on AnalyticExpression with no inner expression
-    // (e.g. row_number()), so use sum(c_id) which has an arg the resolver can walk.
     val out = rw.rewrite(
-      "SELECT sum(c_id) OVER (PARTITION BY c_email) FROM customer",
+      "SELECT row_number() OVER (PARTITION BY c_email) FROM customer",
       schema, List(maskEmail),
       Some("acme_tpch"), Some("tpch1")
     )
@@ -117,7 +115,7 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
 
   it should "mask c_email inside window ORDER BY" in {
     val out = rw.rewrite(
-      "SELECT sum(c_id) OVER (ORDER BY c_email) FROM customer",
+      "SELECT row_number() OVER (ORDER BY c_email) FROM customer",
       schema, List(maskEmail),
       Some("acme_tpch"), Some("tpch1")
     )

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -55,3 +55,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside CAST" in {
+    val out = rw.rewrite(
+      "SELECT CAST(c_email AS VARCHAR) FROM customer",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -164,3 +164,18 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
         sql.toLowerCase should include ("o_id")
       case other => fail(s"expected Rewritten, got $other")
   }
+
+  it should "resolve unqualified c_email in a multi-join to the customer table" in {
+    val multi = Map(
+      "customer" -> List("c_id", "c_email"),
+      "orders"   -> List("o_id", "o_customer")
+    )
+    val out = rw.rewrite(
+      "SELECT c_email FROM customer JOIN orders ON c_id = o_customer",
+      multi, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriterSpec.scala
@@ -125,3 +125,14 @@ class JsqltranspilerRewriterSpec extends AnyFlatSpec with Matchers:
       case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
       case other                          => fail(s"expected Rewritten, got $other")
   }
+
+  it should "mask c_email inside LIKE pattern" in {
+    val out = rw.rewrite(
+      "SELECT c_id FROM customer WHERE c_email LIKE '%@acme.com'",
+      schema, List(maskEmail),
+      Some("acme_tpch"), Some("tpch1")
+    )
+    out match
+      case RewriteOutcome.Rewritten(sql) => sql should include ("'***'")
+      case other                          => fail(s"expected Rewritten, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/observability/metrics/CLSOutcomeTagSpec.scala
+++ b/src/test/scala/ai/starlake/quack/observability/metrics/CLSOutcomeTagSpec.scala
@@ -1,0 +1,24 @@
+package ai.starlake.quack.observability.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+/** Pins the wire-level tag values emitted on `column_policy_rewrites_total`. The rewriter splits
+  * `passthrough` into (`passthrough` | `parse_failed`) and `denied` into (`denied` |
+  * `unresolved_deny`); this spec just verifies the counter accepts the new tag values without
+  * mangling them.
+  */
+class CLSOutcomeTagSpec extends AnyFlatSpec with Matchers:
+
+  "StatementInstruments" should "emit parse_failed and unresolved_deny tags" in {
+    val registry = new SimpleMeterRegistry
+    val si       = new StatementInstruments(registry)
+    si.recordColumnPolicyRewrite("acme", "bi", "parse_failed")
+    si.recordColumnPolicyRewrite("acme", "bi", "unresolved_deny")
+    val meters   = registry.find("column_policy_rewrites_total").meters().asScala
+    val outcomes = meters.map(_.getId.getTag("outcome")).toSet
+    outcomes should contain allOf ("parse_failed", "unresolved_deny")
+  }

--- a/website/docs/operating/rbac-model.md
+++ b/website/docs/operating/rbac-model.md
@@ -197,6 +197,21 @@ FROM x` is masked according to the base table's policy. For FROM-item subqueries
 outer-scope policy keyed on `(subAlias, exposedName)` so the outer projection is masked too,
 since jsqltranspiler's lineage stops at the FROM boundary.
 
+### Kill switch (feature flag — EXPERIMENTAL)
+
+Column-level security is **experimental** and ships **disabled by default**. Operators opt in
+by setting `quack-on-demand.cls.enabled = true` (or env `QOD_CLS_ENABLED=true`). When disabled,
+every statement bypasses the rewriter completely: no FROM-table catalog lookup, no
+jsqltranspiler call, no per-statement overhead. The behaviour matches a build with column
+policies absent. Treat the toggle as a kill switch you can flip off in an incident: change
+the env var and restart the manager.
+
+While the feature is experimental, expect rough edges around federated sources,
+`LateralSubSelect` / `TableFunction` FROM items, and the 5-second catalog cache TTL race
+documented below. Standard SELECT, JOIN, CTE, UNION, subquery, CASE, CAST, IN, BETWEEN,
+EXTRACT, window, and LIKE constructs are covered by tests and considered ready for staging
+trials.
+
 ### Unresolved-table behaviour
 
 When the rewriter encounters a table the DuckLake catalog cannot enumerate (federated alias

--- a/website/docs/operating/rbac-model.md
+++ b/website/docs/operating/rbac-model.md
@@ -181,6 +181,45 @@ The rewriter only runs for SELECT-shaped statements; DML and DDL pass through un
 
 Superusers bypass the rewriter, matching the bypass behaviour of the table-level ACL.
 
+### Column-level security guarantees
+
+The rewriter walks every projection-eligible JSqlParser node kind: direct column references,
+CASE arms, CAST inner, IN list members, BETWEEN bounds, EXTRACT inner, window PARTITION BY and
+ORDER BY expressions, LIKE patterns, and row constructors. Star (`*`) projections are expanded
+against the DuckLake catalog before the policy walk, so multi-table joins and qualified `t.*`
+both apply per-column policies. CTE, FROM-item subqueries, scalar subqueries in projection, and
+UNION / INTERSECT / EXCEPT arms are all recursed into; the v1 bypass list is closed.
+
+CTE and view indirection are resolved at the physical (table, column) level via jsqltranspiler's
+lineage tree. A column projected through `WITH x AS (SELECT c_email FROM customer) SELECT c_email
+FROM x` is masked according to the base table's policy. For FROM-item subqueries
+(`SELECT c_email FROM (SELECT c_email FROM customer) sub`) the rewriter synthesises a transient
+outer-scope policy keyed on `(subAlias, exposedName)` so the outer projection is masked too,
+since jsqltranspiler's lineage stops at the FROM boundary.
+
+### Unresolved-table behaviour
+
+When the rewriter encounters a table the DuckLake catalog cannot enumerate (federated alias
+the catalog does not expose, metadata fetch raced a DDL), the request falls back per
+`QOD_CLS_UNRESOLVED_TABLE`:
+
+- `pass` (default): forward the unrewritten SQL to DuckDB. Matches v1 behaviour.
+- `deny`: refuse the statement with an "unknown table" error. Safer; recommended for
+  production tenants where any unexpected SQL is suspicious.
+
+### Catalog cache and schema evolution (known limitation)
+
+`DuckLakeColumnCatalog` caches column-name lookups at a 5-second TTL. After a `CREATE / ALTER /
+DROP TABLE` or column DDL, the rewriter sees a stale column list for up to 5 seconds. Concrete
+race: a freshly-added column plus a freshly-added policy on it leaves a window where the policy
+lookup runs but the resolver does not see the new column. In `pass` mode the unmasked SQL
+reaches DuckDB during this window; in `deny` mode the statement is denied. Operators expecting
+simultaneous DDL + RBAC changes should pin tenants to `deny` mode, or accept the 5-second
+exposure on `pass`.
+
+A future release will hook DDL classification into cache invalidation so the window closes to
+under one statement; until then this is operator-visible.
+
 ### Action: deny
 
 A `deny` policy refuses any query that references the protected column anywhere — projection, WHERE clause, HAVING, GROUP BY, ORDER BY, JOIN condition, subquery, CTE body — and short-circuits with a 403 carrying the column qualifier. `SELECT *` deny is fail-closed: if star expansion uncovers a denied column, the query is refused rather than silently dropping the column from the projection.
@@ -224,9 +263,21 @@ Three Micrometer metrics expose the rewriter's behaviour:
 
 | Metric | Tags | Use |
 |---|---|---|
-| `column_policy_rewrites_total`       | `tenant`, `pool`, `outcome` ∈ `{rewritten, denied, passthrough}` | Fraction of reads paying the rewrite cost; spot policy regressions. |
+| `column_policy_rewrites_total`       | `tenant`, `pool`, `outcome` ∈ `{rewritten, denied, unresolved_deny, parse_failed, passthrough}` | Fraction of reads paying the rewrite cost; spot policy regressions. |
 | `column_policy_catalog_lookups_total` | `tenant`, `pool`, `result` ∈ `{hit, miss, error}` | `ColumnCatalog` cache effectiveness; alert on `error > 0` to catch federation breakage. |
 | `column_policy_rewrite_duration_seconds` | `tenant`, `pool` | Histogram of rewrite step wall time; alert on percentile regressions. |
+
+The `column_policy_rewrites_total{outcome=...}` counter emits five outcomes:
+
+- `rewritten`: at least one projection or predicate column was replaced with a mask transform.
+- `denied`: a deny policy matched a referenced column.
+- `unresolved_deny`: `QOD_CLS_UNRESOLVED_TABLE=deny` refused a query because the catalog did
+  not know the referenced table.
+- `parse_failed`: jsqltranspiler could not parse / resolve the SQL; the original statement is
+  forwarded unchanged. Distinct from `passthrough` so operators can tell "rewriter inactive
+  because nothing to rewrite" from "rewriter inactive because it gave up".
+- `passthrough`: the rewriter inspected the SQL and decided no rewrite was needed (no covered
+  column referenced; non-SELECT; superuser; user has no column policies).
 
 `Denied` outcomes also surface in the statement-history view (with `status=denied` and the offending column qualifier in the error message) and in the audit log line `column policy denied: user=… column=… role=… statement=…`.
 


### PR DESCRIPTION
## Summary

- **Column-level security v2**: replace the hand-rolled `walkAndReplace` walker with a jsqltranspiler-backed rewriter that closes the v1 CASE / CAST / IN / BETWEEN / EXTRACT / window / multi-table-star / CTE / FROM-item-subquery / scalar-subquery / UNION bypasses. Behind a new `SchemaAwareSqlRewriter` trait so the inner impl is swappable.
- **Experimental opt-in**: ships disabled by default (`quack-on-demand.cls.enabled = false`, env `QOD_CLS_ENABLED=true` to opt in). Zero per-statement overhead when off; operator-tunable in-incident.
- **Memory hygiene**: migrate `PoolSupervisor.effectiveCache` and `GoogleGroupsLookup.groupsCache` from hand-rolled `ConcurrentHashMap` + manual timestamp checks to Caffeine — closes two real unbounded-cache leaks.

## What's in the PR

### Column-level security v2

| Bypass closed | Test pinning it |
|---|---|
| CASE WHEN arms (including deep nesting) | `JsqltranspilerRewriterSpec` |
| CAST | same |
| IN list | same |
| BETWEEN bounds | same |
| EXTRACT inner | same |
| window PARTITION BY / ORDER BY (incl. `row_number()`) | same |
| LIKE pattern | same |
| row constructor / parenthesized expression list | same |
| Multi-table `SELECT *` (per-table expansion) | same |
| Unqualified column in multi-join resolves to right table | same |
| CTE column lineage to base table | same |
| FROM-item subquery (synthesized outer-scope policy) | `ColumnPolicyRewriterSpec` |
| Scalar subquery in projection | same |
| UNION / INTERSECT / EXCEPT arms | same |

Pipeline shape: `classifier → validator → ColumnPolicyRewriter (facade) → JsqltranspilerRewriter (inner) → Router`. The facade handles IO + early exits; the inner is pure (no IO), tested in isolation.

### Architecture decisions

- **New dep**: `ai.starlake.jsqltranspiler:jsqltranspiler:1.10` (Starlake fork). 1.9 had an upstream NPE on argless analytic functions (`row_number()`); filed [starlake-ai/jsqltranspiler#146](https://github.com/starlake-ai/jsqltranspiler/issues/146), fix shipped in 1.10.
- **3-arg `JSQLColumResolver` constructor**: threads `defaultCatalog` / `defaultSchema` so schema-qualified table references (`tpch1.customer`) match the schemaless rows in the schemaDef.
- **Synthetic outer-scope policies for FROM-item subqueries**: jsqltranspiler's lineage stops at the FROM boundary, so we keep an alias-keyed transient policy so the outer projection masks `sub.c_email`.
- **`QOD_CLS_UNRESOLVED_TABLE = pass | deny`** (default `pass`, v1-compatible): controls behavior when the catalog can't enumerate a referenced table. STRICT mode denies; LENIENT mode passes through.
- **`QOD_CLS_ENABLED = true | false`** (default `false`): global kill switch. Feature is opt-in while we harden the rough edges below.
- **Observability**: `column_policy_rewrites_total{outcome=...}` gains two new tags — `parse_failed` (distinct from `passthrough`) and `unresolved_deny` (distinct from `denied`).
- **Code style**: rewriter uses structured `if/else` + `match` expression chains; no `return`, no `scala.util.boundary`/`break`.

### Caffeine cleanup (independent scope)

`PoolSupervisor.effectiveCache` (RBAC EffectiveSet) and `GoogleGroupsLookup.groupsCache` (Google Workspace group memberships) both used `ConcurrentHashMap` with manual `expiresAt` / `fetchedAt + ttl` checks and **no maximum size**, so distinct cache keys accumulated over the manager's lifetime indefinitely. Migrated both to Caffeine with `expireAfterWrite` + `maximumSize(10_000)` and the same TTLs (60s / configurable 300s).

## Known limitations (documented in `website/docs/operating/rbac-model.md`)

- **5-second catalog cache TTL race**: after a DDL, the rewriter sees the stale column list for up to 5s. In `pass` mode, a freshly-added column+policy combination can leak during the window; in `deny` mode, it over-denies. Hooking DDL classification into cache invalidation is a follow-up.
- **Federated sources**: their schemas aren't in DuckLake metadata; queries that reference only a federated table fall to the `unresolvedTable` branch.
- **`LateralSubSelect` / `TableFunction` FROM items**: not yet walked. Real SQL using them would silently passthrough; tests + visitor arms are a follow-up.

## Test plan

- [ ] `sbt "testOnly ai.starlake.quack.edge.cls.*"` — 47 tests pass (16 new `JsqltranspilerRewriterSpec` + 20 `ColumnPolicyRewriterSpec` + 11 `TransformSqlValidatorSpec`)
- [ ] `sbt "testOnly ai.starlake.quack.edge.FlightSqlRouterSpec"` — 19 tests pass
- [ ] `sbt "testOnly ai.starlake.quack.observability.metrics.CLSOutcomeTagSpec"` — 1 test passes
- [ ] `sbt "testOnly ai.starlake.quack.ondemand.PoolSupervisorSpec"` — 36 tests pass (Caffeine migration regression check)
- [ ] `sbt test` — 862 passing, 0 failing (1 pre-existing `UserStoreGrantsSpec` abort on missing `QOD_PG_HOST`, unrelated)
- [ ] `sbt assembly` — 226 MB uber-jar, no new merge conflicts from jsqltranspiler 1.10
- [ ] Manual: with `QOD_CLS_ENABLED=true` and a `mask` policy on `customer.c_email`, run `SELECT c_email FROM customer` via FlightSQL CLI — output should be `'***'`. Repeat with `QOD_CLS_ENABLED=false` — output should be raw.

## Follow-ups (captured in `docs/superpowers/plans/2026-06-14-column-level-security-v2.md` under "Follow-ups")

1. DDL → catalog-cache invalidation hook in `FlightSqlRouter` post-execute.
2. `quack-on-demand.cls.catalogTtlSec` config knob (currently hard-coded to 5s).
3. Visitor arms for `LateralSubSelect` / `TableFunction` FROM items.
4. Per-tenant CLS enable/disable (today's toggle is global).

🤖 Generated with [Claude Code](https://claude.com/claude-code)