### PR TITLE
feat(pool): drain/force stop scales pool to 0 instead of deleting it

### DIFF
--- a/skills/quack-on-demand/SKILL.md
+++ b/skills/quack-on-demand/SKILL.md
@@ -94,8 +94,13 @@ curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/scale \
   -d '{"tenant":"acme","pool":"sales","targetSize":6,
        "roleDistribution":{"writeonly":1,"readonly":2,"dual":3}}'
 
-# Stop a pool (force=true skips graceful drain)
+# Stop a pool: scales it down to 0 nodes but KEEPS the pool (force=true skips graceful drain)
 curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/stop \
+  -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","pool":"sales","force":true}'
+
+# Delete a pool: stops nodes AND removes the pool from the registry
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/delete \
   -H 'Content-Type: application/json' \
   -d '{"tenant":"acme","pool":"sales","force":true}'
 
@@ -345,7 +350,7 @@ The Python script needs `pip install adbc_driver_flightsql adbc_driver_manager p
 | `no node with role READONLY or DUAL` | All nodes flipped unhealthy (port unreachable) | Check `pgrep -fl spawn-quack-node`; if 0, run `stop` + `start` (reconcile respawns) |
 | `access denied: missing RO grant on ...` | ACL is enabled and the user has no matching grant | Add the grant via the role-permission API or set `QOD_ACL_ENABLED=false` |
 | `session expired; please reconnect` | Bearer token unknown (manager restarted between calls) | Re-login or pass Basic credentials |
-| `Could not connect to server` for `http://127.0.0.1:21NNN/quack` | Quack child died after manager restart | Reconcile respawns on next boot; until then `pool/stop` + `pool/create` |
+| `Could not connect to server` for `http://127.0.0.1:21NNN/quack` | Quack child died after manager restart | Reconcile respawns on next boot; until then `pool/delete` + `pool/create` |
 | Python load test: "PyArrow not installed" | Missing pyarrow | `pip install --break-system-packages pyarrow` on macOS |
 | Manager (or spawned node) hangs at startup right after `BaseAllocator` log line, java pegged at 100% CPU | `INSTALL quack` is blocked by a corporate proxy - DuckDB is silently retrying to fetch the extension from `extensions.duckdb.org` | Pass `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` env vars to the process (container `-e` or shell env). See README "Behind a corporate proxy". |
 

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -298,6 +298,9 @@ final class ManagerServer(
       Endpoints.stopPool.serverLogic { case (req, key) =>
         pools.stopPool(req, key)(sessions.scopeOf)
       },
+      Endpoints.deletePool.serverLogic { case (req, key) =>
+        pools.deletePool(req, key)(sessions.scopeOf)
+      },
       Endpoints.listPools.serverLogic(apiKey => pools.listPools(apiKey)(sessions.scopeOf)),
       Endpoints.poolStatus.serverLogic((t, td, p) => pools.poolStatus(t, td, p)),
       Endpoints.setPoolDisabled.serverLogic { case (req, key) =>

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -904,7 +904,23 @@ final class PoolSupervisor(
                  else IO.unit).as(combined)
               }
 
+  /** Stop every node of the pool but KEEP the pool itself registered. The pool row survives in the
+    * control plane and the in-memory state stays with an empty node list and a zero distribution,
+    * so the pool is effectively scaled to 0 and stays drained across a manager restart (reconcile
+    * only respawns when the persisted distribution is non-zero). Use [[deletePool]] to remove the
+    * pool entirely. `force=true` kills nodes immediately; `force=false` drains them (stop accepting
+    * new queries, then shut down).
+    */
   def stopPool(key: PoolKey, force: Boolean): IO[Unit] =
+    pools.get(key) match
+      case None    => IO.unit
+      case Some(_) => scale(key, 0, RoleDistribution(0, 0, 0), force).void
+
+  /** Remove the pool entirely: stop every node, then delete the pool and its node rows from the
+    * control plane and forget it in memory. This is the only path that deletes a pool; [[stopPool]]
+    * merely scales it to 0.
+    */
+  def deletePool(key: PoolKey, force: Boolean): IO[Unit] =
     pools.get(key) match
       case None        => IO.unit
       case Some(state) =>

--- a/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
@@ -118,6 +118,13 @@ final case class StopPoolRequest(
     force: Boolean = false
 )
 
+final case class DeletePoolRequest(
+    tenant: String,
+    tenantDb: String,
+    pool: String,
+    force: Boolean = false
+)
+
 final case class PoolListResponse(pools: List[PoolResponse])
 final case class HealthResponse(status: String, poolsCount: Int, nodesCount: Int)
 
@@ -690,6 +697,26 @@ object Dtos:
         pool     <- c.get[String]("pool")
         force    <- c.getOrElse[Boolean]("force")(false)
       yield StopPoolRequest(tenant, tenantDb, pool, force)
+    },
+    Encoder.instance { r =>
+      Json.fromJsonObject(
+        JsonObject(
+          "tenant"   -> r.tenant.asJson,
+          "tenantDb" -> r.tenantDb.asJson,
+          "pool"     -> r.pool.asJson,
+          "force"    -> r.force.asJson
+        )
+      )
+    }
+  )
+  given Codec[DeletePoolRequest] = Codec.from(
+    Decoder.instance { (c: HCursor) =>
+      for
+        tenant   <- c.get[String]("tenant")
+        tenantDb <- c.get[String]("tenantDb")
+        pool     <- c.get[String]("pool")
+        force    <- c.getOrElse[Boolean]("force")(false)
+      yield DeletePoolRequest(tenant, tenantDb, pool, force)
     },
     Encoder.instance { r =>
       Json.fromJsonObject(

--- a/src/main/scala/ai/starlake/quack/ondemand/api/Endpoints.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/Endpoints.scala
@@ -62,6 +62,17 @@ object Endpoints:
       .in(jsonBody[StopPoolRequest])
       .in(header[Option[String]]("X-API-Key"))
 
+  val deletePool: PublicEndpoint[
+    (DeletePoolRequest, Option[String]),
+    (sttp.model.StatusCode, ErrorResponse),
+    Unit,
+    Any
+  ] =
+    base.post
+      .in("pool" / "delete")
+      .in(jsonBody[DeletePoolRequest])
+      .in(header[Option[String]]("X-API-Key"))
+
   val listPools: PublicEndpoint[Option[
     String
   ], (sttp.model.StatusCode, ErrorResponse), PoolListResponse, Any] =

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PoolHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PoolHandlers.scala
@@ -170,6 +170,19 @@ final class PoolHandlers(sup: PoolSupervisor, tracker: NodeLoadTracker):
           case Some(_) =>
             sup.stopPool(key, req.force).map(_ => Right(()))
 
+  def deletePool(req: DeletePoolRequest, apiKey: Option[String])(
+      scopeOf: String => Option[SessionScope]
+  ): Out[Unit] =
+    TenantScopeCheck.reject(apiKey, req.tenant)(scopeOf) match
+      case Some(err) => IO.pure(Left(err))
+      case None      =>
+        val key = PoolKey(req.tenant, req.tenantDb, req.pool)
+        sup.get(key) match
+          case None =>
+            IO.pure(Left((StatusCode.NotFound, ErrorResponse("not_found", s"pool $key not found"))))
+          case Some(_) =>
+            sup.deletePool(key, req.force).map(_ => Right(()))
+
   def listPools(apiKey: Option[String])(
       scopeOf: String => Option[SessionScope]
   ): Out[PoolListResponse] = IO.delay {

--- a/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
@@ -197,10 +197,18 @@ class PoolSupervisorSpec extends AnyFlatSpec with Matchers:
     sup.createPool(key, RoleDistribution(0, 0, 1)).unsafeRunSync()
     sup.setMaxConcurrent(key, "nope", 5).unsafeRunSync() shouldBe None
 
-  "PoolSupervisor.stopPool" should "stop all nodes and forget the pool" in:
+  "PoolSupervisor.stopPool" should "stop all nodes but keep the pool (scaled to 0)" in:
     val sup = freshSupervisor()
     sup.createPool(key, RoleDistribution(0, 1, 1)).unsafeRunSync()
     sup.stopPool(key, force = true).unsafeRunSync()
+    // Pool survives; it is just scaled down to zero nodes.
+    sup.get(key).map(_.nodes) shouldBe Some(Nil)
+    sup.get(key).map(_.distribution) shouldBe Some(RoleDistribution(0, 0, 0))
+
+  "PoolSupervisor.deletePool" should "stop all nodes and forget the pool" in:
+    val sup = freshSupervisor()
+    sup.createPool(key, RoleDistribution(0, 1, 1)).unsafeRunSync()
+    sup.deletePool(key, force = true).unsafeRunSync()
     sup.get(key) shouldBe None
 
   // ---------- Tenant CRUD ----------

--- a/src/test/scala/ai/starlake/quack/ondemand/api/PoolHandlersSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/PoolHandlersSpec.scala
@@ -107,11 +107,22 @@ class PoolHandlersSpec extends AnyFlatSpec with Matchers:
     ), None)((_: String) => None).unsafeRunSync()
     out.left.toOption.map(_._1) shouldBe Some(StatusCode.NotFound)
 
-  "stopPool" should "stop a known pool" in:
+  "stopPool" should "stop a known pool but keep it (scaled to 0)" in:
     val h = freshHandlers
     h.createPool(req(size = 1, dist = RoleDistribution(0, 0, 1)), None)((_: String) => None).unsafeRunSync()
     h.stopPool(StopPoolRequest("acme", "acme_default", "sales", force = true), None)((_: String) => None)
       .unsafeRunSync() shouldBe Right(())
+    // Pool still exists, just with no nodes.
+    h.poolStatus("acme", "acme_default", "sales").unsafeRunSync()
+      .toOption.map(_.nodes) shouldBe Some(Nil)
+
+  "deletePool" should "remove a known pool" in:
+    val h = freshHandlers
+    h.createPool(req(size = 1, dist = RoleDistribution(0, 0, 1)), None)((_: String) => None).unsafeRunSync()
+    h.deletePool(DeletePoolRequest("acme", "acme_default", "sales", force = true), None)((_: String) => None)
+      .unsafeRunSync() shouldBe Right(())
+    h.poolStatus("acme", "acme_default", "sales").unsafeRunSync()
+      .left.toOption.map(_._1) shouldBe Some(StatusCode.NotFound)
 
   "listPools" should "return all pools" in:
     val h = freshHandlers

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -2,6 +2,7 @@ import type {
   CreatePoolRequest,
   ScalePoolRequest,
   StopPoolRequest,
+  DeletePoolRequest,
   SetMaxConcurrentRequest,
   SetPoolDisabledRequest,
   SetTenantAuthRequest,
@@ -165,6 +166,7 @@ export const api = {
   createPool:  (req: CreatePoolRequest) => post<PoolResponse>('/pool/create', req),
   scalePool:   (req: ScalePoolRequest) => post<PoolResponse>('/pool/scale', req),
   stopPool:    (req: StopPoolRequest) => post<void>('/pool/stop', req),
+  deletePool:  (req: DeletePoolRequest) => post<void>('/pool/delete', req),
   setMaxConcurrent: (req: SetMaxConcurrentRequest) => post<void>('/node/setMaxConcurrent', req),
   setPoolDisabled:  (req: SetPoolDisabledRequest)  => post<PoolResponse>('/pool/setDisabled', req),
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -98,6 +98,13 @@ export interface StopPoolRequest {
   force?: boolean;
 }
 
+export interface DeletePoolRequest {
+  tenant: string;
+  tenantDb: string;
+  pool: string;
+  force?: boolean;
+}
+
 export interface SetMaxConcurrentRequest {
   tenant: string;
   tenantDb: string;

--- a/ui/src/components/PoolSection.tsx
+++ b/ui/src/components/PoolSection.tsx
@@ -85,17 +85,33 @@ export default function PoolSection({ tenant }: { tenant: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tenant]);
 
-  async function handleDelete(p: PoolResponse, force: boolean) {
+  async function handleStop(p: PoolResponse, force: boolean) {
     setError(null);
     const mode = force ? 'FORCE' : 'DRAIN';
     if (!window.confirm(
-      `Delete pool "${p.tenantDb}/${p.pool}" (${mode})?\n\n` +
+      `Stop pool "${p.tenantDb}/${p.pool}" (${mode})?\n\n` +
+      'The pool scales down to 0 nodes but is NOT deleted; scale it back up later.\n\n' +
       (force
         ? 'Nodes stop immediately; outstanding queries fail.'
         : 'Nodes stop accepting new queries first, then shut down.')
     )) return;
     try {
       await api.stopPool({ tenant, tenantDb: p.tenantDb, pool: p.pool, force });
+      await reloadPools();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e));
+    }
+  }
+
+  async function handleDelete(p: PoolResponse) {
+    setError(null);
+    if (!window.confirm(
+      `Delete pool "${p.tenantDb}/${p.pool}"?\n\n` +
+      'This permanently removes the pool and all its nodes. ' +
+      'Running nodes are force-stopped; outstanding queries fail.'
+    )) return;
+    try {
+      await api.deletePool({ tenant, tenantDb: p.tenantDb, pool: p.pool, force: true });
       await reloadPools();
     } catch (e) {
       setError(e instanceof ApiError ? e.message : String(e));
@@ -289,24 +305,31 @@ export default function PoolSection({ tenant }: { tenant: string }) {
                   {' '}
                   <button
                     type="button"
-                    className="danger"
-                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                    onClick={() => void handleDelete(p, false)}
+                    onClick={() => void handleStop(p, false)}
                     aria-label={`Drain pool ${p.pool}`}
-                    title="Drain: stop accepting new queries, then shut down gracefully."
+                    title="Drain: stop accepting new queries, then shut down. Scales to 0 nodes; the pool is kept."
                   >
-                    <DeleteIcon /> Drain
+                    Drain
+                  </button>
+                  {' '}
+                  <button
+                    type="button"
+                    onClick={() => void handleStop(p, true)}
+                    aria-label={`Force-stop pool ${p.pool}`}
+                    title="Force: stop immediately; outstanding queries fail. Scales to 0 nodes; the pool is kept."
+                  >
+                    Force
                   </button>
                   {' '}
                   <button
                     type="button"
                     className="danger"
                     style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
-                    onClick={() => void handleDelete(p, true)}
-                    aria-label={`Force-stop pool ${p.pool}`}
-                    title="Force: stop immediately; outstanding queries fail."
+                    onClick={() => void handleDelete(p)}
+                    aria-label={`Delete pool ${p.pool}`}
+                    title="Delete: permanently remove the pool and all its nodes."
                   >
-                    <DeleteIcon /> Force
+                    <DeleteIcon /> Delete
                   </button>
                 </td>
               </tr>

--- a/ui/src/components/PoolSection.tsx
+++ b/ui/src/components/PoolSection.tsx
@@ -324,12 +324,12 @@ export default function PoolSection({ tenant }: { tenant: string }) {
                   <button
                     type="button"
                     className="danger"
-                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                    style={{ display: 'inline-flex', alignItems: 'center' }}
                     onClick={() => void handleDelete(p)}
                     aria-label={`Delete pool ${p.pool}`}
                     title="Delete: permanently remove the pool and all its nodes."
                   >
-                    <DeleteIcon /> Delete
+                    <DeleteIcon />
                   </button>
                 </td>
               </tr>


### PR DESCRIPTION
## What

Drain and Force-stop on a pool now **scale it down to 0 nodes while keeping the pool registered**. Only the new **Delete** action removes the pool from the control plane.

## Why

Previously `stopPool` (drain/force) stopped all nodes **and** deleted the pool, so there was no way to temporarily wind a pool down to zero and bring it back. Operators expect drain/force to be a lifecycle operation on the running nodes, not a destructive delete.

## How

- **`PoolSupervisor.stopPool`** now delegates to `scale(key, 0, RoleDistribution(0,0,0), force)`. The pool row survives, the in-memory state keeps an empty node list with a zero distribution, and the pool stays drained across a manager restart (reconcile only respawns when the persisted distribution is non-zero).
- **`PoolSupervisor.deletePool`** (new) keeps the old destructive behavior: stop nodes, then delete the pool and its node rows.
- New `DeletePoolRequest` DTO + circe codec, `POST /api/pool/delete` endpoint, and `deletePool` handler (tenant-scope checked like `stopPool`).
- UI: Drain/Force become plain "scale to 0" actions with updated confirm text; a new danger **Delete** button calls the delete endpoint.
- Operator runbook (`SKILL.md`) documents `pool/delete` and clarifies `pool/stop` semantics.

## Tests

- `PoolSupervisorSpec` / `PoolHandlersSpec`: updated stop assertions (pool kept, 0 nodes) and added delete cases.
- `FlightSqlRouterSpec` PinnedNodeGone test still passes (stopPool still removes nodes from the snapshot).
- 49 pool-spec tests pass; `tsc --noEmit` clean; changed Scala files scalafmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)