### PR TITLE
Row-level security (experimental)

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -67,6 +67,20 @@ quack-on-demand {
     unresolvedTable = ${?QOD_CLS_UNRESOLVED_TABLE}
   }
 
+  # Row-level security (EXPERIMENTAL).
+  # `enabled` is the kill switch. When false (the default), every statement
+  # bypasses the row-policy rewriter - no parse, no table wrapping, no
+  # per-statement overhead. Set true to opt in. When on, each base table a
+  # SELECT touches that carries a matching qodstate_role_row_policy for the
+  # principal is replaced by `(SELECT * FROM <table> WHERE <predicate>)`;
+  # predicates from the principal's several roles combine with OR (permissive
+  # union). Superusers (tenant IS NULL) are never filtered. Unparseable SQL
+  # falls through unrewritten (tagged parse_failed on row_policy_rewrites_total).
+  rls {
+    enabled = false
+    enabled = ${?QOD_RLS_ENABLED}
+  }
+
   # Toggle the JNI-backed native Quack wire client in QuackHttpClient.
   # Default: true (the JNI native path is the production-grade default).
   # Set QOD_NATIVE_CLIENT=false (or change

--- a/src/main/resources/db/changelog/0013-role-row-policy.yaml
+++ b/src/main/resources/db/changelog/0013-role-row-policy.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0013-qodstate-role-row-policy
+      author: quack-on-demand
+      changes:
+        - createTable:
+            tableName: qodstate_role_row_policy
+            columns:
+              - column: { name: id,            type: TEXT,        constraints: { primaryKey: true, nullable: false } }
+              - column: { name: role_id,       type: TEXT,        constraints: { nullable: false } }
+              - column: { name: catalog_name,  type: TEXT,        constraints: { nullable: false } }
+              - column: { name: schema_name,   type: TEXT,        constraints: { nullable: false } }
+              - column: { name: table_name,    type: TEXT,        constraints: { nullable: false } }
+              - column: { name: predicate_sql, type: TEXT,        constraints: { nullable: false } }
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: now()
+                  constraints: { nullable: false }
+        - addForeignKeyConstraint:
+            baseTableName: qodstate_role_row_policy
+            baseColumnNames: role_id
+            referencedTableName: qodstate_role
+            referencedColumnNames: id
+            constraintName: qodstate_role_row_policy_role_fk
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: qodstate_role_row_policy
+            columnNames: role_id, catalog_name, schema_name, table_name
+            constraintName: qodstate_role_row_policy_uniq
+        - createIndex:
+            tableName: qodstate_role_row_policy
+            indexName: qodstate_role_row_policy_role_idx
+            columns:
+              - column: { name: role_id }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,5 @@ databaseChangeLog:
       file: db/changelog/0011-pool-init-sql.yaml
   - include:
       file: db/changelog/0012-role-column-policy.yaml
+  - include:
+      file: db/changelog/0013-role-row-policy.yaml

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -498,6 +498,15 @@ object Main extends IOApp with LazyLogging:
         enabled = clsEnabled
       )
 
+      val rlsEnabled: Boolean =
+        com.typesafe.config.ConfigFactory.load().getBoolean("quack-on-demand.rls.enabled")
+      if !rlsEnabled then
+        logger.info(
+          "row-level security is DISABLED (quack-on-demand.rls.enabled=false). " +
+            "Every statement bypasses the row-policy rewriter."
+        )
+      val rowPolicyRewriter = new ai.starlake.quack.edge.rls.RowPolicyRewriter(enabled = rlsEnabled)
+
       val fsRouter = new FlightSqlRouter(
         sup,
         sessions,
@@ -507,7 +516,8 @@ object Main extends IOApp with LazyLogging:
         stmtHistory,
         stmtInstruments,
         classifier,
-        columnPolicyRewriter
+        columnPolicyRewriter,
+        rowPolicyRewriter
       )
 
       // FlightEdgeServer construction allocates Arrow's RootAllocator eagerly,

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -578,6 +578,7 @@ object Main extends IOApp with LazyLogging:
       val membershipHandlers   = new MembershipHandlers(sup, userHandlers)
       val poolPermHandlers     = new PoolPermissionHandlers(sup, userHandlers)
       val columnPolicyHandlers = new ai.starlake.quack.ondemand.api.RoleColumnPolicyHandlers(sup)
+      val rowPolicyHandlers    = new ai.starlake.quack.ondemand.api.RoleRowPolicyHandlers(sup)
 
       // Config page registry. The roots list pairs each typed config
       // class with its HOCON prefix; the reflector pulls every
@@ -644,7 +645,8 @@ object Main extends IOApp with LazyLogging:
         serverConfigHandlers,
         manifestHandlers,
         federatedSourceHandlers,
-        columnPolicyHandlers
+        columnPolicyHandlers,
+        rowPolicyHandlers
       )
       // DuckLake pre-init is per-tenant-db; PoolSupervisor.createTenantDb
       // calls DuckLakeInitializer.initBlocking once the tenant-db's own

--- a/src/main/scala/ai/starlake/quack/edge/FlightSqlRouter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/FlightSqlRouter.scala
@@ -39,7 +39,9 @@ final class FlightSqlRouter(
     val columnPolicyRewriter: ai.starlake.quack.edge.cls.ColumnPolicyRewriter =
       new ai.starlake.quack.edge.cls.ColumnPolicyRewriter(
         new ai.starlake.quack.edge.cls.ColumnCatalog.MapCatalog(Map.empty)
-      )
+      ),
+    val rowPolicyRewriter: ai.starlake.quack.edge.rls.RowPolicyRewriter =
+      new ai.starlake.quack.edge.rls.RowPolicyRewriter()
 ):
 
   private def record(
@@ -192,6 +194,31 @@ final class FlightSqlRouter(
             maybeRecord(nodeId = "-", durationMs = 0, status = "denied", error = Some(reason))
             return IO.pure(Left(s"access denied: $reason"))
 
+    // Row-level security: filter rows AFTER column masking is decided, but injected at the BASE
+    // table so the predicate runs on the true (unmasked) values. Operates on the CLS output so the
+    // two rewriters compose (RLS innermost, CLS outermost).
+    val finalSql: String = effectiveSet match
+      case None      => rewrittenSql
+      case Some(eff) =>
+        val r0         = System.nanoTime()
+        val schemaCtxR = ai.starlake.quack.edge.rls.SchemaContext(
+          defaultDatabase = ctx.defaultDatabase,
+          defaultSchema = ctx.defaultSchema
+        )
+        val outcome   = rowPolicyRewriter.rewrite(rewrittenSql, kind, eff, schemaCtxR)
+        val elapsedMs = (System.nanoTime() - r0) / 1_000_000L
+        stmtInstruments.recordRowPolicyRewriteDuration(poolKey.tenant, poolKey.pool, elapsedMs)
+        outcome match
+          case ai.starlake.quack.edge.rls.RowPolicyRewriter.Passthrough =>
+            stmtInstruments.recordRowPolicyRewrite(poolKey.tenant, poolKey.pool, "passthrough")
+            rewrittenSql
+          case ai.starlake.quack.edge.rls.RowPolicyRewriter.PassthroughParseFailed =>
+            stmtInstruments.recordRowPolicyRewrite(poolKey.tenant, poolKey.pool, "parse_failed")
+            rewrittenSql
+          case ai.starlake.quack.edge.rls.RowPolicyRewriter.Rewritten(s) =>
+            stmtInstruments.recordRowPolicyRewrite(poolKey.tenant, poolKey.pool, "rewritten")
+            s
+
     supervisor.snapshot(poolKey) match
       case None =>
         if s.txOpen then sessions.invalidatePin(connectionId)
@@ -206,7 +233,7 @@ final class FlightSqlRouter(
         // an unqualified `SELECT * FROM customer` would 404 - we wrap the user
         // SQL with `USE <dbName>.<dbName>; ...` (matching the spawn script's
         // initial schema) when the pool's metastore advertises a dbName.
-        val wrappedSql = wrapWithDefaultSchema(supervisor.get(poolKey), rewrittenSql)
+        val wrappedSql = wrapWithDefaultSchema(supervisor.get(poolKey), finalSql)
         Router.pick(snap, kind, pinned) match
           case RoutingDecision.Unavailable(reason) =>
             maybeRecord(nodeId = "-", durationMs = 0, status = "no-node", error = Some(reason))

--- a/src/main/scala/ai/starlake/quack/edge/rls/RowPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/rls/RowPolicyRewriter.scala
@@ -1,0 +1,205 @@
+package ai.starlake.quack.edge.rls
+
+import ai.starlake.quack.model.StatementKind
+import ai.starlake.quack.ondemand.rbac.EffectiveSet
+import ai.starlake.quack.ondemand.state.RoleRowPolicy
+import net.sf.jsqlparser.expression.{Alias, Expression}
+import net.sf.jsqlparser.parser.CCJSqlParserUtil
+import net.sf.jsqlparser.schema.Table
+import net.sf.jsqlparser.statement.select.{
+  AllColumns,
+  ParenthesedSelect,
+  PlainSelect,
+  Select,
+  SetOperationList
+}
+
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+/** Schema/catalog defaults in scope when the statement runs, used to qualify bare table references
+  * (`customer` -> catalog `acme_tpch`, schema `tpch1`) so they match policies keyed on
+  * `catalog.schema.table`. Mirrors [[ai.starlake.quack.edge.cls.SchemaContext]]; kept local so the
+  * row-level rewriter does not depend on the column-level package.
+  */
+final case class SchemaContext(
+    defaultDatabase: Option[String],
+    defaultSchema: Option[String]
+)
+
+/** Row-level security rewriter. For every base table referenced by a SELECT that carries a matching
+  * [[RoleRowPolicy]] for the requesting principal, the table is replaced by an inline filtered view
+  * `(SELECT * FROM <table> WHERE <predicate>) <alias>`, so the node only ever sees the rows the
+  * predicate admits. Predicates from multiple policies on the same table are combined with **OR**
+  * (permissive union - a row is visible if ANY of the principal's roles allow it).
+  *
+  * Wrapping the BASE table (rather than appending a top-level WHERE) keeps the filter correct under
+  * joins, set operations, CTEs and subqueries, and - when stacked under the column-level rewriter -
+  * means row filtering runs on the true values before any column masking is applied.
+  *
+  * `enabled` is the kill switch. When false (the default) every call short-circuits to
+  * [[Outcome.Passthrough]]. Row-level security is EXPERIMENTAL: operators opt in via
+  * `quack-on-demand.rls.enabled = true` (`QOD_RLS_ENABLED=true`).
+  */
+object RowPolicyRewriter:
+  sealed trait Outcome
+  final case class Rewritten(sql: String) extends Outcome
+  case object Passthrough                 extends Outcome
+
+  /** SQL could not be parsed. Routed identically to [[Passthrough]] (original SQL forwarded) but
+    * tagged separately on `row_policy_rewrites_total` so dashboards can split "rewriter blind"
+    * from "no policy applied".
+    */
+  case object PassthroughParseFailed extends Outcome
+
+  private val Wildcard = RoleRowPolicy.Wildcard
+  private val TokenRegex = "\\$\\{[a-zA-Z]+\\}".r
+
+  /** SQL-escape a scalar value into a quoted literal: `O'Brien` -> `'O''Brien'`. */
+  private def lit(v: String): String = "'" + v.replace("'", "''") + "'"
+
+  /** Build the identity-token substitution map for one principal. List tokens that resolve to an
+    * empty set collapse to `NULL` so `col IN (${groups})` becomes `col IN (NULL)` - a predicate
+    * that matches nothing (safe-restrictive) rather than invalid `IN ()`.
+    */
+  private def tokenValues(eff: EffectiveSet): Map[String, String] =
+    def listLit(xs: List[String]): String =
+      if xs.isEmpty then "NULL" else xs.map(lit).mkString(", ")
+    val tenantId = eff.user.tenant.getOrElse("")
+    Map(
+      "user"     -> lit(eff.user.username),
+      "tenant"   -> lit(tenantId),
+      "tenantId" -> lit(tenantId),
+      "roles"    -> listLit(eff.roles.map(_.name)),
+      "groups"   -> listLit(eff.groups.map(_.name))
+    )
+
+  /** Replace every `${token}`. Known tokens expand to their literal/literal-list; any unknown
+    * `${...}` that slipped past the create-time validator collapses to `NULL` (safe-restrictive).
+    */
+  private def substitute(predicate: String, values: Map[String, String]): String =
+    TokenRegex.replaceAllIn(
+      predicate,
+      m =>
+        val name = m.matched.substring(2, m.matched.length - 1)
+        // replaceAllIn treats $ and \ in the replacement as group refs; quote them out.
+        java.util.regex.Matcher.quoteReplacement(values.getOrElse(name, "NULL"))
+    )
+
+class RowPolicyRewriter(enabled: Boolean = false):
+  import RowPolicyRewriter._
+
+  def rewrite(
+      sql: String,
+      kind: StatementKind,
+      eff: EffectiveSet,
+      ctx: SchemaContext
+  ): Outcome =
+    if !enabled then Passthrough
+    else if eff.user.tenant.isEmpty then Passthrough // superuser: no row filtering
+    else if kind != StatementKind.Select then Passthrough
+    else if eff.rowPolicies.isEmpty then Passthrough
+    else
+      Try(CCJSqlParserUtil.parse(sql)) match
+        case Failure(_)            => PassthroughParseFailed
+        case Success(stmt: Select) =>
+          val values  = tokenValues(eff)
+          val changed = new java.util.concurrent.atomic.AtomicBoolean(false)
+          try
+            rewriteSelect(stmt, eff, ctx, values, changed)
+            if changed.get() then Rewritten(stmt.toString) else Passthrough
+          catch
+            // A predicate that fails to parse at rewrite time (should never happen - the
+            // create-time validator already parsed it) must not crash the request path.
+            case _: Throwable => Passthrough
+        case Success(_) => Passthrough
+
+  // ---------- table-occurrence walk (mirrors ColumnPolicyRewriter.collectTables) ----------
+
+  private def rewriteSelect(
+      sel: Select,
+      eff: EffectiveSet,
+      ctx: SchemaContext,
+      values: Map[String, String],
+      changed: java.util.concurrent.atomic.AtomicBoolean
+  ): Unit =
+    // CTE bodies first, so a base table inside a WITH item is filtered too.
+    Option(sel.getWithItemsList).foreach(_.asScala.foreach { wi =>
+      Option(wi.getParenthesedStatement).foreach {
+        case ps: ParenthesedSelect => rewriteSelect(ps.getSelect, eff, ctx, values, changed)
+        case _                     => ()
+      }
+    })
+    sel match
+      case ps: PlainSelect =>
+        Option(ps.getFromItem).foreach {
+          case t: Table               => ps.setFromItem(maybeWrap(t, eff, ctx, values, changed))
+          case sub: ParenthesedSelect => rewriteSelect(sub.getSelect, eff, ctx, values, changed)
+          case _                      => ()
+        }
+        Option(ps.getJoins).foreach(_.asScala.foreach { j =>
+          Option(j.getRightItem).foreach {
+            case t: Table               => j.setRightItem(maybeWrap(t, eff, ctx, values, changed))
+            case sub: ParenthesedSelect => rewriteSelect(sub.getSelect, eff, ctx, values, changed)
+            case _                      => ()
+          }
+        })
+      case ps: ParenthesedSelect => rewriteSelect(ps.getSelect, eff, ctx, values, changed)
+      case sol: SetOperationList =>
+        Option(sol.getSelects)
+          .foreach(_.asScala.foreach(rewriteSelect(_, eff, ctx, values, changed)))
+      case _ => ()
+
+  /** If `t` matches one or more of the principal's row policies, return a parenthesed
+    * `(SELECT * FROM t WHERE <ORed predicate>)` carrying t's original alias; else return `t`
+    * unchanged.
+    */
+  private def maybeWrap(
+      t: Table,
+      eff: EffectiveSet,
+      ctx: SchemaContext,
+      values: Map[String, String],
+      changed: java.util.concurrent.atomic.AtomicBoolean
+  ): net.sf.jsqlparser.statement.select.FromItem =
+    val name   = t.getName
+    val schema = Option(t.getSchemaName).getOrElse(ctx.defaultSchema.getOrElse(""))
+    val catalog = Option(t.getDatabase)
+      .flatMap(d => Option(d.getDatabaseName))
+      .getOrElse(ctx.defaultDatabase.getOrElse(""))
+
+    val matched = eff.rowPolicies.filter(p => policyMatches(p, catalog, schema, name))
+    if matched.isEmpty then t
+    else
+      val predicate =
+        matched.map(p => "(" + substitute(p.predicateSql, values) + ")").mkString(" OR ")
+      val expr: Expression = CCJSqlParserUtil.parseCondExpression(predicate)
+
+      val alias: Alias = t.getAlias
+      val baseTable    = new Table(name)
+      Option(t.getSchemaName).foreach(_ => baseTable.setSchemaName(t.getSchemaName))
+      Option(t.getDatabase).foreach(baseTable.setDatabase)
+
+      val inner = new PlainSelect()
+      inner.addSelectItem(new AllColumns())
+      inner.setFromItem(baseTable)
+      inner.setWhere(expr)
+
+      val wrapped = new ParenthesedSelect()
+      wrapped.setSelect(inner)
+      // Preserve the caller's alias so outer `alias.col` references still resolve; when the table
+      // had no alias, fall back to the table name so a bare `SELECT t.col` keeps working.
+      wrapped.setAlias(if alias != null then alias else new Alias(name))
+      changed.set(true)
+      wrapped
+
+  private def policyMatches(
+      p: RoleRowPolicy,
+      catalog: String,
+      schema: String,
+      table: String
+  ): Boolean =
+    def matchesPart(policyPart: String, actual: String): Boolean =
+      policyPart == Wildcard || policyPart.equalsIgnoreCase(actual)
+    matchesPart(p.tableName, table) &&
+    matchesPart(p.schemaName, schema) &&
+    matchesPart(p.catalogName, catalog)

--- a/src/main/scala/ai/starlake/quack/edge/rls/RowPredicateValidator.scala
+++ b/src/main/scala/ai/starlake/quack/edge/rls/RowPredicateValidator.scala
@@ -1,0 +1,124 @@
+package ai.starlake.quack.edge.rls
+
+import net.sf.jsqlparser.expression.Expression
+import net.sf.jsqlparser.expression.{Function => SqlFunction}
+import net.sf.jsqlparser.parser.CCJSqlParserUtil
+import net.sf.jsqlparser.statement.select.Select
+
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+/** Strict-safety validator for free-form row-filter predicates on row policies. Runs once at policy
+  * create/update time. Pure (no I/O, no DuckDB connection).
+  *
+  * A `predicate_sql` value must be ONE boolean DuckDB expression that:
+  *   1. Parses via JSqlParser's `parseExpression` entry point once identity-substitution tokens
+  *      (`${user}`, `${tenant}`, `${tenantId}`, `${groups}`, `${roles}`) are neutralised.
+  *   2. Contains no subqueries (parenthesed SELECTs) or EXISTS clauses.
+  *   3. Calls no side-effect or escape functions (denylist + `pragma_*` prefix).
+  *   4. Is bounded in size (<= 1024 chars).
+  *
+  * Unlike [[ai.starlake.quack.edge.cls.TransformSqlValidator]] the predicate may reference ANY
+  * column (it filters rows of the protected table), so there is no single-column containment check.
+  * The canonical form returned keeps the `${...}` tokens intact - they are substituted by the
+  * rewriter at query time, not here.
+  */
+object RowPredicateValidator:
+
+  sealed trait Result
+  final case class Valid(canonical: String) extends Result
+  final case class Invalid(reason: String)  extends Result
+
+  private val MaxLen = 1024
+
+  /** Same escape/side-effect denylist as the CLS transform validator. */
+  private val Denylist: Set[String] = Set(
+    "read_csv",
+    "read_csv_auto",
+    "read_parquet",
+    "read_json",
+    "read_json_auto",
+    "query",
+    "sql",
+    "attach",
+    "detach",
+    "install",
+    "load",
+    "system",
+    "current_setting",
+    "set_setting",
+    "pg_read_server_files",
+    "pg_read_binary_file"
+  )
+
+  private val TokenRegex = "\\$\\{[a-zA-Z]+\\}".r
+
+  def validate(predicateSql: String): Result =
+    val trimmed = Option(predicateSql).map(_.trim).getOrElse("")
+    if trimmed.isEmpty then return Invalid("predicateSql is empty")
+    if trimmed.length > MaxLen then
+      return Invalid(s"predicateSql exceeds $MaxLen chars (got ${trimmed.length})")
+
+    // Neutralise identity tokens before parsing: `${user}` -> NULL so both bare (`u = ${user}`)
+    // and list (`g IN (${groups})`) forms parse. Tokens inside string literals collapse to the
+    // literal 'NULL', which is harmless for the parse check.
+    val probe = TokenRegex.replaceAllIn(trimmed, "NULL")
+
+    val expr: Expression = Try(CCJSqlParserUtil.parseExpression(probe)) match
+      case Success(e)  => e
+      case Failure(ex) => return Invalid(s"predicateSql does not parse: ${ex.getMessage}")
+
+    val violations = scala.collection.mutable.ListBuffer.empty[String]
+    walk(expr) {
+      case _: Select =>
+        violations += "subqueries are not allowed in predicateSql"
+      case _: net.sf.jsqlparser.expression.operators.relational.ExistsExpression =>
+        violations += "EXISTS subqueries are not allowed in predicateSql"
+      case fn: SqlFunction =>
+        val name = Option(fn.getName).getOrElse("").toLowerCase
+        if Denylist.contains(name) || name.startsWith("pragma_") then
+          violations += s"function '$name' is not allowed in predicateSql"
+      case _ => ()
+    }
+
+    if violations.nonEmpty then return Invalid(violations.distinct.mkString("; "))
+
+    // Keep the original (tokens intact) as the canonical stored form.
+    Valid(trimmed)
+
+  /** Walk reachable expression nodes depth-first. Mirrors
+    * [[ai.starlake.quack.edge.cls.TransformSqlValidator]] but additionally descends into IN-lists so
+    * a subquery hidden in `x IN (SELECT ...)` is still flagged.
+    */
+  private def walk(start: Expression)(visit: PartialFunction[Any, Unit]): Unit =
+    val stack = scala.collection.mutable.Stack[Any](start)
+    while stack.nonEmpty do
+      val node = stack.pop()
+      if visit.isDefinedAt(node) then visit(node)
+      node match
+        case fn: SqlFunction =>
+          if fn.getParameters != null then fn.getParameters.asScala.foreach(stack.push)
+        case b: net.sf.jsqlparser.expression.BinaryExpression =>
+          stack.push(b.getLeftExpression); stack.push(b.getRightExpression)
+        case u: net.sf.jsqlparser.expression.SignedExpression =>
+          stack.push(u.getExpression)
+        case p: net.sf.jsqlparser.expression.Parenthesis =>
+          stack.push(p.getExpression)
+        case n: net.sf.jsqlparser.expression.NotExpression =>
+          stack.push(n.getExpression)
+        case in: net.sf.jsqlparser.expression.operators.relational.InExpression =>
+          if in.getLeftExpression != null then stack.push(in.getLeftExpression)
+          if in.getRightExpression != null then stack.push(in.getRightExpression)
+        case c: net.sf.jsqlparser.expression.CaseExpression =>
+          if c.getSwitchExpression != null then stack.push(c.getSwitchExpression)
+          if c.getElseExpression != null then stack.push(c.getElseExpression)
+          if c.getWhenClauses != null then
+            c.getWhenClauses.asScala.foreach { w =>
+              stack.push(w.getWhenExpression)
+              stack.push(w.getThenExpression)
+            }
+        case cast: net.sf.jsqlparser.expression.CastExpression =>
+          stack.push(cast.getLeftExpression)
+        case _: Select =>
+          () // visited above; do not recurse
+        case _ => ()

--- a/src/main/scala/ai/starlake/quack/edge/rls/RowPredicateValidator.scala
+++ b/src/main/scala/ai/starlake/quack/edge/rls/RowPredicateValidator.scala
@@ -1,27 +1,29 @@
 package ai.starlake.quack.edge.rls
 
 import net.sf.jsqlparser.expression.Expression
-import net.sf.jsqlparser.expression.{Function => SqlFunction}
 import net.sf.jsqlparser.parser.CCJSqlParserUtil
-import net.sf.jsqlparser.statement.select.Select
 
-import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 /** Strict-safety validator for free-form row-filter predicates on row policies. Runs once at policy
   * create/update time. Pure (no I/O, no DuckDB connection).
   *
   * A `predicate_sql` value must be ONE boolean DuckDB expression that:
-  *   1. Parses via JSqlParser's `parseExpression` entry point once identity-substitution tokens
-  *      (`${user}`, `${tenant}`, `${tenantId}`, `${groups}`, `${roles}`) are neutralised.
-  *   2. Contains no subqueries (parenthesed SELECTs) or EXISTS clauses.
+  *   1. Parses via JSqlParser's `parseCondExpression` once identity-substitution tokens (`${user}`,
+  *      `${tenant}`, `${tenantId}`, `${groups}`, `${roles}`) are neutralised.
+  *   2. Contains no subqueries (`SELECT`) or `EXISTS` clauses.
   *   3. Calls no side-effect or escape functions (denylist + `pragma_*` prefix).
   *   4. Is bounded in size (<= 1024 chars).
   *
   * Unlike [[ai.starlake.quack.edge.cls.TransformSqlValidator]] the predicate may reference ANY
   * column (it filters rows of the protected table), so there is no single-column containment check.
-  * The canonical form returned keeps the `${...}` tokens intact - they are substituted by the
-  * rewriter at query time, not here.
+  * The canonical form returned keeps the `${...}` tokens intact - they are substituted by
+  * [[RowPolicyRewriter]] at query time, not here.
+  *
+  * Detection works on the PARSED, canonicalised expression with string literals stripped, rather
+  * than a node-by-node AST walk: a function or sub-`SELECT` nested inside any wrapper node (e.g.
+  * `read_csv(...) IS NOT NULL`) is still caught, and stripping literals first avoids flagging a
+  * harmless value like `note = 'select one'`.
   */
 object RowPredicateValidator:
 
@@ -52,6 +54,8 @@ object RowPredicateValidator:
   )
 
   private val TokenRegex = "\\$\\{[a-zA-Z]+\\}".r
+  // Single-quoted SQL string literal, honouring doubled-quote escapes: 'O''Brien'.
+  private val StringLiteral = "'(?:[^']|'')*'".r
 
   def validate(predicateSql: String): Result =
     val trimmed = Option(predicateSql).map(_.trim).getOrElse("")
@@ -64,61 +68,23 @@ object RowPredicateValidator:
     // literal 'NULL', which is harmless for the parse check.
     val probe = TokenRegex.replaceAllIn(trimmed, "NULL")
 
-    val expr: Expression = Try(CCJSqlParserUtil.parseExpression(probe)) match
+    val expr: Expression = Try(CCJSqlParserUtil.parseCondExpression(probe)) match
       case Success(e)  => e
       case Failure(ex) => return Invalid(s"predicateSql does not parse: ${ex.getMessage}")
 
-    val violations = scala.collection.mutable.ListBuffer.empty[String]
-    walk(expr) {
-      case _: Select =>
-        violations += "subqueries are not allowed in predicateSql"
-      case _: net.sf.jsqlparser.expression.operators.relational.ExistsExpression =>
-        violations += "EXISTS subqueries are not allowed in predicateSql"
-      case fn: SqlFunction =>
-        val name = Option(fn.getName).getOrElse("").toLowerCase
-        if Denylist.contains(name) || name.startsWith("pragma_") then
-          violations += s"function '$name' is not allowed in predicateSql"
-      case _ => ()
-    }
+    // Scan the canonical, literal-stripped form. Lower-cased so keyword/function matching is
+    // case-insensitive; literals removed so their contents can never trip a keyword check.
+    val scan = StringLiteral.replaceAllIn(expr.toString, "''").toLowerCase
 
-    if violations.nonEmpty then return Invalid(violations.distinct.mkString("; "))
+    if "(?<![a-z0-9_])(?:select|exists)(?![a-z0-9_])".r.findFirstIn(scan).isDefined then
+      return Invalid("subqueries are not allowed in predicateSql")
+
+    val hitDeny = Denylist.find(fn => s"(?<![a-z0-9_])$fn\\s*\\(".r.findFirstIn(scan).isDefined)
+    hitDeny match
+      case Some(fn) => return Invalid(s"function '$fn' is not allowed in predicateSql")
+      case None     => ()
+    if "(?<![a-z0-9_])pragma_[a-z0-9_]*\\s*\\(".r.findFirstIn(scan).isDefined then
+      return Invalid("pragma_* functions are not allowed in predicateSql")
 
     // Keep the original (tokens intact) as the canonical stored form.
     Valid(trimmed)
-
-  /** Walk reachable expression nodes depth-first. Mirrors
-    * [[ai.starlake.quack.edge.cls.TransformSqlValidator]] but additionally descends into IN-lists so
-    * a subquery hidden in `x IN (SELECT ...)` is still flagged.
-    */
-  private def walk(start: Expression)(visit: PartialFunction[Any, Unit]): Unit =
-    val stack = scala.collection.mutable.Stack[Any](start)
-    while stack.nonEmpty do
-      val node = stack.pop()
-      if visit.isDefinedAt(node) then visit(node)
-      node match
-        case fn: SqlFunction =>
-          if fn.getParameters != null then fn.getParameters.asScala.foreach(stack.push)
-        case b: net.sf.jsqlparser.expression.BinaryExpression =>
-          stack.push(b.getLeftExpression); stack.push(b.getRightExpression)
-        case u: net.sf.jsqlparser.expression.SignedExpression =>
-          stack.push(u.getExpression)
-        case p: net.sf.jsqlparser.expression.Parenthesis =>
-          stack.push(p.getExpression)
-        case n: net.sf.jsqlparser.expression.NotExpression =>
-          stack.push(n.getExpression)
-        case in: net.sf.jsqlparser.expression.operators.relational.InExpression =>
-          if in.getLeftExpression != null then stack.push(in.getLeftExpression)
-          if in.getRightExpression != null then stack.push(in.getRightExpression)
-        case c: net.sf.jsqlparser.expression.CaseExpression =>
-          if c.getSwitchExpression != null then stack.push(c.getSwitchExpression)
-          if c.getElseExpression != null then stack.push(c.getElseExpression)
-          if c.getWhenClauses != null then
-            c.getWhenClauses.asScala.foreach { w =>
-              stack.push(w.getWhenExpression)
-              stack.push(w.getThenExpression)
-            }
-        case cast: net.sf.jsqlparser.expression.CastExpression =>
-          stack.push(cast.getLeftExpression)
-        case _: Select =>
-          () // visited above; do not recurse
-        case _ => ()

--- a/src/main/scala/ai/starlake/quack/observability/metrics/StatementInstruments.scala
+++ b/src/main/scala/ai/starlake/quack/observability/metrics/StatementInstruments.scala
@@ -94,6 +94,40 @@ final class StatementInstruments(registry: MeterRegistry):
   def recordColumnPolicyRewriteDuration(tenant: String, pool: String, ms: Long): Unit =
     resolveRewriteTimer(tenant, pool).record(Duration.ofMillis(ms))
 
+  private val rowRewriteTimerCache =
+    new java.util.concurrent.ConcurrentHashMap[(String, String), Timer]()
+
+  private def resolveRowRewriteTimer(tenant: String, pool: String): Timer =
+    rowRewriteTimerCache.computeIfAbsent(
+      (tenant, pool),
+      _ =>
+        Timer
+          .builder("row_policy_rewrite_duration_seconds")
+          .tag("tenant", tenant)
+          .tag("pool", pool)
+          .register(registry)
+    )
+
+  /** Increment the row-policy rewrite counter. `outcome` is one of: `rewritten`, `passthrough`,
+    * `parse_failed`.
+    */
+  def recordRowPolicyRewrite(tenant: String, pool: String, outcome: String): Unit =
+    registry
+      .counter(
+        "row_policy_rewrites_total",
+        "tenant",
+        tenant,
+        "pool",
+        pool,
+        "outcome",
+        outcome
+      )
+      .increment()
+
+  /** Observe the wall-clock duration of a row-policy rewrite pass. */
+  def recordRowPolicyRewriteDuration(tenant: String, pool: String, ms: Long): Unit =
+    resolveRowRewriteTimer(tenant, pool).record(Duration.ofMillis(ms))
+
 object StatementInstruments:
 
   /** Singleton no-op used when callers don't need real metric recording. Backed by an empty

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -37,7 +37,8 @@ final class ManagerServer(
     serverConfig: ConfigHandlers,
     manifest: ManifestHandlers,
     federatedSources: Option[FederatedSourceHandlers] = None,
-    columnPolicies: RoleColumnPolicyHandlers
+    columnPolicies: RoleColumnPolicyHandlers,
+    rowPolicies: RoleRowPolicyHandlers
 ) extends LazyLogging:
 
   /** Path is unauthenticated - the UI needs these before login. */
@@ -227,6 +228,18 @@ final class ManagerServer(
       },
       RbacEndpoints.listColumnPolicies.serverLogic { case (roleId, key) =>
         columnPolicies.list(roleId, key)(sessions.scopeOf)
+      },
+      RbacEndpoints.createRowPolicy.serverLogic { case (req, key) =>
+        rowPolicies.create(req, key)(sessions.scopeOf)
+      },
+      RbacEndpoints.updateRowPolicy.serverLogic { case (req, key) =>
+        rowPolicies.update(req, key)(sessions.scopeOf)
+      },
+      RbacEndpoints.deleteRowPolicy.serverLogic { case (req, key) =>
+        rowPolicies.delete(req, key)(sessions.scopeOf)
+      },
+      RbacEndpoints.listRowPolicies.serverLogic { case (roleId, key) =>
+        rowPolicies.list(roleId, key)(sessions.scopeOf)
       }
     )
 

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -1133,6 +1133,53 @@ final class PoolSupervisor(
   def listColumnPoliciesByRole(roleId: String): IO[List[state.RoleColumnPolicy]] =
     IO.blocking(store.listColumnPolicies(roleId))
 
+  // ---------- RBAC: row policies ----------
+
+  def tenantForRowPolicy(id: String): Option[String] =
+    store.getRowPolicy(id).flatMap(p => rbacResolver.role(p.roleId).map(_.tenantId))
+
+  def createRowPolicy(
+      roleId: String,
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      predicateSql: String
+  ): IO[Either[String, state.RoleRowPolicy]] = IO.blocking {
+    ai.starlake.quack.edge.rls.RowPredicateValidator.validate(predicateSql) match
+      case ai.starlake.quack.edge.rls.RowPredicateValidator.Invalid(reason) =>
+        Left(s"invalid predicateSql: $reason")
+      case ai.starlake.quack.edge.rls.RowPredicateValidator.Valid(canon) =>
+        val p = state.RoleRowPolicy(
+          id = newId("rp"),
+          roleId = roleId,
+          catalogName = catalogName,
+          schemaName = schemaName,
+          tableName = tableName,
+          predicateSql = canon
+        )
+        val persisted = store.insertRowPolicy(p)
+        invalidateEffectiveCache()
+        Right(persisted)
+  }
+
+  def updateRowPolicy(id: String, predicateSql: String): IO[Either[String, Unit]] = IO.blocking {
+    ai.starlake.quack.edge.rls.RowPredicateValidator.validate(predicateSql) match
+      case ai.starlake.quack.edge.rls.RowPredicateValidator.Invalid(reason) =>
+        Left(s"invalid predicateSql: $reason")
+      case ai.starlake.quack.edge.rls.RowPredicateValidator.Valid(canon) =>
+        val ok = store.updateRowPolicy(id, canon)
+        if ok then { invalidateEffectiveCache(); Right(()) }
+        else Left(s"row policy $id not found")
+  }
+
+  def deleteRowPolicy(id: String): IO[Either[String, Unit]] = IO.blocking {
+    if store.deleteRowPolicy(id) then { invalidateEffectiveCache(); Right(()) }
+    else Left(s"row policy $id not found")
+  }
+
+  def listRowPoliciesByRole(roleId: String): IO[List[state.RoleRowPolicy]] =
+    IO.blocking(store.listRowPolicies(roleId))
+
   // ---------- RBAC: groups ----------
 
   def createGroup(
@@ -1418,13 +1465,15 @@ final class PoolSupervisor(
       val directPools    = store.listPoolPermissionsForUser(u.id)
       val viaGroupPools  = groupIds.toList.flatMap(rbacResolver.poolPermissionsForGroup)
       val columnPolicies = allRoleIds.toList.flatMap(store.listColumnPolicies)
+      val rowPolicies    = allRoleIds.toList.flatMap(store.listRowPolicies)
       ai.starlake.quack.ondemand.rbac.EffectiveSet(
         u,
         effRoles,
         effGroups,
         effPerms,
         directPools ++ viaGroupPools,
-        columnPolicies
+        columnPolicies,
+        rowPolicies
       )
     }
 

--- a/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
@@ -454,6 +454,30 @@ final case class UpdateColumnPolicyRequest(
 final case class DeleteColumnPolicyRequest(id: String)
 final case class ColumnPolicyListResponse(policies: List[ColumnPolicyDto])
 
+// ----- RBAC: row policies ------------------------------------------------
+
+final case class RowPolicyDto(
+    id: String,
+    roleId: String,
+    catalogName: String,
+    schemaName: String,
+    tableName: String,
+    predicateSql: String
+)
+final case class CreateRowPolicyRequest(
+    roleId: String,
+    catalogName: String,
+    schemaName: String,
+    tableName: String,
+    predicateSql: String
+)
+final case class UpdateRowPolicyRequest(
+    id: String,
+    predicateSql: String
+)
+final case class DeleteRowPolicyRequest(id: String)
+final case class RowPolicyListResponse(policies: List[RowPolicyDto])
+
 // ----- RBAC: pool permissions --------------------------------------------
 
 final case class PoolPermissionGrantRequest(
@@ -968,6 +992,34 @@ object Dtos:
   )
   given Codec[DeleteColumnPolicyRequest] = deriveCodec
   given Codec[ColumnPolicyListResponse]  = deriveCodec
+
+  // RBAC: row policies
+  given Codec[RowPolicyDto]           = deriveCodec
+  given Codec[CreateRowPolicyRequest] = Codec.from(
+    Decoder.instance { (c: HCursor) =>
+      for
+        roleId       <- c.get[String]("roleId")
+        catalogName  <- c.getOrElse[String]("catalogName")("*")
+        schemaName   <- c.getOrElse[String]("schemaName")("*")
+        tableName    <- c.getOrElse[String]("tableName")("*")
+        predicateSql <- c.get[String]("predicateSql")
+      yield CreateRowPolicyRequest(roleId, catalogName, schemaName, tableName, predicateSql)
+    },
+    Encoder.instance { r =>
+      Json.fromJsonObject(
+        JsonObject(
+          "roleId"       -> r.roleId.asJson,
+          "catalogName"  -> r.catalogName.asJson,
+          "schemaName"   -> r.schemaName.asJson,
+          "tableName"    -> r.tableName.asJson,
+          "predicateSql" -> r.predicateSql.asJson
+        )
+      )
+    }
+  )
+  given Codec[UpdateRowPolicyRequest] = deriveCodec
+  given Codec[DeleteRowPolicyRequest] = deriveCodec
+  given Codec[RowPolicyListResponse]  = deriveCodec
 
   // RBAC: pool permissions
   given Codec[PoolPermissionGrantRequest]  = deriveCodec

--- a/src/main/scala/ai/starlake/quack/ondemand/api/RbacEndpoints.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/RbacEndpoints.scala
@@ -202,6 +202,54 @@ object RbacEndpoints:
       .in(apiKey)
       .out(jsonBody[ColumnPolicyListResponse])
 
+  // ----- RBAC: row policies -----
+
+  val createRowPolicy: PublicEndpoint[
+    (CreateRowPolicyRequest, Option[String]),
+    (sttp.model.StatusCode, ErrorResponse),
+    RowPolicyDto,
+    Any
+  ] =
+    base.post
+      .in("role" / "row-policy" / "create")
+      .in(jsonBody[CreateRowPolicyRequest])
+      .in(apiKey)
+      .out(jsonBody[RowPolicyDto])
+
+  val updateRowPolicy: PublicEndpoint[
+    (UpdateRowPolicyRequest, Option[String]),
+    (sttp.model.StatusCode, ErrorResponse),
+    Unit,
+    Any
+  ] =
+    base.post
+      .in("role" / "row-policy" / "update")
+      .in(jsonBody[UpdateRowPolicyRequest])
+      .in(apiKey)
+
+  val deleteRowPolicy: PublicEndpoint[
+    (DeleteRowPolicyRequest, Option[String]),
+    (sttp.model.StatusCode, ErrorResponse),
+    Unit,
+    Any
+  ] =
+    base.post
+      .in("role" / "row-policy" / "delete")
+      .in(jsonBody[DeleteRowPolicyRequest])
+      .in(apiKey)
+
+  val listRowPolicies: PublicEndpoint[
+    (String, Option[String]),
+    (sttp.model.StatusCode, ErrorResponse),
+    RowPolicyListResponse,
+    Any
+  ] =
+    base.get
+      .in("role" / "row-policy" / "list")
+      .in(query[String]("roleId"))
+      .in(apiKey)
+      .out(jsonBody[RowPolicyListResponse])
+
   // ----- RBAC: groups -----
   val createGroup: PublicEndpoint[
     (GroupCreateRequest, Option[String]),

--- a/src/main/scala/ai/starlake/quack/ondemand/api/RoleRowPolicyHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/RoleRowPolicyHandlers.scala
@@ -1,0 +1,83 @@
+package ai.starlake.quack.ondemand.api
+
+import ai.starlake.quack.ondemand.PoolSupervisor
+import ai.starlake.quack.ondemand.auth.SessionScope
+import ai.starlake.quack.ondemand.state.RoleRowPolicy
+import cats.effect.IO
+import sttp.model.StatusCode
+
+/** REST handlers for the row-policy surface (`/api/role/row-policy/...`).
+  *
+  * Every mutating endpoint enforces a per-request tenant-scope check before touching the store
+  * (resource-id path: resolve owning tenant via [[PoolSupervisor.tenantForRowPolicy]] /
+  * [[PoolSupervisor.tenantForRole]], then gate via [[TenantScopeCheck.rejectForResource]]). See
+  * [[TenantScopeCheck]].
+  */
+final class RoleRowPolicyHandlers(sup: PoolSupervisor):
+
+  type Out[A] = IO[Either[(StatusCode, ErrorResponse), A]]
+
+  def create(req: CreateRowPolicyRequest, apiKey: Option[String])(
+      scopeOf: String => Option[SessionScope]
+  ): Out[RowPolicyDto] =
+    TenantScopeCheck.rejectForResource(apiKey, sup.tenantForRole(req.roleId))(scopeOf) match
+      case Some(err) => IO.pure(Left(err))
+      case None      =>
+        sup
+          .createRowPolicy(
+            req.roleId,
+            req.catalogName,
+            req.schemaName,
+            req.tableName,
+            req.predicateSql
+          )
+          .map {
+            case Right(p)     => Right(toDto(p))
+            case Left(reason) =>
+              Left((StatusCode.BadRequest, ErrorResponse("invalid_policy", reason)))
+          }
+
+  def update(req: UpdateRowPolicyRequest, apiKey: Option[String])(
+      scopeOf: String => Option[SessionScope]
+  ): Out[Unit] =
+    TenantScopeCheck.rejectForResource(apiKey, sup.tenantForRowPolicy(req.id))(scopeOf) match
+      case Some(err) => IO.pure(Left(err))
+      case None      =>
+        sup.updateRowPolicy(req.id, req.predicateSql).map {
+          case Right(())                          => Right(())
+          case Left(r) if r.endsWith("not found") =>
+            Left((StatusCode.NotFound, ErrorResponse("not_found", r)))
+          case Left(r) =>
+            Left((StatusCode.BadRequest, ErrorResponse("invalid_policy", r)))
+        }
+
+  def delete(req: DeleteRowPolicyRequest, apiKey: Option[String])(
+      scopeOf: String => Option[SessionScope]
+  ): Out[Unit] =
+    TenantScopeCheck.rejectForResource(apiKey, sup.tenantForRowPolicy(req.id))(scopeOf) match
+      case Some(err) => IO.pure(Left(err))
+      case None      =>
+        sup.deleteRowPolicy(req.id).map {
+          case Right(()) => Right(())
+          case Left(r)   => Left((StatusCode.NotFound, ErrorResponse("not_found", r)))
+        }
+
+  def list(roleId: String, apiKey: Option[String])(
+      scopeOf: String => Option[SessionScope]
+  ): Out[RowPolicyListResponse] =
+    TenantScopeCheck.rejectForResource(apiKey, sup.tenantForRole(roleId))(scopeOf) match
+      case Some(err) => IO.pure(Left(err))
+      case None      =>
+        sup
+          .listRowPoliciesByRole(roleId)
+          .map(ps => Right(RowPolicyListResponse(ps.map(toDto))))
+
+  private def toDto(p: RoleRowPolicy): RowPolicyDto =
+    RowPolicyDto(
+      p.id,
+      p.roleId,
+      p.catalogName,
+      p.schemaName,
+      p.tableName,
+      p.predicateSql
+    )

--- a/src/main/scala/ai/starlake/quack/ondemand/manifest/ConfigManifest.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/manifest/ConfigManifest.scala
@@ -95,12 +95,20 @@ final case class ManifestRoleColumnPolicy(
     transformSql: Option[String] = None
 )
 
+final case class ManifestRoleRowPolicy(
+    catalog: String = "*",
+    schema: String,
+    table: String,
+    predicateSql: String
+)
+
 final case class ManifestRole(
     tenant: String,
     name: String,
     description: Option[String] = None,
     permissions: List[ManifestTablePermission] = Nil,
-    columnPolicies: List[ManifestRoleColumnPolicy] = Nil
+    columnPolicies: List[ManifestRoleColumnPolicy] = Nil,
+    rowPolicies: List[ManifestRoleRowPolicy] = Nil
 )
 
 final case class ManifestGroup(
@@ -156,6 +164,18 @@ object ConfigManifest:
       yield ManifestRoleColumnPolicy(catalog, schema, table, column, action, transformSql)
     },
     deriveEncoder[ManifestRoleColumnPolicy]
+  )
+
+  given Codec[ManifestRoleRowPolicy] = Codec.from(
+    Decoder.instance { (c: HCursor) =>
+      for
+        catalog      <- c.getOrElse[String]("catalog")("*")
+        schema       <- c.get[String]("schema")
+        table        <- c.get[String]("table")
+        predicateSql <- c.get[String]("predicateSql")
+      yield ManifestRoleRowPolicy(catalog, schema, table, predicateSql)
+    },
+    deriveEncoder[ManifestRoleRowPolicy]
   )
 
   // Placement codecs: every field but `key` (tolerations) and
@@ -293,7 +313,8 @@ object ConfigManifest:
         description    <- c.getOrElse[Option[String]]("description")(None)
         permissions    <- c.getOrElse[List[ManifestTablePermission]]("permissions")(Nil)
         columnPolicies <- c.getOrElse[List[ManifestRoleColumnPolicy]]("columnPolicies")(Nil)
-      yield ManifestRole(tenant, name, description, permissions, columnPolicies)
+        rowPolicies    <- c.getOrElse[List[ManifestRoleRowPolicy]]("rowPolicies")(Nil)
+      yield ManifestRole(tenant, name, description, permissions, columnPolicies, rowPolicies)
     },
     deriveEncoder[ManifestRole]
   )

--- a/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestExporter.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestExporter.scala
@@ -38,6 +38,7 @@ object ManifestExporter:
     val groupsByT         = snap.groups.groupBy(_.tenantId)
     val rolePermsByRole   = snap.rolePermissions.groupBy(_.roleId)
     val colPoliciesByRole = snap.columnPolicies.groupBy(_.roleId)
+    val rowPoliciesByRole = snap.rowPolicies.groupBy(_.roleId)
     val rolesByGroup      = snap.groupRoles.groupBy(_.groupId).view.mapValues(_.map(_.roleId)).toMap
     val rolesByUser       = snap.userRoles.groupBy(_.userId).view.mapValues(_.map(_.roleId)).toMap
     val groupsByUser      = snap.userGroups.groupBy(_.userId).view.mapValues(_.map(_.groupId)).toMap
@@ -153,6 +154,17 @@ object ManifestExporter:
                 column = p.columnName,
                 action = p.action,
                 transformSql = p.transformSql
+              )
+            },
+          rowPolicies = rowPoliciesByRole
+            .getOrElse(r.id, Nil)
+            .sortBy(p => (p.catalogName, p.schemaName, p.tableName, p.predicateSql))
+            .map { p =>
+              ManifestRoleRowPolicy(
+                catalog = p.catalogName,
+                schema = p.schemaName,
+                table = p.tableName,
+                predicateSql = p.predicateSql
               )
             }
         )

--- a/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestImporter.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestImporter.scala
@@ -21,7 +21,8 @@ import ai.starlake.quack.ondemand.state.{
   RbacGroup,
   RbacRole,
   RoleColumnPolicy,
-  RolePermission
+  RolePermission,
+  RoleRowPolicy
 }
 
 object ManifestImporter:
@@ -367,6 +368,20 @@ object ManifestImporter:
                   columnName = mcp.column,
                   action = mcp.action,
                   transformSql = mcp.transformSql
+                )
+              )
+            }
+            // Replace row policies: delete every existing then re-insert.
+            store.listRowPolicies(roleId).foreach(p => store.deleteRowPolicy(p.id))
+            mr.rowPolicies.foreach { mrp =>
+              store.insertRowPolicy(
+                RoleRowPolicy(
+                  id = Names.newSurrogateId("rp"),
+                  roleId = roleId,
+                  catalogName = mrp.catalog,
+                  schemaName = mrp.schema,
+                  tableName = mrp.table,
+                  predicateSql = mrp.predicateSql
                 )
               )
             }

--- a/src/main/scala/ai/starlake/quack/ondemand/rbac/EffectiveSet.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/rbac/EffectiveSet.scala
@@ -22,5 +22,6 @@ final case class EffectiveSet(
     groups: List[RbacGroup],
     permissions: List[RolePermission],
     poolPerms: List[PoolPermission],
-    columnPolicies: List[RoleColumnPolicy] = Nil
+    columnPolicies: List[RoleColumnPolicy] = Nil,
+    rowPolicies: List[RoleRowPolicy] = Nil
 )

--- a/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneSnapshot.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneSnapshot.scala
@@ -25,5 +25,6 @@ final case class ControlPlaneSnapshot(
     userRoles: List[UserRoleEdge] = Nil,
     groupRoles: List[GroupRoleEdge] = Nil,
     poolPermissions: List[PoolPermission] = Nil,
-    columnPolicies: List[RoleColumnPolicy] = Nil
+    columnPolicies: List[RoleColumnPolicy] = Nil,
+    rowPolicies: List[RoleRowPolicy] = Nil
 )

--- a/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
@@ -189,6 +189,7 @@ trait ControlPlaneStore:
 
   // ----- Row policies -----
   def insertRowPolicy(p: RoleRowPolicy): RoleRowPolicy
+  def updateRowPolicy(id: String, predicateSql: String): Boolean
   def deleteRowPolicy(id: String): Boolean
   def getRowPolicy(id: String): Option[RoleRowPolicy]
   def listRowPolicies(roleId: String): List[RoleRowPolicy]

--- a/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
@@ -187,6 +187,12 @@ trait ControlPlaneStore:
   def listColumnPolicies(roleId: String): List[RoleColumnPolicy]
   def listAllColumnPolicies(): List[RoleColumnPolicy]
 
+  // ----- Row policies -----
+  def insertRowPolicy(p: RoleRowPolicy): RoleRowPolicy
+  def deleteRowPolicy(id: String): Boolean
+  def getRowPolicy(id: String): Option[RoleRowPolicy]
+  def listRowPolicies(roleId: String): List[RoleRowPolicy]
+
   /** Load the full topology in one round-trip. Used by the supervisor at boot to seed its in-memory
     * caches. The RBAC graph is included so [[ai.starlake.quack.ondemand.rbac.RbacResolver]] can
     * answer effective_pools / effective_roles without per-request joins.

--- a/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
@@ -1173,6 +1173,70 @@ final class PostgresControlPlaneStore(
       transformSql = Option(rs.getString("transform_sql"))
     )
 
+  // ---------------- Row policies (Liquibase 0013) ----------------
+
+  def insertRowPolicy(p: RoleRowPolicy): RoleRowPolicy = withConn { c =>
+    val ps = c.prepareStatement(
+      """INSERT INTO qodstate_role_row_policy
+        |  (id, role_id, catalog_name, schema_name, table_name, predicate_sql)
+        |VALUES (?, ?, ?, ?, ?, ?)""".stripMargin
+    )
+    try
+      ps.setString(1, p.id)
+      ps.setString(2, p.roleId)
+      ps.setString(3, p.catalogName)
+      ps.setString(4, p.schemaName)
+      ps.setString(5, p.tableName)
+      ps.setString(6, p.predicateSql)
+      ps.executeUpdate()
+      p
+    finally ps.close()
+  }
+
+  def deleteRowPolicy(id: String): Boolean = withConn { c =>
+    val ps = c.prepareStatement("DELETE FROM qodstate_role_row_policy WHERE id = ?")
+    try
+      ps.setString(1, id)
+      ps.executeUpdate() > 0
+    finally ps.close()
+  }
+
+  def getRowPolicy(id: String): Option[RoleRowPolicy] = withConn { c =>
+    val ps = c.prepareStatement(
+      """SELECT id, role_id, catalog_name, schema_name, table_name, predicate_sql
+        |FROM qodstate_role_row_policy WHERE id = ?""".stripMargin
+    )
+    try
+      ps.setString(1, id)
+      val rs = ps.executeQuery()
+      try if rs.next() then Some(readRowPolicy(rs)) else None
+      finally rs.close()
+    finally ps.close()
+  }
+
+  def listRowPolicies(roleId: String): List[RoleRowPolicy] = withConn { c =>
+    val ps = c.prepareStatement(
+      """SELECT id, role_id, catalog_name, schema_name, table_name, predicate_sql
+        |FROM qodstate_role_row_policy WHERE role_id = ? ORDER BY id""".stripMargin
+    )
+    try
+      ps.setString(1, roleId)
+      val rs = ps.executeQuery()
+      try drain(rs)(readRowPolicy)
+      finally rs.close()
+    finally ps.close()
+  }
+
+  private def readRowPolicy(rs: ResultSet): RoleRowPolicy =
+    RoleRowPolicy(
+      id = rs.getString("id"),
+      roleId = rs.getString("role_id"),
+      catalogName = rs.getString("catalog_name"),
+      schemaName = rs.getString("schema_name"),
+      tableName = rs.getString("table_name"),
+      predicateSql = rs.getString("predicate_sql")
+    )
+
   // ---------------- Snapshot ----------------
 
   def snapshot(): ControlPlaneSnapshot = withConn { c =>
@@ -1250,6 +1314,11 @@ final class PostgresControlPlaneStore(
         c,
         "SELECT id, role_id, catalog_name, schema_name, table_name, column_name, action, transform_sql FROM qodstate_role_column_policy ORDER BY id",
         readColumnPolicy
+      ),
+      rowPolicies = selectAll(
+        c,
+        "SELECT id, role_id, catalog_name, schema_name, table_name, predicate_sql FROM qodstate_role_row_policy ORDER BY id",
+        readRowPolicy
       )
     )
   }

--- a/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
@@ -1193,6 +1193,17 @@ final class PostgresControlPlaneStore(
     finally ps.close()
   }
 
+  def updateRowPolicy(id: String, predicateSql: String): Boolean = withConn { c =>
+    val ps = c.prepareStatement(
+      "UPDATE qodstate_role_row_policy SET predicate_sql = ? WHERE id = ?"
+    )
+    try
+      ps.setString(1, predicateSql)
+      ps.setString(2, id)
+      ps.executeUpdate() > 0
+    finally ps.close()
+  }
+
   def deleteRowPolicy(id: String): Boolean = withConn { c =>
     val ps = c.prepareStatement("DELETE FROM qodstate_role_row_policy WHERE id = ?")
     try

--- a/src/main/scala/ai/starlake/quack/ondemand/state/RoleRowPolicy.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/RoleRowPolicy.scala
@@ -1,0 +1,19 @@
+package ai.starlake.quack.ondemand.state
+
+/** A row in `qodstate_role_row_policy`. Attaches one row-filter predicate on
+  * `catalogName.schemaName.tableName` to a role. Catalog / schema / table accept `*` for
+  * wildcards (same convention as [[RolePermission]] / [[RoleColumnPolicy]]). `predicateSql` is a
+  * boolean SQL expression that may embed identity substitution tokens (`${user}`, `${tenant}`,
+  * `${tenantId}`, `${groups}`, `${roles}`) filled at rewrite time.
+  */
+final case class RoleRowPolicy(
+    id: String,
+    roleId: String,
+    catalogName: String,
+    schemaName: String,
+    tableName: String,
+    predicateSql: String
+)
+
+object RoleRowPolicy:
+  val Wildcard: String = "*"

--- a/src/test/scala/ai/starlake/quack/edge/rls/RowPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/rls/RowPolicyRewriterSpec.scala
@@ -30,8 +30,29 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   ): EffectiveSet =
     EffectiveSet(user, roles, groups, Nil, Nil, Nil, rowPolicies)
 
-  private def rw: RowPolicyRewriter = new RowPolicyRewriter(enabled = true)
+  private val rw  = new RowPolicyRewriter(enabled = true)
   private val ctx = SchemaContext(defaultDatabase = Some("acme_tpch"), defaultSchema = Some("tpch1"))
+
+  /** Run the rewrite and echo, at info level, the original SQL, the policy predicate(s) in scope,
+    * and the resulting SQL (or the passthrough outcome). Every test routes through this so the
+    * test report shows the before/after of each case.
+    */
+  private def go(
+      sql: String,
+      effSet: EffectiveSet,
+      kind: StatementKind = StatementKind.Select,
+      rewriter: RowPolicyRewriter = rw
+  ): Outcome =
+    val outcome = rewriter.rewrite(sql, kind, effSet, ctx)
+    val preds   = effSet.rowPolicies.map(_.predicateSql)
+    val result  = outcome match
+      case Rewritten(s)           => s
+      case Passthrough            => s"$sql  [passthrough]"
+      case PassthroughParseFailed => s"$sql  [parse-failed]"
+    info(s"original:  $sql")
+    info(s"predicate: ${if preds.isEmpty then "(none)" else preds.mkString("  ;  ")}")
+    info(s"result:    $result")
+    outcome
 
   private def rewritten(o: Outcome): String = o match
     case Rewritten(sql) => sql.toLowerCase
@@ -40,118 +61,69 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
   // ---------- short-circuits ----------
 
   "rewrite" should "passthrough when the feature is disabled" in {
-    val disabled = new RowPolicyRewriter(enabled = false)
-    disabled.rewrite(
+    go(
       "SELECT * FROM customer",
-      StatementKind.Select,
       eff(tenantUser, List(policy("c_region = 'eu'"))),
-      ctx
+      rewriter = new RowPolicyRewriter(enabled = false)
     ) shouldBe Passthrough
   }
 
   it should "passthrough for superusers" in {
-    rw.rewrite(
-      "SELECT * FROM customer",
-      StatementKind.Select,
-      eff(superuser, List(policy("c_region = 'eu'"))),
-      ctx
-    ) shouldBe Passthrough
+    go("SELECT * FROM customer", eff(superuser, List(policy("c_region = 'eu'")))) shouldBe Passthrough
   }
 
   it should "passthrough when the user has no row policies" in {
-    rw.rewrite("SELECT * FROM customer", StatementKind.Select, eff(tenantUser, Nil), ctx) shouldBe
-      Passthrough
+    go("SELECT * FROM customer", eff(tenantUser, Nil)) shouldBe Passthrough
   }
 
   it should "passthrough for non-Select statement kinds" in {
     val effSet = eff(tenantUser, List(policy("c_region = 'eu'")))
-    rw.rewrite("INSERT INTO audit VALUES (1)", StatementKind.Dml, effSet, ctx) shouldBe Passthrough
-    rw.rewrite("CREATE TABLE x(y INT)", StatementKind.Ddl, effSet, ctx) shouldBe Passthrough
-    rw.rewrite("BEGIN", StatementKind.Begin, effSet, ctx) shouldBe Passthrough
+    go("INSERT INTO audit VALUES (1)", effSet, StatementKind.Dml) shouldBe Passthrough
+    go("CREATE TABLE x(y INT)", effSet, StatementKind.Ddl) shouldBe Passthrough
+    go("BEGIN", effSet, StatementKind.Begin) shouldBe Passthrough
   }
 
   it should "emit PassthroughParseFailed when the SQL fails to parse" in {
-    rw.rewrite(
-      "SELEC' WRONG",
-      StatementKind.Select,
-      eff(tenantUser, List(policy("c_region = 'eu'"))),
-      ctx
-    ) shouldBe PassthroughParseFailed
+    go("SELEC' WRONG", eff(tenantUser, List(policy("c_region = 'eu'")))) shouldBe
+      PassthroughParseFailed
   }
 
   it should "passthrough when no referenced table matches a policy" in {
-    rw.rewrite(
-      "SELECT * FROM orders",
-      StatementKind.Select,
-      eff(tenantUser, List(policy("c_region = 'eu'", table = "customer"))),
-      ctx
-    ) shouldBe Passthrough
+    go("SELECT * FROM orders", eff(tenantUser, List(policy("c_region = 'eu'", table = "customer")))) shouldBe
+      Passthrough
   }
 
   // ---------- wrapping ----------
 
   it should "wrap a matched base table in a filtered subselect" in {
-    val sql = rewritten(
-      rw.rewrite(
-        "SELECT c_id FROM customer",
-        StatementKind.Select,
-        eff(tenantUser, List(policy("c_region = 'eu'"))),
-        ctx
-      )
-    )
+    val sql = rewritten(go("SELECT c_id FROM customer", eff(tenantUser, List(policy("c_region = 'eu'")))))
     sql should include("select * from customer where")
     sql should include("c_region = 'eu'")
   }
 
   it should "preserve the caller's table alias" in {
-    val sql = rewritten(
-      rw.rewrite(
-        "SELECT c.c_id FROM customer c",
-        StatementKind.Select,
-        eff(tenantUser, List(policy("c_region = 'eu'"))),
-        ctx
-      )
-    )
+    val sql = rewritten(go("SELECT c.c_id FROM customer c", eff(tenantUser, List(policy("c_region = 'eu'")))))
     // outer reference c.c_id must still resolve -> wrapper carries alias `c`
     sql should include("c_id")
     sql.replaceAll("\\s+", " ") should (include(") as c") or include(") c"))
   }
 
   it should "substitute the ${user} identity token with a quoted literal" in {
-    val sql = rewritten(
-      rw.rewrite(
-        "SELECT * FROM customer",
-        StatementKind.Select,
-        eff(tenantUser, List(policy("c_owner = ${user}"))),
-        ctx
-      )
-    )
+    val sql = rewritten(go("SELECT * FROM customer", eff(tenantUser, List(policy("c_owner = ${user}")))))
     sql should include("c_owner = 'alice'")
   }
 
   it should "expand a ${groups} list token for an IN predicate" in {
     val groups = List(RbacGroup("g-1", "acme", "sales"), RbacGroup("g-2", "acme", "eng"))
     val sql = rewritten(
-      rw.rewrite(
-        "SELECT * FROM customer",
-        StatementKind.Select,
-        eff(tenantUser, List(policy("c_dept IN (${groups})")), groups = groups),
-        ctx
-      )
+      go("SELECT * FROM customer", eff(tenantUser, List(policy("c_dept IN (${groups})")), groups = groups))
     )
     sql should include("'sales'")
     sql should include("'eng'")
   }
 
   it should "collapse an empty ${groups} list to NULL (matches no rows)" in {
-    val sql = rewritten(
-      rw.rewrite(
-        "SELECT * FROM customer",
-        StatementKind.Select,
-        eff(tenantUser, List(policy("c_dept IN (${groups})"))),
-        ctx
-      )
-    )
+    val sql = rewritten(go("SELECT * FROM customer", eff(tenantUser, List(policy("c_dept IN (${groups})")))))
     sql.replaceAll("\\s+", " ") should include("in (null)")
   }
 
@@ -160,9 +132,7 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
       policy("c_region = 'eu'", id = "rp-1"),
       policy("c_tier = 'gold'", id = "rp-2")
     )
-    val sql = rewritten(
-      rw.rewrite("SELECT * FROM customer", StatementKind.Select, eff(tenantUser, policies), ctx)
-    )
+    val sql = rewritten(go("SELECT * FROM customer", eff(tenantUser, policies)))
     sql should include("c_region = 'eu'")
     sql should include("c_tier = 'gold'")
     sql should include(" or ")
@@ -170,12 +140,7 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
 
   it should "match a wildcard-table policy against any table" in {
     val sql = rewritten(
-      rw.rewrite(
-        "SELECT * FROM orders",
-        StatementKind.Select,
-        eff(tenantUser, List(policy("tenant_id = ${tenantId}", table = "*"))),
-        ctx
-      )
+      go("SELECT * FROM orders", eff(tenantUser, List(policy("tenant_id = ${tenantId}", table = "*"))))
     )
     sql should include("select * from orders where")
     sql should include("tenant_id = 'acme'")
@@ -187,12 +152,7 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
       policy("o_year = 2024", table = "orders", id = "rp-2")
     )
     val sql = rewritten(
-      rw.rewrite(
-        "SELECT * FROM customer c JOIN orders o ON c.c_id = o.c_id",
-        StatementKind.Select,
-        eff(tenantUser, policies),
-        ctx
-      )
+      go("SELECT * FROM customer c JOIN orders o ON c.c_id = o.c_id", eff(tenantUser, policies))
     )
     sql should include("c_region = 'eu'")
     sql should include("o_year = 2024")
@@ -200,13 +160,6 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
 
   it should "SQL-escape a single quote in a substituted identity value" in {
     val odd = RbacUser(id = "u-2", tenant = Some("acme"), username = "o'brien", role = "user")
-    val sql = rewritten(
-      rw.rewrite(
-        "SELECT * FROM customer",
-        StatementKind.Select,
-        eff(odd, List(policy("c_owner = ${user}"))),
-        ctx
-      )
-    )
+    val sql = rewritten(go("SELECT * FROM customer", eff(odd, List(policy("c_owner = ${user}")))))
     sql should include("'o''brien'")
   }

--- a/src/test/scala/ai/starlake/quack/edge/rls/RowPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/rls/RowPolicyRewriterSpec.scala
@@ -1,0 +1,212 @@
+package ai.starlake.quack.edge.rls
+
+import ai.starlake.quack.model.StatementKind
+import ai.starlake.quack.ondemand.rbac.EffectiveSet
+import ai.starlake.quack.ondemand.state._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
+  import RowPolicyRewriter._
+
+  private val superuser  = RbacUser(id = "u-super", tenant = None, username = "root", role = "admin")
+  private val tenantUser =
+    RbacUser(id = "u-1", tenant = Some("acme"), username = "alice", role = "user")
+
+  private def policy(
+      predicate: String,
+      catalog: String = "*",
+      schema: String = "tpch1",
+      table: String = "customer",
+      id: String = "rp-1"
+  ): RoleRowPolicy =
+    RoleRowPolicy(id, "r-1", catalog, schema, table, predicate)
+
+  private def eff(
+      user: RbacUser,
+      rowPolicies: List[RoleRowPolicy] = Nil,
+      roles: List[RbacRole] = Nil,
+      groups: List[RbacGroup] = Nil
+  ): EffectiveSet =
+    EffectiveSet(user, roles, groups, Nil, Nil, Nil, rowPolicies)
+
+  private def rw: RowPolicyRewriter = new RowPolicyRewriter(enabled = true)
+  private val ctx = SchemaContext(defaultDatabase = Some("acme_tpch"), defaultSchema = Some("tpch1"))
+
+  private def rewritten(o: Outcome): String = o match
+    case Rewritten(sql) => sql.toLowerCase
+    case other          => fail(s"expected Rewritten, got $other")
+
+  // ---------- short-circuits ----------
+
+  "rewrite" should "passthrough when the feature is disabled" in {
+    val disabled = new RowPolicyRewriter(enabled = false)
+    disabled.rewrite(
+      "SELECT * FROM customer",
+      StatementKind.Select,
+      eff(tenantUser, List(policy("c_region = 'eu'"))),
+      ctx
+    ) shouldBe Passthrough
+  }
+
+  it should "passthrough for superusers" in {
+    rw.rewrite(
+      "SELECT * FROM customer",
+      StatementKind.Select,
+      eff(superuser, List(policy("c_region = 'eu'"))),
+      ctx
+    ) shouldBe Passthrough
+  }
+
+  it should "passthrough when the user has no row policies" in {
+    rw.rewrite("SELECT * FROM customer", StatementKind.Select, eff(tenantUser, Nil), ctx) shouldBe
+      Passthrough
+  }
+
+  it should "passthrough for non-Select statement kinds" in {
+    val effSet = eff(tenantUser, List(policy("c_region = 'eu'")))
+    rw.rewrite("INSERT INTO audit VALUES (1)", StatementKind.Dml, effSet, ctx) shouldBe Passthrough
+    rw.rewrite("CREATE TABLE x(y INT)", StatementKind.Ddl, effSet, ctx) shouldBe Passthrough
+    rw.rewrite("BEGIN", StatementKind.Begin, effSet, ctx) shouldBe Passthrough
+  }
+
+  it should "emit PassthroughParseFailed when the SQL fails to parse" in {
+    rw.rewrite(
+      "SELEC' WRONG",
+      StatementKind.Select,
+      eff(tenantUser, List(policy("c_region = 'eu'"))),
+      ctx
+    ) shouldBe PassthroughParseFailed
+  }
+
+  it should "passthrough when no referenced table matches a policy" in {
+    rw.rewrite(
+      "SELECT * FROM orders",
+      StatementKind.Select,
+      eff(tenantUser, List(policy("c_region = 'eu'", table = "customer"))),
+      ctx
+    ) shouldBe Passthrough
+  }
+
+  // ---------- wrapping ----------
+
+  it should "wrap a matched base table in a filtered subselect" in {
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT c_id FROM customer",
+        StatementKind.Select,
+        eff(tenantUser, List(policy("c_region = 'eu'"))),
+        ctx
+      )
+    )
+    sql should include("select * from customer where")
+    sql should include("c_region = 'eu'")
+  }
+
+  it should "preserve the caller's table alias" in {
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT c.c_id FROM customer c",
+        StatementKind.Select,
+        eff(tenantUser, List(policy("c_region = 'eu'"))),
+        ctx
+      )
+    )
+    // outer reference c.c_id must still resolve -> wrapper carries alias `c`
+    sql should include("c_id")
+    sql.replaceAll("\\s+", " ") should (include(") as c") or include(") c"))
+  }
+
+  it should "substitute the ${user} identity token with a quoted literal" in {
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT * FROM customer",
+        StatementKind.Select,
+        eff(tenantUser, List(policy("c_owner = ${user}"))),
+        ctx
+      )
+    )
+    sql should include("c_owner = 'alice'")
+  }
+
+  it should "expand a ${groups} list token for an IN predicate" in {
+    val groups = List(RbacGroup("g-1", "acme", "sales"), RbacGroup("g-2", "acme", "eng"))
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT * FROM customer",
+        StatementKind.Select,
+        eff(tenantUser, List(policy("c_dept IN (${groups})")), groups = groups),
+        ctx
+      )
+    )
+    sql should include("'sales'")
+    sql should include("'eng'")
+  }
+
+  it should "collapse an empty ${groups} list to NULL (matches no rows)" in {
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT * FROM customer",
+        StatementKind.Select,
+        eff(tenantUser, List(policy("c_dept IN (${groups})"))),
+        ctx
+      )
+    )
+    sql.replaceAll("\\s+", " ") should include("in (null)")
+  }
+
+  it should "OR-combine multiple policies on the same table" in {
+    val policies = List(
+      policy("c_region = 'eu'", id = "rp-1"),
+      policy("c_tier = 'gold'", id = "rp-2")
+    )
+    val sql = rewritten(
+      rw.rewrite("SELECT * FROM customer", StatementKind.Select, eff(tenantUser, policies), ctx)
+    )
+    sql should include("c_region = 'eu'")
+    sql should include("c_tier = 'gold'")
+    sql should include(" or ")
+  }
+
+  it should "match a wildcard-table policy against any table" in {
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT * FROM orders",
+        StatementKind.Select,
+        eff(tenantUser, List(policy("tenant_id = ${tenantId}", table = "*"))),
+        ctx
+      )
+    )
+    sql should include("select * from orders where")
+    sql should include("tenant_id = 'acme'")
+  }
+
+  it should "filter both sides of a join" in {
+    val policies = List(
+      policy("c_region = 'eu'", table = "customer", id = "rp-1"),
+      policy("o_year = 2024", table = "orders", id = "rp-2")
+    )
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT * FROM customer c JOIN orders o ON c.c_id = o.c_id",
+        StatementKind.Select,
+        eff(tenantUser, policies),
+        ctx
+      )
+    )
+    sql should include("c_region = 'eu'")
+    sql should include("o_year = 2024")
+  }
+
+  it should "SQL-escape a single quote in a substituted identity value" in {
+    val odd = RbacUser(id = "u-2", tenant = Some("acme"), username = "o'brien", role = "user")
+    val sql = rewritten(
+      rw.rewrite(
+        "SELECT * FROM customer",
+        StatementKind.Select,
+        eff(odd, List(policy("c_owner = ${user}"))),
+        ctx
+      )
+    )
+    sql should include("'o''brien'")
+  }

--- a/src/test/scala/ai/starlake/quack/edge/rls/RowPredicateValidatorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/rls/RowPredicateValidatorSpec.scala
@@ -1,0 +1,48 @@
+package ai.starlake.quack.edge.rls
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RowPredicateValidatorSpec extends AnyFlatSpec with Matchers:
+  import RowPredicateValidator._
+
+  private def valid(p: String): String = validate(p) match
+    case Valid(c)     => c
+    case Invalid(why) => fail(s"expected Valid, got Invalid($why)")
+
+  private def invalid(p: String): String = validate(p) match
+    case Invalid(why) => why
+    case Valid(c)     => fail(s"expected Invalid, got Valid($c)")
+
+  "validate" should "accept a simple boolean predicate" in {
+    valid("region = 'eu'") shouldBe "region = 'eu'"
+  }
+
+  it should "accept identity tokens (single and list forms)" in {
+    valid("owner = ${user}") shouldBe "owner = ${user}"
+    valid("dept IN (${groups})") shouldBe "dept IN (${groups})"
+  }
+
+  it should "keep the tokens intact in the canonical form" in {
+    valid("tenant_id = ${tenantId} AND owner = ${user}") should include("${tenantId}")
+  }
+
+  it should "reject an empty predicate" in {
+    invalid("   ") should include("empty")
+  }
+
+  it should "reject a subquery" in {
+    invalid("id IN (SELECT id FROM secrets)") should include("subqueries")
+  }
+
+  it should "reject a denylisted escape function" in {
+    invalid("read_csv('/etc/passwd') IS NOT NULL") should include("not allowed")
+  }
+
+  it should "reject an unparseable predicate" in {
+    invalid("region = = 'eu'") should include("does not parse")
+  }
+
+  it should "reject an over-long predicate" in {
+    invalid("x = " + "'" + ("a" * 1100) + "'") should include("exceeds")
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
@@ -262,6 +262,20 @@ final class InMemoryControlPlaneStore extends ControlPlaneStore:
   def listAllColumnPolicies(): List[RoleColumnPolicy] =
     columnPolicies.values.toList.sortBy(_.id)
 
+  // ---------------- Row policies ----------------
+  private val rowPolicies = TrieMap.empty[String, RoleRowPolicy]
+
+  def insertRowPolicy(p: RoleRowPolicy): RoleRowPolicy = {
+    rowPolicies.put(p.id, p); p
+  }
+
+  def deleteRowPolicy(id: String): Boolean = rowPolicies.remove(id).isDefined
+
+  def getRowPolicy(id: String): Option[RoleRowPolicy] = rowPolicies.get(id)
+
+  def listRowPolicies(roleId: String): List[RoleRowPolicy] =
+    rowPolicies.values.filter(_.roleId == roleId).toList.sortBy(_.id)
+
   def snapshot(): ControlPlaneSnapshot = ControlPlaneSnapshot(
     tenants         = listTenants(),
     tenantDbs       = tenantDbs.values.toList.sortBy(_.name),
@@ -274,5 +288,7 @@ final class InMemoryControlPlaneStore extends ControlPlaneStore:
     userGroups      = userGroups.toList.sorted.map((u, g) => UserGroupEdge(u, g)),
     userRoles       = userRoles .toList.sorted.map((u, r) => UserRoleEdge (u, r)),
     groupRoles      = groupRoles.toList.sorted.map((g, r) => GroupRoleEdge(g, r)),
-    poolPermissions = poolPermissions.values.toList.sortBy(_.id)
+    poolPermissions = poolPermissions.values.toList.sortBy(_.id),
+    columnPolicies  = columnPolicies.values.toList.sortBy(_.id),
+    rowPolicies     = rowPolicies.values.toList.sortBy(_.id)
   )

--- a/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
@@ -269,6 +269,12 @@ final class InMemoryControlPlaneStore extends ControlPlaneStore:
     rowPolicies.put(p.id, p); p
   }
 
+  def updateRowPolicy(id: String, predicateSql: String): Boolean =
+    rowPolicies.get(id) match {
+      case Some(p) => rowPolicies.put(id, p.copy(predicateSql = predicateSql)); true
+      case None    => false
+    }
+
   def deleteRowPolicy(id: String): Boolean = rowPolicies.remove(id).isDefined
 
   def getRowPolicy(id: String): Option[RoleRowPolicy] = rowPolicies.get(id)

--- a/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryRowPolicyStoreSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryRowPolicyStoreSpec.scala
@@ -1,0 +1,27 @@
+package ai.starlake.quack.ondemand.state
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class InMemoryRowPolicyStoreSpec extends AnyFlatSpec with Matchers:
+
+  private def policy(id: String, roleId: String) = RoleRowPolicy(
+    id, roleId, catalogName = "*", schemaName = "tpch1", tableName = "orders",
+    predicateSql = "region = ${tenant}"
+  )
+
+  "InMemoryControlPlaneStore" should "insert, list by role, get, delete row policies" in {
+    val s = new InMemoryControlPlaneStore()
+    s.insertRowPolicy(policy("rp-1", "r-1"))
+    s.insertRowPolicy(policy("rp-2", "r-2").copy(tableName = "lineitem"))
+    s.listRowPolicies("r-1").map(_.id) shouldBe List("rp-1")
+    s.getRowPolicy("rp-1").map(_.tableName) shouldBe Some("orders")
+    s.deleteRowPolicy("rp-1") shouldBe true
+    s.listRowPolicies("r-1") shouldBe Nil
+  }
+
+  it should "include row policies in snapshot()" in {
+    val s = new InMemoryControlPlaneStore()
+    s.insertRowPolicy(policy("rp-9", "r-9"))
+    s.snapshot().rowPolicies.map(_.id) shouldBe List("rp-9")
+  }

--- a/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
+++ b/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
@@ -250,6 +250,7 @@ object ManagerServerHarness:
     val membershipHandlers   = new MembershipHandlers(sup, userHandlers)
     val poolPermHandlers     = new PoolPermissionHandlers(sup, userHandlers)
     val columnPolicyHandlers = new RoleColumnPolicyHandlers(sup)
+    val rowPolicyHandlers    = new RoleRowPolicyHandlers(sup)
 
     val sessions   = new SessionTokenStore
     val authSvc    = new InMemoryAuthService.Service(store, providersEnabled = enableProviders)
@@ -304,7 +305,8 @@ object ManagerServerHarness:
       serverConfigHandlers,
       manifestHandlers,
       federatedSources = None,
-      columnPolicies   = columnPolicyHandlers
+      columnPolicies   = columnPolicyHandlers,
+      rowPolicies      = rowPolicyHandlers
     )
 
     // Bound the boot. http4s Ember on macOS occasionally stalls binding port

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -45,6 +45,11 @@ import type {
   UpdateColumnPolicyRequest,
   DeleteColumnPolicyRequest,
   ColumnPolicyListResponse,
+  RowPolicyDto,
+  CreateRowPolicyRequest,
+  UpdateRowPolicyRequest,
+  DeleteRowPolicyRequest,
+  RowPolicyListResponse,
   GroupResponse,
   GroupCreateRequest,
   GroupDeleteRequest,
@@ -260,6 +265,15 @@ export const api = {
     post<void>('/role/column-policy/delete', req),
   listColumnPolicies: (roleId: string) =>
     get<ColumnPolicyListResponse>(`/role/column-policy/list?roleId=${encodeURIComponent(roleId)}`),
+
+  createRowPolicy: (req: CreateRowPolicyRequest) =>
+    post<RowPolicyDto>('/role/row-policy/create', req),
+  updateRowPolicy: (req: UpdateRowPolicyRequest) =>
+    post<void>('/role/row-policy/update', req),
+  deleteRowPolicy: (req: DeleteRowPolicyRequest) =>
+    post<void>('/role/row-policy/delete', req),
+  listRowPolicies: (roleId: string) =>
+    get<RowPolicyListResponse>(`/role/row-policy/list?roleId=${encodeURIComponent(roleId)}`),
 
   // ----- RBAC: groups -----
   listGroups:  (tenant: string) =>

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -322,6 +322,32 @@ export interface UpdateColumnPolicyRequest {
 export interface DeleteColumnPolicyRequest { id: string; }
 export interface ColumnPolicyListResponse { policies: ColumnPolicyDto[]; }
 
+// ----- RBAC: row-level policies -----
+export interface RowPolicyDto {
+  id:           string;
+  roleId:       string;
+  catalogName:  string;
+  schemaName:   string;
+  tableName:    string;
+  predicateSql: string;
+}
+
+export interface CreateRowPolicyRequest {
+  roleId:       string;
+  catalogName:  string;
+  schemaName:   string;
+  tableName:    string;
+  predicateSql: string;
+}
+
+export interface UpdateRowPolicyRequest {
+  id:           string;
+  predicateSql: string;
+}
+
+export interface DeleteRowPolicyRequest { id: string; }
+export interface RowPolicyListResponse { policies: RowPolicyDto[]; }
+
 // ----- RBAC: groups -----
 export interface GroupResponse {
   id:          string;

--- a/ui/src/components/RoleRowPoliciesSection.tsx
+++ b/ui/src/components/RoleRowPoliciesSection.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+import { api, ApiError } from '../api/client';
+import type { RowPolicyDto } from '../api/types';
+import { DeleteIcon } from './Icons';
+
+/** Row-level policy tab body inside the Role edit modal.
+  * Lists existing row policies for the role and provides an inline
+  * "+ Add row policy" form that calls createRowPolicy. The predicate is a
+  * boolean SQL expression that may embed identity tokens
+  * (${user}, ${tenant}, ${tenantId}, ${roles}, ${groups}) substituted at
+  * query time. Row-level security is experimental and gated by
+  * QOD_RLS_ENABLED on the manager. */
+export default function RoleRowPoliciesSection({ roleId }: { roleId: string }) {
+  const [policies, setPolicies] = useState<RowPolicyDto[]>([]);
+  const [error,    setError]    = useState<string | null>(null);
+  const [adding,   setAdding]   = useState(false);
+
+  // Form fields
+  const [fCatalog,   setFCatalog]   = useState('*');
+  const [fSchema,    setFSchema]    = useState('');
+  const [fTable,     setFTable]     = useState('');
+  const [fPredicate, setFPredicate] = useState('');
+
+  function reload() {
+    setError(null);
+    api.listRowPolicies(roleId)
+      .then(r => setPolicies(r.policies))
+      .catch(e => setError(e instanceof ApiError ? e.message : String(e)));
+  }
+
+  useEffect(() => {
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roleId]);
+
+  function resetForm() {
+    setFCatalog('*');
+    setFSchema('');
+    setFTable('');
+    setFPredicate('');
+    setError(null);
+  }
+
+  async function handleCreate(ev: React.FormEvent) {
+    ev.preventDefault();
+    setError(null);
+    try {
+      await api.createRowPolicy({
+        roleId,
+        catalogName:  fCatalog.trim() || '*',
+        schemaName:   fSchema.trim(),
+        tableName:    fTable.trim(),
+        predicateSql: fPredicate.trim(),
+      });
+      setAdding(false);
+      resetForm();
+      reload();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e));
+    }
+  }
+
+  async function handleDelete(p: RowPolicyDto) {
+    if (!confirm(`Delete row policy on ${p.tableName}?`)) return;
+    setError(null);
+    try {
+      await api.deleteRowPolicy({ id: p.id });
+      reload();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e));
+    }
+  }
+
+  return (
+    <div>
+      {error && <div className="login-err">Error: {error}</div>}
+
+      {policies.length === 0 ? (
+        <div className="empty">(no row policies yet)</div>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>Catalog</th>
+              <th>Schema</th>
+              <th>Table</th>
+              <th>Predicate SQL</th>
+              <th className="actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {policies.map(p => (
+              <tr key={p.id}>
+                <td><code>{p.catalogName}</code></td>
+                <td><code>{p.schemaName}</code></td>
+                <td><code>{p.tableName}</code></td>
+                <td>
+                  <code style={{ fontFamily: 'var(--mono)', fontSize: '0.85em', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>{p.predicateSql}</code>
+                </td>
+                <td className="actions">
+                  <button
+                    className="icon-btn danger"
+                    title="Delete"
+                    aria-label="Delete"
+                    onClick={() => handleDelete(p)}
+                  >
+                    <DeleteIcon />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {!adding && (
+        <div style={{ marginTop: '0.75rem' }}>
+          <button type="button" className="link-button" onClick={() => setAdding(true)}>
+            + Add row policy
+          </button>
+        </div>
+      )}
+
+      {adding && (
+        <form
+          onSubmit={handleCreate}
+          style={{
+            marginTop: '0.75rem',
+            background: 'var(--bg-elev)',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius)',
+            padding: '0.75rem 1rem',
+          }}
+        >
+          <div className="row" style={{ gap: 8, marginBottom: 8, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+            <div style={{ flex: '1 1 8rem', minWidth: 80 }}>
+              <label style={{ margin: 0 }}>
+                Catalog
+                <input
+                  value={fCatalog}
+                  onChange={ev => setFCatalog(ev.target.value)}
+                  placeholder="*"
+                />
+              </label>
+            </div>
+            <div style={{ flex: '1 1 8rem', minWidth: 80 }}>
+              <label style={{ margin: 0 }}>
+                Schema
+                <input
+                  value={fSchema}
+                  onChange={ev => setFSchema(ev.target.value)}
+                  placeholder="schema"
+                  required
+                />
+              </label>
+            </div>
+            <div style={{ flex: '1 1 8rem', minWidth: 80 }}>
+              <label style={{ margin: 0 }}>
+                Table
+                <input
+                  value={fTable}
+                  onChange={ev => setFTable(ev.target.value)}
+                  placeholder="table"
+                  required
+                />
+              </label>
+            </div>
+          </div>
+          <label style={{ marginBottom: '0.5rem' }}>
+            Predicate SQL
+            <textarea
+              rows={4}
+              style={{ fontFamily: 'var(--mono)', resize: 'vertical' }}
+              value={fPredicate}
+              onChange={ev => setFPredicate(ev.target.value)}
+              placeholder="region = ${tenantId} OR owner = ${user}"
+              required
+            />
+          </label>
+          <div style={{ color: 'var(--text-mute)', fontSize: '0.8em', marginBottom: '0.5rem' }}>
+            Boolean filter applied to each matching table. Identity tokens:{' '}
+            <code>{'${user}'}</code>, <code>{'${tenant}'}</code>, <code>{'${tenantId}'}</code>,{' '}
+            <code>{'${roles}'}</code>, <code>{'${groups}'}</code> (list tokens for <code>IN (…)</code>).
+          </div>
+          <div className="row" style={{ gap: 8, justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              className="cancel-button"
+              style={{ minWidth: '7rem' }}
+              onClick={() => { setAdding(false); resetForm(); }}
+            >
+              Cancel
+            </button>
+            <button type="submit" style={{ minWidth: '7rem' }}>Create</button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/RoleSection.tsx
+++ b/ui/src/components/RoleSection.tsx
@@ -3,6 +3,7 @@ import { api, ApiError } from '../api/client';
 import type { RolePermissionResponse, RoleResponse } from '../api/types';
 import { DeleteIcon, EditIcon } from './Icons';
 import RoleColumnPoliciesSection from './RoleColumnPoliciesSection';
+import RoleRowPoliciesSection from './RoleRowPoliciesSection';
 import Tabs from './Tabs';
 
 const VERBS = ['RO', 'RW', 'DDL', 'ALL'];
@@ -256,6 +257,11 @@ export default function RoleSection({ tenant }: { tenant: string | null }) {
                     id: 'column-policies',
                     label: 'Column policies',
                     body: <RoleColumnPoliciesSection roleId={selected.id} />,
+                  },
+                  {
+                    id: 'row-policies',
+                    label: 'Row policies',
+                    body: <RoleRowPoliciesSection roleId={selected.id} />,
                   },
                 ]}
               />

--- a/website/docs/operating/rbac-model.md
+++ b/website/docs/operating/rbac-model.md
@@ -300,6 +300,119 @@ The `column_policy_rewrites_total{outcome=...}` counter emits five outcomes:
 
 Column policies are administered the same way as table permissions: via REST endpoints under `/api/role/column-policy/{create,update,delete,list}`, via the admin UI's "Column policies" tab on the role detail page, and via YAML manifest (`columnPolicies` list under each role). The bundled demo manifest (`bootstrap-demo.yaml`) ships an example mask policy on `acme/analyst/customer.c_phone` so a fresh `LOAD_TPCH=1` boot demonstrates the feature end-to-end without manual setup.
 
+## Row-level policies
+
+Column policies restrict *which columns* a role sees; row policies restrict *which rows*. Where column-level security blanks out `c_ssn`, row-level security drops the customer records a role is not allowed to see in the first place — a salesperson sees only their own region's orders, a tenant analyst sees only rows tagged with their tenant id, an auditor sees everything. Like column policies, row policies are enforced by rewriting the user's SELECT before it reaches a Quack node; unlike column policies, the rewrite pushes a boolean filter down onto each protected table rather than transforming the projection.
+
+### Data model
+
+Policies live in `qodstate_role_row_policy` (one row per `(role, catalog, schema, table)`) and attach to roles only; users inherit them through the same role-membership graph as table permissions.
+
+| Column | Meaning |
+|---|---|
+| `role_id`        | The role that carries the policy. |
+| `catalog_name` / `schema_name` / `table_name` | The protected table. `*` wildcards work the same way as for table permissions, including tenant scoping on `catalog_name`. A `table_name = '*'` policy filters every table the query touches — useful for a tenant-id predicate that should apply everywhere. |
+| `predicate_sql`  | A boolean SQL expression that admits a row when it evaluates true. May embed identity-substitution tokens (see below). Validated at create time. |
+
+`UNIQUE (role_id, catalog_name, schema_name, table_name)` so updates replace in place; a role carries at most one predicate per exact table tuple (a wildcard policy and a specific-table policy are different tuples and both apply). `ON DELETE CASCADE from qodstate_role` so dropping a role drops its policies.
+
+### Where the rewriter sits in the pipeline
+
+The row rewriter runs *after* the column rewriter, so the two compose with row filtering innermost:
+
+```
+client SQL
+   │
+   ▼  table-level ACL                                    ─── unchanged
+   │
+   ▼  ColumnPolicyRewriter (masking / deny)              ─── outer
+   │
+   ▼  RowPolicyRewriter                                  ─── inner
+   │     - parses the (already column-rewritten) SQL
+   │     - walks every table reference reachable
+   │       (FROM, JOINs, subqueries, CTE bodies, UNION arms)
+   │     - for each table with a matching policy, replaces it with
+   │         (SELECT * FROM <table> WHERE <predicate>) <alias>
+   │
+   ▼  adapter sends the rewritten SQL to the Quack node
+```
+
+Pushing the predicate onto the **base relation** (rather than wrapping the whole query in an outer `WHERE`) is what keeps the filter correct under joins (each table filters independently), aggregation (rows are dropped *before* `GROUP BY`), `LIMIT`/`DISTINCT`/set operations (filtering happens before they apply), and projections that do not select the predicate's columns. It also means the filter runs on the *true* (unmasked) values, so a row policy keyed on a column that a column policy masks still filters correctly. This matches the semantics of Postgres RLS and Snowflake row-access policies, where the predicate is a property of the table scan.
+
+The rewriter only runs for SELECT-shaped statements; DML and DDL pass through unchanged. Statements that fail to parse are forwarded unmodified (tagged `parse_failed`). Superusers (tenant `NULL`) bypass the rewriter entirely.
+
+### Row-level security guarantees
+
+Every table occurrence reachable from the statement is considered: the top-level `FROM` item, each `JOIN` right-hand item, parenthesised subqueries, and CTE (`WITH`) bodies are recursed into. A table matches a policy when its `(catalog, schema, table)` — resolved against the session's default catalog/schema for bare names — equals the policy tuple component-wise, with `*` matching anything. When a table matches more than one of the principal's policies (e.g. a wildcard tenant-id policy plus a specific-table policy, or policies from two different roles), the predicates are combined (see "Combining policies").
+
+### Kill switch (feature flag — EXPERIMENTAL)
+
+Row-level security is **experimental** and ships **disabled by default**. Operators opt in by setting `quack-on-demand.rls.enabled = true` (or env `QOD_RLS_ENABLED=true`). When disabled, every statement bypasses the rewriter completely — no parse, no table walk, no per-statement overhead. Treat the toggle as a kill switch you can flip off in an incident: change the env var and restart the manager. It is independent of `QOD_CLS_ENABLED`; either feature can run without the other.
+
+### Predicate validation
+
+`predicate_sql` is validated once at policy create/update time and rejected (`400 invalid_policy`, with the violated rule named) when it:
+
+1. Fails to parse as a single boolean SQL expression (after identity tokens are neutralised).
+2. Contains a subquery or `EXISTS` — nesting a SELECT inside the predicate is refused.
+3. Calls a side-effect or escape function: the denylist matches column-level security's — `read_csv`, `read_parquet`, `read_json`, `query`, `sql`, `attach`, `detach`, `install`, `load`, `system`, `current_setting`, `set_setting`, `pg_read_server_files`, `pg_read_binary_file`, and anything matching `pragma_*`.
+4. Exceeds 1024 characters.
+
+Detection runs on the parsed, canonicalised expression with string literals stripped, so a denylisted function nested inside any wrapper (`read_csv(...) IS NOT NULL`) is still caught, while a harmless literal like `note = 'select one'` is not mistaken for a subquery. Unlike a column mask transform, the predicate may reference *any* column of the protected table — it filters rows, so there is no single-column containment rule.
+
+### Identity substitution tokens
+
+Predicates may embed identity tokens that are filled from the principal's `EffectiveSet` at query time (never at authoring time — the stored predicate keeps the tokens). Each token expands to a complete SQL literal, so a single value is quoted and escaped and a list is rendered for `IN (…)`:
+
+| Token | Expands to | Example expansion |
+|---|---|---|
+| `${user}`     | the username, quoted        | `'alice'` |
+| `${tenant}` / `${tenantId}` | the principal's tenant id, quoted | `'acme'` |
+| `${roles}`    | the effective role names as a quoted list | `'analyst', 'auditor'` |
+| `${groups}`   | the effective group names as a quoted list | `'sales', 'eng'` |
+
+Single-quotes in a value are doubled (`o'brien` → `'o''brien'`), so substitution is injection-safe. A **list token that resolves to the empty set becomes `NULL`**, so `dept IN (${groups})` becomes `dept IN (NULL)` — a predicate that matches no rows. This is the safe-restrictive default: a principal in no groups sees nothing through a group-keyed policy rather than erroring on `IN ()`.
+
+Typical predicates:
+
+| `predicate_sql` | Effect |
+|---|---|
+| `region = ${tenantId}`              | rows tagged with the caller's tenant |
+| `owner = ${user}`                   | row-ownership |
+| `dept IN (${groups})`               | rows for any of the caller's groups |
+| `is_public OR owner = ${user}`      | public rows plus the caller's own |
+
+### Combining policies
+
+A principal sees a row if **any** matching policy admits it: predicates are combined with `OR` (permissive union). When role A filters `customer` by `region = 'eu'` and role B filters it by `tier = 'gold'`, a user holding both sees `WHERE (region = 'eu') OR (tier = 'gold')`. This makes additional roles strictly *widen* visibility, matching the additive nature of the rest of the RBAC model. A table with no matching policy for the principal is left unfiltered (table-level ACL already decided whether the principal may read it at all).
+
+### Interaction with column-level security
+
+When both features are on, the row filter is injected inside the column rewrite, so rows are filtered on their true values and only the surviving rows are then masked for display. A row policy may safely key on a column that a column policy masks: the filter sees the real value (inside `(SELECT * FROM t WHERE …)`), the masking applies in the outer projection.
+
+### Effective policies and caching
+
+Row policies join column policies and the `RolePermission` / pool-permission rows in the per-user `EffectiveSet.rowPolicies`. The same 60-second `PoolSupervisor` cache covers them, and the same mutator-invalidation contract applies: `createRowPolicy`, `updateRowPolicy`, and `deleteRowPolicy` each call `invalidateEffectiveCache()`, so a freshly-authored policy takes effect on the next handshake regardless of the TTL. Per-statement cost is in-memory only: an AST table-walk plus per-table lookup against the cached list — no Postgres traffic on the hot path.
+
+### Observability
+
+Two Micrometer metrics expose the rewriter's behaviour:
+
+| Metric | Tags | Use |
+|---|---|---|
+| `row_policy_rewrites_total`          | `tenant`, `pool`, `outcome` ∈ `{rewritten, parse_failed, passthrough}` | Fraction of reads paying the rewrite cost; spot policy regressions. |
+| `row_policy_rewrite_duration_seconds` | `tenant`, `pool` | Histogram of rewrite step wall time; alert on percentile regressions. |
+
+The `outcome` tag emits:
+
+- `rewritten`: at least one table was wrapped in a filtered subselect.
+- `parse_failed`: the SQL could not be parsed; the original statement is forwarded unchanged. Distinct from `passthrough` so operators can tell "rewriter inactive because nothing to filter" from "rewriter gave up".
+- `passthrough`: the rewriter inspected the SQL and decided no rewrite was needed (no covered table referenced; non-SELECT; superuser; user has no row policies; feature disabled).
+
+### Authoring
+
+Row policies are administered the same way as column policies: via REST endpoints under `/api/role/row-policy/{create,update,delete,list}`, via the admin UI's "Row policies" tab on the role detail page, and via YAML manifest (`rowPolicies` list under each role, each entry a `{catalog, schema, table, predicateSql}` object).
+
 ## The two gates
 
 Every FlightSQL request passes through two sequential gates.


### PR DESCRIPTION
## What

Adds **row-level security**: per-role row-filter policies that rewrite a user's `SELECT` to drop rows the role may not see, the row-level counterpart to the existing column-level masking/deny feature. Experimental and **off by default** (`QOD_RLS_ENABLED=true` to enable).

A policy attaches a boolean predicate to a `(role, catalog, schema, table)`. At query time each matching base table is replaced with `(SELECT * FROM <table> WHERE <predicate>) <alias>`, so the node only ever sees admissible rows.

## How it works

- **Predicate pushed to the base relation** (not an outer `WHERE`), so filtering stays correct under joins (each table filters independently), aggregation (rows drop before `GROUP BY`), `LIMIT`/`DISTINCT`/set-ops, and projections that don't select the predicate's columns. Matches Postgres RLS / Snowflake row-access-policy semantics.
- **OR-combine**: when a principal holds several roles with policies on the same table, predicates combine with `OR` (permissive union) — more roles widen visibility, consistent with the rest of the RBAC model.
- **Identity tokens** `${user}` / `${tenant}` / `${tenantId}` / `${roles}` / `${groups}` expand to escaped SQL literals at query time; empty list tokens collapse to `NULL` (matches nothing — safe-restrictive).
- **Composes with CLS**: row filter is injected *inside* the column rewrite, so rows filter on true values before any masking.
- **Predicate validation** at create/update: parses, no subqueries/`EXISTS`, denylisted escape functions rejected (scan of the parsed canonical form, literals stripped), ≤1024 chars.
- SELECT-only; superusers and the disabled flag short-circuit to passthrough; unparseable SQL → `parse_failed` (forwarded unchanged).

## Surface area

- **Storage**: `qodstate_role_row_policy` (Liquibase `0013`), store CRUD across the trait + Postgres + in-memory impls, snapshot field.
- **Plumbing**: `EffectiveSet.rowPolicies`, `PoolSupervisor` CRUD + cache invalidation, manifest import/export (`rowPolicies` under each role).
- **REST**: `/api/role/row-policy/{create,update,delete,list}`, tenant-scope gated.
- **Rewriter**: `edge/rls/RowPolicyRewriter` + `RowPredicateValidator`, wired into `FlightSqlRouter` after CLS; `row_policy_rewrites_total` + duration metrics; `quack-on-demand.rls.enabled` config.
- **UI**: a "Row policies" tab in the Role editor (list + inline add form), mirroring Column policies.
- **Docs**: a Row-level policies section in `website/docs/operating/rbac-model.md`.

## Testing

- `RowPolicyRewriterSpec` (15) — passthrough/short-circuit cases, table wrapping, alias preservation, token substitution (incl. empty-list→NULL and quote escaping), OR-combine, wildcard match, join filtering. Each case logs original → predicate → result SQL at info level.
- `RowPredicateValidatorSpec` (8) — accept/reject paths incl. nested denylisted function.
- `InMemoryRowPolicyStoreSpec`, plus manifest round-trip and RBAC tenant-scope suites green.
- Full `Test/compile` clean; manually verified end-to-end on a booted manager (create/list/invalid-predicate-400) with RLS enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)