### PR TITLE
docs: BI data-residency diagram + WSL run-jar tty fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ODBC strings, the Power BI walkthrough, ADBC `db_kwargs`, and the Python load te
 
 ```mermaid
 flowchart TD
-    client["Client<br/>(JDBC · ADBC · curl · browser)"]
+    client["Client<br/>(ODBC · JDBC · ADBC · curl · browser)"]
     manager["Manager<br/>FlightSQL edge · REST · UI"]
     nodes["Quack node pool<br/>DuckDB · per-tenant"]
     pg["Postgres<br/>control plane · DuckLake catalog"]
@@ -133,6 +133,30 @@ flowchart TD
 ```
 
 One Manager process fronts every client (FlightSQL on `:31338`, REST + admin UI on `:20900`) and routes each statement to a single Quack node it spawned for the matching tenant + pool. Control-plane state and per-tenant DuckLake catalogs live in Postgres; Parquet data lives in object storage. The full auth → ACL → routing pipeline diagram is in the [Architecture docs](https://starlake-ai.github.io/quack-on-demand/concepts/architecture).
+
+### Data residency - the base tables never leave the server
+
+When Power BI or Tableau connect with a **live / DirectQuery** connection, each user interaction issues SQL over the FlightSQL wire. The query runs on a Quack node, against DuckLake data that stays in your object storage, and only the *result rows* stream back as an Arrow batch. The base tables never cross the trust boundary onto the analyst's machine.
+
+```mermaid
+flowchart LR
+    subgraph client["BI client (Power BI / Tableau)"]
+        bi["user / password<br/>or OAuth (OIDC / JWT)"]
+    end
+
+    subgraph server["Quack on Demand · your infrastructure"]
+        edge["FlightSQL edge :31338<br/>authn + RBAC"]
+        node["Quack nodes<br/>DuckDB + DuckLake"]
+        store[("Postgres catalog +<br/>object storage<br/>S3 · GCS · FS")]
+        edge --> node
+        node -. data at rest .-> store
+    end
+
+    bi -- "SQL over TLS" --> edge
+    edge -- "Arrow result rows only" --> bi
+```
+
+> **Live / DirectQuery only.** Power BI **Import** mode and Tableau **extract** mode copy the full dataset into a local `.pbix` / `.hyper` file by design - that data lands on the client regardless of the gateway. Use a live / DirectQuery connection when server-side residency is the goal.
 
 ---
 

--- a/scripts/run-jar.sh
+++ b/scripts/run-jar.sh
@@ -359,14 +359,19 @@ rebuild_libquackwire_locally() {
   # 5. Publish all available classifiers into the local ivy cache so the
   # assembly task resolves them without round-tripping Central for the host.
   echo "sbt libquackwire/publishLocal..."
-  "$SBT_CMD" libquackwire/publishLocal
+  # </dev/null: keep sbt's JLine from seizing an interactive tty (raw/no-echo
+  # mode) on WSL. With a non-tty stdin JLine stays "dumb" and never reconfigures
+  # the pty -- the same reason CI runs never corrupt the terminal.
+  "$SBT_CMD" libquackwire/publishLocal </dev/null
 }
 
 build_locally() {
   ensure_sbt
   rebuild_libquackwire_locally
   echo "running '$SBT_CMD assembly' (local build)..."
-  "$SBT_CMD" assembly
+  # </dev/null: see the publishLocal note above -- prevents sbt/JLine from
+  # leaving the WSL pty in raw mode for the foreground java run that follows.
+  "$SBT_CMD" assembly </dev/null
   JAR="$(ls -t "$DISTRIB_DIR"/quack-on-demand-assembly-*.jar 2>/dev/null | head -n1 || true)"
   [[ -n "$JAR" ]] || { echo "ERROR: sbt assembly did not produce a jar in $DISTRIB_DIR" >&2; exit 1; }
 }
@@ -726,6 +731,10 @@ preflight_ports
 #                   leave the WSL pty in raw / no-echo mode. We do NOT
 #                   `exec` so the trap still fires after Java returns.
 trap 'stty sane 2>/dev/null || true' EXIT INT TERM
+# Reset the pty now, after the (possibly tty-grabbing) build/seed tooling and
+# before the long-lived foreground java run, so a corrupted terminal can't
+# persist for the manager's whole lifetime waiting on the EXIT trap.
+stty sane 2>/dev/null || true
 "${JAVA_BIN:-java}" \
   -Darrow.allocation.manager.type=Unsafe \
   ${JAVA_OPTS:-} \


### PR DESCRIPTION
## Summary
- Add a Mermaid **data-residency** diagram to the README showing that Power BI / Tableau **live (DirectQuery)** sessions keep base tables server-side: SQL over TLS in, Arrow result rows out, data at rest behind the trust boundary. Footnotes the Import/Extract caveat so the claim stays honest.
- Fix `run-jar.sh` so sbt/JLine no longer leaves the WSL pty in raw mode: redirect `publishLocal`/`assembly` stdin from `/dev/null` and reset the tty before the long-lived foreground java run.

## Notes
The diagram matches the existing Architecture Mermaid block's style and renders natively on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)