### PR TITLE
docs: reposition README around DuckLake serving layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,18 @@ API_KEY=
 TLS=true
 
 # ----- Host ports -----
+#
+# Only two ports are part of the public contract and need to be reachable
+# by users / BI tools:
+#   MANAGER_PORT (20900) - Manager REST API + React admin UI
+#   EDGE_PORT    (31338) - Arrow Flight SQL edge (TLS on by default)
+#
+# QUACK_MIN_PORT..QUACK_MAX_PORT (21900-22500) are the internal Quack node
+# child processes. They are published here only because docker-compose runs
+# the nodes as child processes inside the manager container and the manager
+# reaches them over localhost. Clients never connect to them; in Kubernetes
+# the nodes are separate pods and this range is not exposed at all. Do NOT
+# open this range on a public firewall.
 MANAGER_PORT=20900
 EDGE_PORT=31338
 QUACK_MIN_PORT=21900

--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ Jump to: [Quickstart](https://starlake-ai.github.io/quack-on-demand/getting-star
 
 |                              | DuckDB<br/>embedded | OSS Flight SQL servers<br/>(GizmoSQL, sqlflite) | MotherDuck | Trino /<br/>Dremio | **Quack on<br/>Demand** |
 |------------------------------|:---:|:---:|:---:|:---:|:---:|
+| Embedded / in-process        | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Self-hosted                  | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Open source                  | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Fully managed SaaS (zero ops)| ❌ | ❌ | ✅ | vendor cloud | ❌ |
 | Multi-user serving           | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Multi-tenant isolation       | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Table-level RBAC in OSS      | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Table-level RBAC            | ❌ | ❌ | ❌ | ✅ | ✅ |
 | Column security + masking    | ❌ | ❌ | ❌ | add-on | ✅ |
 | Autoscaling node pools       | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Distributed joins (TB-scale) | ❌ | ❌ | ❌ | ✅ | ❌ |
 | BI via JDBC / ODBC           | via files | ✅ | ✅ | ✅ | ✅ |
 | DuckLake-native catalog      | ✅ | partial | ✅ | ❌ | ✅ |
 | Footprint                    | library | single binary | SaaS | cluster | single uber-jar |


### PR DESCRIPTION
## Summary

Repositions the README around Quack on Demand as the open-source **serving layer for DuckLake**, and makes the competitive framing honest.

- Reframe the README intro and "Who is this for?" around the DuckLake serving-layer story
- Simplify the comparison table to bare icons
- Make the comparison table honest about where QoD loses: add **Embedded / in-process**, **Fully managed SaaS**, and **Distributed joins (TB-scale)** rows so each competitor is the sole winner on the axis the prose already names, instead of QoD showing a clean sweep
- Drop the misleading "in OSS" qualifier on the RBAC row and correct MotherDuck to **no** table-level RBAC (it is database-level access control only)
- Document public vs internal ports in `.env.example`: only `20900` (REST + UI) and `31338` (Flight SQL) are the public contract; `21900-22500` is the internal Quack node range

## Test plan

Docs only - no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)