### PR TITLE
docs(admin): declarative manifest YAML per task + Manage by manifest page

### DIFF
--- a/website/docs/administration/access-control.md
+++ b/website/docs/administration/access-control.md
@@ -28,6 +28,26 @@ Access control is **off by default** (`acl.enabled=false`). Set `QOD_ACL_ENABLED
 
 5. Confirm the pool grant: in the **Users** tab, verify the user's row shows the pool grant for the target pool.
 
+**Manifest (YAML)**
+
+```yaml
+roles:
+  - tenant: acme
+    name: analyst
+    permissions:
+      - { catalog: acme_tpch, schema: tpch1, table: customer, verb: SELECT }
+groups:
+  - tenant: acme
+    name: analysts
+    roles: [analyst]
+users:
+  - tenant: acme
+    username: alice
+    groups: [analysts]
+    poolGrants:
+      - { pool: bi }
+```
+
 **REST equivalent:**
 
 The six steps below mirror the UI flow exactly. Surrogate ids (`<roleId>`, `<groupId>`, etc.) are returned by each create call; capture them from the JSON response.
@@ -94,6 +114,16 @@ The permission graph is: user -> roles (direct), user -> groups -> roles (via gr
    - `ALL` to cover every verb at once
 3. Save. The verbs are collapsed to `Read`, `Write`, or `Ddl` at enforcement time; see [Access control model](/operating/rbac-model) for the exact mapping.
 
+**Manifest (YAML)**
+
+```yaml
+roles:
+  - tenant: acme
+    name: loader
+    permissions:
+      - { catalog: acme_tpch, schema: tpch1, table: staging, verb: INSERT }
+```
+
 **REST equivalent:**
 
 ```bash
@@ -131,6 +161,8 @@ Replace `verb` with `UPDATE`, `DELETE`, `CREATE`, `DROP`, or `ALTER` as needed. 
 4. To delete a role permission entirely: open the **Roles** tab, edit the role, and delete the permission row.
 
 **Effect on active sessions:** `invalidateEffectiveCache()` is called on every RBAC mutation in `PoolSupervisor`. This drops the entire in-process EffectiveSet cache immediately, so the revoked grant takes effect on the **next handshake** - there is no TTL window to wait for.
+
+**Manifest (YAML):** Declaratively, remove the entry from its parent's nested list (a `permissions` entry on the role, or a role/group/grant on the user) and re-import; nested collections are replaced to match the file, so the omitted entry is deleted. Top-level roles, groups, and users are upsert-only, so this prunes grants, not whole roles. See [Manage by manifest](/administration/manage-by-manifest).
 
 **REST equivalent:**
 

--- a/website/docs/administration/access-control.md
+++ b/website/docs/administration/access-control.md
@@ -121,7 +121,7 @@ roles:
   - tenant: acme
     name: loader
     permissions:
-      - { catalog: acme_tpch, schema: tpch1, table: staging, verb: INSERT }
+      - { catalog: acme_tpch, schema: tpch1, table: orders, verb: INSERT }
 ```
 
 **REST equivalent:**

--- a/website/docs/administration/day-2-operations.md
+++ b/website/docs/administration/day-2-operations.md
@@ -66,6 +66,19 @@ Per-node fields surfaced via `/api/pool/list`:
 
 ![Pool detail](/img/ui/pool-detail.png)
 
+**Manifest (YAML)**
+
+Re-importing the manifest upserts the pool to this distribution, which is the scale operation.
+
+```yaml
+tenants:
+  - name: acme
+    pools:
+      - name: bi
+        tenantDb: acme_tpch
+        roleDistribution: { writeonly: 1, readonly: 2, dual: 3 }
+```
+
 **REST equivalent:**
 
 ```bash

--- a/website/docs/administration/index.md
+++ b/website/docs/administration/index.md
@@ -49,3 +49,9 @@ Use the table below to jump straight to the playbook for what you need to do.
 | Rotate a federated secret | [Rotate a federated secret](/administration/lifecycle-config#rotate-a-federated-secret) |
 | Back up and restore the control plane | [Back up and restore](/administration/lifecycle-config#back-up-and-restore) |
 | Decommission a tenant or pool | [Decommission](/administration/lifecycle-config#decommission) |
+
+**Configuration as code**
+
+| Task | Playbook |
+|------|----------|
+| Manage the whole config as YAML | [Manage by manifest](/administration/manage-by-manifest) |

--- a/website/docs/administration/lifecycle-config.md
+++ b/website/docs/administration/lifecycle-config.md
@@ -39,6 +39,7 @@ tenants:
             description: Prod warehouse Postgres
             setupSql: |
               INSTALL postgres; LOAD postgres;
+              CREATE OR REPLACE SECRET fedpg_sec (TYPE POSTGRES, HOST 'pg.prod', PORT 5432, DATABASE 'warehouse', USER 'svc_qod', PASSWORD '{{secret.PG_PWD}}');
               ATTACH '' AS {{alias}} (TYPE POSTGRES, SECRET fedpg_sec, READ_ONLY);
             secrets:
               - { name: PG_PWD, value: hunter2 }
@@ -102,6 +103,10 @@ tenants:
       - name: acme_fed
         federatedSources:
           - alias: fedpg
+            setupSql: |
+              INSTALL postgres; LOAD postgres;
+              CREATE OR REPLACE SECRET fedpg_sec (TYPE POSTGRES, HOST 'pg.prod', PORT 5432, DATABASE 'warehouse', USER 'svc_qod', PASSWORD '{{secret.PG_PWD}}');
+              ATTACH '' AS {{alias}} (TYPE POSTGRES, SECRET fedpg_sec, READ_ONLY);
             secrets:
               - { name: PG_PWD, value: <new-value> }
 ```

--- a/website/docs/administration/lifecycle-config.md
+++ b/website/docs/administration/lifecycle-config.md
@@ -27,6 +27,23 @@ Attach external catalogs, rotate secrets, back up and restore configuration, and
 5. Click **Add secret** and enter the secret name (e.g. `PG_PWD`) and its inline value (or an `externalRef` for an externally-managed secret).
 6. Save. The source takes effect the next time a node starts in this pool.
 
+**Manifest (YAML)**
+
+```yaml
+tenants:
+  - name: acme
+    tenantDbs:
+      - name: acme_fed
+        federatedSources:
+          - alias: fedpg
+            description: Prod warehouse Postgres
+            setupSql: |
+              INSTALL postgres; LOAD postgres;
+              ATTACH '' AS {{alias}} (TYPE POSTGRES, SECRET fedpg_sec, READ_ONLY);
+            secrets:
+              - { name: PG_PWD, value: hunter2 }
+```
+
 **REST equivalent**:
 
 ```bash
@@ -73,6 +90,21 @@ Placeholders in `setupSql`:
 3. Click the secret row and enter the new value. The `PUT` is an upsert; only the value field changes, not the `setupSql`.
 4. Go to the **Pools** tab and select the pool that uses this database.
 5. Click **Drain** to stop accepting new queries, then wait for in-flight statements to complete. Click **Scale** to bring nodes back up (or use **Force** if immediate replacement is acceptable). New nodes start with the updated secret value injected into their `setupSql`.
+
+**Manifest (YAML)**
+
+Re-import the full source with every secret you want to keep: omitted secrets under a listed source are pruned.
+
+```yaml
+tenants:
+  - name: acme
+    tenantDbs:
+      - name: acme_fed
+        federatedSources:
+          - alias: fedpg
+            secrets:
+              - { name: PG_PWD, value: <new-value> }
+```
 
 **REST equivalent**:
 
@@ -144,6 +176,8 @@ The import response is a JSON count: `{"tenants":2,"tenantDbs":3,"pools":4,...}`
 1. **Delete a pool**: Go to **Tenants**, select the tenant, open the **Pools** tab, select the pool, and click **Delete**. This stops all nodes and removes the pool from the registry. To stop nodes temporarily without removing the pool, click **Drain** instead.
 2. **Delete a tenant**: Once all pools are removed, go to **Tenants**, select the tenant, and click **Delete**.
 3. **Remove a user, role, or group**: Go to **Users**, select the tenant scope at the top, find the object on the appropriate tab, and click **Delete**.
+
+**Manifest (YAML):** Declaratively, drop a pool from a tenant that is still in the manifest and re-import; nested collections are replaced, so the omitted pool is pruned. Top-level tenants are upsert-only, so deleting a whole tenant uses the REST delete above, not omission. See [Manage by manifest](/administration/manage-by-manifest).
 
 **REST equivalent**:
 

--- a/website/docs/administration/manage-by-manifest.md
+++ b/website/docs/administration/manage-by-manifest.md
@@ -29,7 +29,7 @@ users:
   - { tenant: acme, username: alice, groups: [analysts], poolGrants: [{ pool: bi }] }
 ```
 
-`src/main/resources/bootstrap-demo.yaml` is a complete worked example.
+The fields `exportedAt` (an ISO-8601 instant) and `exportedFrom` (`{managerVersion, hostname}`) are required by the decoder and written automatically on export; when authoring a manifest from scratch, use any valid ISO-8601 instant and any `managerVersion`/`hostname` string, or start from `src/main/resources/bootstrap-demo.yaml`, which is a complete importable example.
 
 ## Export the current state
 
@@ -60,11 +60,10 @@ User passwords are omitted and secret values are redacted on export, so a downlo
 **REST equivalent**
 
 ```bash
-curl -sS -H "X-API-Key: $TOKEN" -H 'Content-Type: text/plain' \
-  --data-binary @manifest.yaml http://localhost:20900/api/manifest/import
+curl -sS -X POST -H "X-API-Key: $TOKEN" -H 'Content-Type: text/plain' --data-binary @manifest.yaml http://localhost:20900/api/manifest/import
 ```
 
-Import is upsert plus prune-within-parent: resources present in the YAML are created or updated; siblings omitted under a parent that IS in the YAML are deleted. For example, listing a tenant with two of its three pools deletes the third; a tenant absent from the YAML is left untouched. Re-supply any secret values, and set a `password` on a user to (re)set it.
+Import uses two different strategies depending on nesting level. At the top level the import is purely additive (upsert only): tenants, roles, groups, and users present in the YAML are created or updated; top-level resources absent from the manifest are left untouched - importing only `tenant: acme` does not delete `tenant: widgets`, and an omitted user is never deleted. Within a parent that IS in the manifest, nested collections are replaced (delete-then-upsert): the child collection in the database is made to match the manifest exactly, so a child absent from the YAML is deleted. For example, listing a tenant with only two of its three pools drops the third; a role's `permissions` and a user's `poolGrants` are fully replaced on import. Re-supply any secret values, and set a `password` on a user to (re)set it.
 
 **Verify:** re-export and diff, or confirm the change on the relevant Administration page (Nodes board, Users tab, and so on).
 

--- a/website/docs/administration/manage-by-manifest.md
+++ b/website/docs/administration/manage-by-manifest.md
@@ -1,0 +1,71 @@
+---
+id: manage-by-manifest
+title: Manage by manifest
+---
+
+The whole control plane is one declarative YAML document: every tenant, database, pool, role, group, user, grant, and federated source. The `Manifest (YAML)` blocks throughout this section are fragments of that document. Edit it, keep it under version control, and apply it by exporting the current state, changing the YAML, and re-importing. The field reference is on the [Manifest backup and restore](/operating/manifest) page.
+
+## Manifest shape
+
+```yaml
+apiVersion: quack-on-demand/v1
+kind: ConfigManifest
+tenants:
+  - name: acme
+    tenantDbs:
+      - { name: acme_tpch, kind: ducklake, defaultSchema: tpch1 }
+    pools:
+      - name: bi
+        tenantDb: acme_tpch
+        roleDistribution: { writeonly: 1, readonly: 1, dual: 1 }
+roles:
+  - tenant: acme
+    name: analyst
+    permissions:
+      - { catalog: acme_tpch, schema: tpch1, table: customer, verb: SELECT }
+groups:
+  - { tenant: acme, name: analysts, roles: [analyst] }
+users:
+  - { tenant: acme, username: alice, groups: [analysts], poolGrants: [{ pool: bi }] }
+```
+
+`src/main/resources/bootstrap-demo.yaml` is a complete worked example.
+
+## Export the current state
+
+**Goal:** capture the live control-plane configuration as YAML.
+
+**Prerequisites:** superuser session (export is cross-tenant; a tenant session is rejected with `403 superuser_required`).
+
+**Steps (UI):** open **Config** -> **Manifest** -> **Download YAML**.
+
+**REST equivalent**
+
+```bash
+curl -sS -H "X-API-Key: $TOKEN" http://localhost:20900/api/manifest/export > manifest.yaml
+```
+
+User passwords are omitted and secret values are redacted on export, so a downloaded manifest is safe to commit. Re-supply them on import.
+
+**Related:** [Manifest backup and restore](/operating/manifest).
+
+## Edit and re-import
+
+**Goal:** apply an edited manifest.
+
+**Prerequisites:** superuser session.
+
+**Steps (UI):** edit the YAML, then **Config** -> **Manifest** -> **Import**.
+
+**REST equivalent**
+
+```bash
+curl -sS -H "X-API-Key: $TOKEN" -H 'Content-Type: text/plain' \
+  --data-binary @manifest.yaml http://localhost:20900/api/manifest/import
+```
+
+Import is upsert plus prune-within-parent: resources present in the YAML are created or updated; siblings omitted under a parent that IS in the YAML are deleted. For example, listing a tenant with two of its three pools deletes the third; a tenant absent from the YAML is left untouched. Re-supply any secret values, and set a `password` on a user to (re)set it.
+
+**Verify:** re-export and diff, or confirm the change on the relevant Administration page (Nodes board, Users tab, and so on).
+
+**Related:** [Manifest backup and restore](/operating/manifest), [Back up and restore](/administration/lifecycle-config#back-up-and-restore).

--- a/website/docs/administration/onboarding.md
+++ b/website/docs/administration/onboarding.md
@@ -62,6 +62,16 @@ curl -H "X-API-Key: $TOKEN" http://localhost:20900/api/pool/list
 
 The form does not have a dedicated screenshot; it is a single-field dialog on the Tenants list page.
 
+**Manifest (YAML)**
+
+This is a fragment of the full config manifest; see [Manage by manifest](/administration/manage-by-manifest) to assemble and apply it.
+
+```yaml
+tenants:
+  - name: acme
+    displayName: Acme Corporation
+```
+
 **REST equivalent:**
 
 ```bash
@@ -103,6 +113,18 @@ curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/tenant/create
 5. Click **Create**.
 
 ![Databases tab](/img/ui/databases.png)
+
+**Manifest (YAML)**
+
+```yaml
+tenants:
+  - name: acme
+    tenantDbs:
+      - name: fed
+        kind: memory
+        defaultDatabase: fedpg
+        defaultSchema: public
+```
 
 **REST equivalent:**
 
@@ -153,6 +175,17 @@ curl -X POST -H "X-API-Key: $TOKEN" -H 'Content-Type: application/json' \
 5. Click **Create**.
 
 ![Pools tab](/img/ui/tenant-pools.png)
+
+**Manifest (YAML)**
+
+```yaml
+tenants:
+  - name: acme
+    pools:
+      - name: bi
+        tenantDb: acme_tpch
+        roleDistribution: { writeonly: 1, readonly: 1, dual: 1 }
+```
 
 **REST equivalent:**
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         'administration/access-control',
         'administration/day-2-operations',
         'administration/lifecycle-config',
+        'administration/manage-by-manifest',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Adds the **declarative (manifest YAML)** view to the Administration docs section, alongside the existing UI-first / REST playbooks.

- A `**Manifest (YAML)**` block above the REST block in each of the 8 **declarative** tasks: create tenant, add database, create/size pool, grant read access, grant DML/DDL, scale a pool, attach external catalog, rotate a federated secret. Runtime-only tasks (sign in, watch nodes, drain, verify, etc.) get no YAML block.
- One-line declarative pointers on **Revoke access** and **Decommission** (these are expressed by omission, not a block).
- A new **Manage by manifest** page (last in the Administration sidebar) covering the export -> edit -> re-import loop, the manifest envelope, and the import semantics.

## Manifest semantics (the important nuance)

Import is **top-level upsert-only, nested replace**:
- Top-level `tenants` / `roles` / `groups` / `users` absent from the file are left untouched (omitting a tenant does **not** delete it).
- Nested collections under a parent that IS in the file are made to match exactly, so an omitted pool / permission / grant is pruned.

The revoke and decommission pointers and the new page all reflect this precisely; deleting a whole tenant/role uses the imperative REST delete, not omission.

## Verification

- Every page gated on `npm run build` (`onBrokenLinks: 'throw'`); build passes.
- A final whole-branch review validated every YAML fragment field-by-field against `ConfigManifest.scala` and against each section's own REST block. It caught and fixed real bugs: the rotate-secret fragment was missing the required `setupSql`, the attach fragment's `setupSql` didn't create the secret it referenced, and a DML table name mismatched its REST. All resolved.
- Previewed locally (`docusaurus start`); the new pages and sidebar entry render and all internal links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
