### PR TITLE
docs(examples): TypeScript FlightSQL client with the 22 TPC-H queries

### DIFF
--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,143 @@
+# TypeScript FlightSQL example
+
+A minimal TypeScript client that runs a SQL query against the Quack-on-Demand
+FlightSQL edge and prints the Arrow result.
+
+Node has no first-party Flight SQL driver, so this talks to the edge over raw
+gRPC ([@grpc/grpc-js](https://www.npmjs.com/package/@grpc/grpc-js)) using a
+minimal slice of the Flight protocol (`src/proto/`), then decodes the Arrow
+result stream with [apache-arrow](https://www.npmjs.com/package/apache-arrow).
+
+## What it does
+
+1. `GetFlightInfo` with a `FlightDescriptor` whose `cmd` is an `Any`-wrapped
+   `CommandStatementQuery`. The edge returns a `FlightInfo` with one or more
+   endpoints, each carrying an opaque ticket.
+2. `DoGet(ticket)` for each endpoint, which streams `FlightData` chunks (an
+   Arrow IPC message header plus its body).
+3. The chunks are reassembled into a standard Arrow IPC stream and decoded into
+   a table.
+
+The edge authenticates every RPC from the call headers (`tenant`, `pool`,
+`authorization: Basic <base64>`), so there is no separate handshake step.
+
+## Run
+
+Always set `QOD_HOST` to point at your edge (`127.0.0.1` for a local one, or the
+remote host/IP otherwise). The commands below use the macOS/Linux shell syntax;
+for Windows see [Windows](#windows).
+
+```bash
+npm install
+QOD_HOST=127.0.0.1 npm run query
+```
+
+The defaults connect as the superuser `admin` against the `acme` tenant's `bi`
+pool and run a self-contained query that needs no loaded data. Pass your own SQL
+as an argument:
+
+```bash
+QOD_HOST=127.0.0.1 npm run query -- "SELECT count(*) FROM tpch1.customer"
+```
+
+### TPC-H benchmark
+
+`npm run tpch` runs the 22 standard TPC-H queries (with the spec's validation
+substitution parameters) against the `tpch1` schema and reports the row count,
+latency, and a first-row preview for each:
+
+```bash
+QOD_HOST=127.0.0.1 npm run tpch            # all 22 queries
+QOD_HOST=127.0.0.1 npm run tpch -- 1 6 14  # just queries 1, 6 and 14 (by id)
+```
+
+Set `QOD_TPCH_SCHEMA` to target a different schema. The queries live in
+`src/tpch-queries.ts`.
+
+## Configuration
+
+Every setting has an environment-variable override:
+
+| Variable          | Default     | Purpose                                                |
+| ----------------- | ----------- | ------------------------------------------------------ |
+| `QOD_HOST`        | `127.0.0.1` | Edge host                                              |
+| `QOD_PORT`        | `31338`     | Edge FlightSQL port                                    |
+| `QOD_USER`        | `admin`     | Basic-auth username                                    |
+| `QOD_PASSWORD`    | `admin`     | Basic-auth password                                    |
+| `QOD_TENANT`      | `acme`      | Tenant (routing)                                       |
+| `QOD_POOL`        | `bi`        | Pool within the tenant (routing)                       |
+| `QOD_SUPERUSER`   | `true`      | Send `superuser: true` (system realm, ACL bypass)      |
+| `QOD_TLS`         | `true`      | `false` connects in plaintext (`grpc://`)              |
+| `QOD_TLS_VERIFY`  | `false`     | `true` validates the cert chain against system trust   |
+| `QOD_SQL`         | demo query  | SQL to run (the CLI argument takes precedence)         |
+| `QOD_TPCH_SCHEMA` | `tpch1`     | Schema the TPC-H runner targets                        |
+
+By default `QOD_TLS_VERIFY=false`: the example pins the edge's auto-generated
+self-signed certificate off the wire and skips the hostname check. Set
+`QOD_TLS_VERIFY=true` once a CA-signed certificate is installed on the edge.
+
+## Connecting as a non-superuser
+
+Drop the superuser flag and authenticate as a tenant user (the per-statement
+ACL gate then applies, so the user must be granted access to the tables):
+
+```bash
+QOD_HOST=127.0.0.1 QOD_SUPERUSER=false QOD_USER=alice QOD_PASSWORD=demo-alice \
+  npm run query -- "SELECT count(*) FROM tpch1.customer"
+```
+
+## Windows
+
+The example itself is cross-platform; only the way you set environment
+variables differs from the macOS/Linux examples above. Node 18+ is required
+(install from [nodejs.org](https://nodejs.org/) or `winget install OpenJS.NodeJS`).
+
+### PowerShell
+
+Set each variable with `$env:NAME = "value"` before the `npm` command. The `--`
+separator still passes the SQL through to the script:
+
+```powershell
+npm install
+
+# Single query (default demo SQL)
+$env:QOD_HOST = "127.0.0.1"; npm run query
+
+# Single query with your own SQL
+$env:QOD_HOST = "127.0.0.1"; npm run query -- "SELECT count(*) FROM tpch1.customer"
+
+# All 22 TPC-H queries
+$env:QOD_HOST = "127.0.0.1"; npm run tpch
+
+# A subset of TPC-H queries by id
+$env:QOD_HOST = "127.0.0.1"; npm run tpch -- 1 6 14
+
+# Connect as a non-superuser tenant user
+$env:QOD_HOST = "127.0.0.1"; $env:QOD_SUPERUSER = "false"; $env:QOD_USER = "alice"; $env:QOD_PASSWORD = "demo-alice"; npm run query -- "SELECT count(*) FROM tpch1.customer"
+```
+
+`$env:` assignments persist for the rest of the PowerShell session, so once set
+you can drop them from subsequent commands. To clear one: `Remove-Item Env:\QOD_HOST`.
+
+### Command Prompt (cmd.exe)
+
+Use `set NAME=value` (no spaces around `=`) joined with `&&`:
+
+```bat
+npm install
+
+REM Single query (default demo SQL)
+set QOD_HOST=127.0.0.1 && npm run query
+
+REM Single query with your own SQL
+set QOD_HOST=127.0.0.1 && npm run query -- "SELECT count(*) FROM tpch1.customer"
+
+REM All 22 TPC-H queries
+set QOD_HOST=127.0.0.1 && npm run tpch
+
+REM A subset of TPC-H queries by id
+set QOD_HOST=127.0.0.1 && npm run tpch -- 1 6 14
+
+REM Connect as a non-superuser tenant user
+set QOD_HOST=127.0.0.1 && set QOD_SUPERUSER=false && set QOD_USER=alice && set QOD_PASSWORD=demo-alice && npm run query -- "SELECT count(*) FROM tpch1.customer"
+```

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "quack-on-demand-typescript-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "FlightSQL query client for Quack-on-Demand, in TypeScript over raw gRPC + Apache Arrow.",
+  "scripts": {
+    "query": "tsx src/query.ts",
+    "tpch": "tsx src/tpch.ts"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.10.9",
+    "@grpc/proto-loader": "^0.7.13",
+    "apache-arrow": "^17.0.0",
+    "protobufjs": "^7.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.3"
+  }
+}

--- a/examples/typescript/src/client.ts
+++ b/examples/typescript/src/client.ts
@@ -1,0 +1,234 @@
+// Reusable FlightSQL client for Quack-on-Demand.
+//
+// Node has no first-party Flight SQL driver, so this talks to the edge over
+// raw gRPC (@grpc/grpc-js) using a minimal slice of the Flight protocol
+// (src/proto/), then decodes the Arrow result stream with apache-arrow.
+//
+// The flow every Flight SQL client follows:
+//   1. GetFlightInfo with a FlightDescriptor whose cmd is an Any-wrapped
+//      CommandStatementQuery -> the edge returns a FlightInfo with endpoints,
+//      each carrying an opaque ticket.
+//   2. DoGet(ticket) for each endpoint -> a stream of FlightData (an Arrow IPC
+//      message header + body split across two fields).
+//   3. Reassemble the Arrow IPC stream from those chunks and decode it.
+//
+// The edge authenticates every RPC from the call headers (tenant, pool,
+// authorization), so there is no separate handshake step.
+import * as grpc from "@grpc/grpc-js";
+import * as protoLoader from "@grpc/proto-loader";
+import protobuf from "protobufjs";
+import * as tls from "node:tls";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { tableFromIPC, Table } from "apache-arrow";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const protoPath = (name: string) => path.join(here, "proto", name);
+
+const ANY_TYPE_URL =
+  "type.googleapis.com/arrow.flight.protocol.sql.CommandStatementQuery";
+
+export interface QodConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  tenant: string;
+  pool: string;
+  superuser: boolean;
+  tls: boolean;
+  tlsVerify: boolean;
+}
+
+// Build a config from QOD_* env vars, falling back to a local edge
+// (127.0.0.1:31338) and the superuser admin against the acme tenant's bi pool.
+export function configFromEnv(): QodConfig {
+  return {
+    host: process.env.QOD_HOST ?? "127.0.0.1",
+    port: Number(process.env.QOD_PORT ?? "31338"),
+    user: process.env.QOD_USER ?? "admin",
+    password: process.env.QOD_PASSWORD ?? "admin",
+    tenant: process.env.QOD_TENANT ?? "acme",
+    pool: process.env.QOD_POOL ?? "bi",
+    superuser: (process.env.QOD_SUPERUSER ?? "true") === "true",
+    tls: (process.env.QOD_TLS ?? "true") === "true",
+    tlsVerify: (process.env.QOD_TLS_VERIFY ?? "false") === "true",
+  };
+}
+
+interface FlightClient extends grpc.Client {
+  GetFlightInfo(
+    descriptor: unknown,
+    metadata: grpc.Metadata,
+    cb: (err: grpc.ServiceError | null, info: any) => void,
+  ): void;
+  DoGet(ticket: unknown, metadata: grpc.Metadata): grpc.ClientReadableStream<any>;
+}
+
+// Pull the server's self-signed leaf certificate off the wire and return it as
+// PEM, so it can be pinned as the gRPC root. Combined with a no-op
+// checkServerIdentity this is the JS equivalent of "skip verification".
+function fetchServerCertPem(host: string, port: number): Promise<string> {
+  const isIp = /^[\d.]+$/.test(host) || host.includes(":");
+  return new Promise((resolve, reject) => {
+    const socket = tls.connect(
+      { host, port, rejectUnauthorized: false, ...(isIp ? {} : { servername: host }) },
+      () => {
+        const cert = socket.getPeerCertificate(true);
+        socket.end();
+        if (!cert || !cert.raw) {
+          reject(new Error("server presented no certificate"));
+          return;
+        }
+        const b64 = cert.raw.toString("base64").match(/.{1,64}/g)!.join("\n");
+        resolve(`-----BEGIN CERTIFICATE-----\n${b64}\n-----END CERTIFICATE-----\n`);
+      },
+    );
+    socket.on("error", reject);
+  });
+}
+
+// A FlightData chunk carries an Arrow IPC message split into its flatbuffer
+// header (data_header) and its body (data_body). Reassemble the encapsulated
+// IPC message format the Arrow stream reader expects:
+//   [continuation 0xFFFFFFFF][int32 LE header length, padded to 8][header][body]
+function encapsulate(header: Buffer, body: Buffer): Buffer {
+  const padded = (header.length + 7) & ~7;
+  const prefix = Buffer.alloc(8 + padded); // padding bytes left as zero
+  prefix.writeUInt32LE(0xffffffff, 0);
+  prefix.writeInt32LE(padded, 4);
+  header.copy(prefix, 8);
+  return Buffer.concat([prefix, body]);
+}
+
+// 8-byte end-of-stream marker (continuation + zero length).
+const EOS = Buffer.from([0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00]);
+
+export class QodClient {
+  private constructor(
+    private readonly client: FlightClient,
+    private readonly cfg: QodConfig,
+    private readonly any: protobuf.Type,
+    private readonly cmd: protobuf.Type,
+  ) {}
+
+  static async connect(cfg: QodConfig): Promise<QodClient> {
+    const creds = await QodClient.credentials(cfg);
+
+    const pkgDef = protoLoader.loadSync(protoPath("flight.proto"), {
+      keepCase: true, // keep snake_case field names (data_header, data_body, ...)
+      longs: String,
+      enums: String, // DescriptorType comes back as 'CMD' etc.
+      defaults: true,
+      oneofs: true,
+    });
+    const proto = grpc.loadPackageDefinition(pkgDef) as any;
+    const FlightService = proto.arrow.flight.protocol.FlightService;
+
+    // grpc-js refuses to use an IP literal as the TLS server name. When we are
+    // skipping verification anyway, override the SSL target name with a
+    // placeholder hostname so the handshake proceeds against an IP target.
+    const options: grpc.ClientOptions = {};
+    if (cfg.tls && !cfg.tlsVerify) {
+      options["grpc.ssl_target_name_override"] = "quack-on-demand";
+      options["grpc.default_authority"] = "quack-on-demand";
+    }
+    const client: FlightClient = new FlightService(
+      `${cfg.host}:${cfg.port}`,
+      creds,
+      options,
+    );
+
+    const root = protobuf.loadSync(protoPath("flightsql.proto"));
+    const any = root.lookupType("arrow.flight.protocol.sql.Any");
+    const cmd = root.lookupType("arrow.flight.protocol.sql.CommandStatementQuery");
+    return new QodClient(client, cfg, any, cmd);
+  }
+
+  private static async credentials(cfg: QodConfig): Promise<grpc.ChannelCredentials> {
+    if (!cfg.tls) return grpc.credentials.createInsecure();
+    if (cfg.tlsVerify) return grpc.credentials.createSsl();
+    const pem = await fetchServerCertPem(cfg.host, cfg.port);
+    return grpc.credentials.createSsl(Buffer.from(pem), null, null, {
+      checkServerIdentity: () => undefined, // self-signed cert: skip hostname/IP match
+    });
+  }
+
+  describe(): string {
+    const proto = this.cfg.tls ? "grpc+tls" : "grpc";
+    const su = this.cfg.superuser ? " (superuser)" : "";
+    return `${proto}://${this.cfg.host}:${this.cfg.port} as ${this.cfg.user}@${this.cfg.tenant}/${this.cfg.pool}${su}`;
+  }
+
+  // The edge reads these headers on every RPC. authorization is HTTP Basic;
+  // tenant/pool route the query; superuser=true selects the system realm and
+  // bypasses the per-statement ACL gate.
+  private metadata(): grpc.Metadata {
+    const md = new grpc.Metadata();
+    md.set("tenant", this.cfg.tenant);
+    md.set("pool", this.cfg.pool);
+    const basic = Buffer.from(`${this.cfg.user}:${this.cfg.password}`).toString("base64");
+    md.set("authorization", `Basic ${basic}`);
+    if (this.cfg.superuser) md.set("superuser", "true");
+    return md;
+  }
+
+  // Build the FlightDescriptor.cmd: an Any-wrapped CommandStatementQuery.
+  private command(sql: string): Buffer {
+    const inner = this.cmd.encode({ query: sql }).finish();
+    // protobufjs exposes proto fields as camelCase, so `type_url` is `typeUrl`.
+    const any = this.any.encode({ typeUrl: ANY_TYPE_URL, value: inner }).finish();
+    return Buffer.from(any);
+  }
+
+  // Run one SQL statement and return the decoded Arrow table.
+  async query(sql: string): Promise<Table> {
+    const info = await new Promise<any>((resolve, reject) => {
+      this.client.GetFlightInfo(
+        { type: "CMD", cmd: this.command(sql) },
+        this.metadata(),
+        (err, resp) => (err ? reject(err) : resolve(resp)),
+      );
+    });
+
+    const messages: Buffer[] = [];
+    for (const endpoint of info.endpoint ?? []) {
+      await new Promise<void>((resolve, reject) => {
+        const stream = this.client.DoGet(
+          { ticket: endpoint.ticket.ticket },
+          this.metadata(),
+        );
+        stream.on("data", (fd: any) => {
+          const header: Buffer = fd.data_header ?? Buffer.alloc(0);
+          const body: Buffer = fd.data_body ?? Buffer.alloc(0);
+          if (header.length > 0) messages.push(encapsulate(header, body));
+        });
+        stream.on("end", resolve);
+        stream.on("error", reject);
+      });
+    }
+
+    return tableFromIPC(Buffer.concat([...messages, EOS]));
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}
+
+// Convert one Arrow row into a plain JSON-friendly object. Int64 columns come
+// back as BigInt and Decimal columns as DecimalBigNum objects, neither of which
+// JSON.stringify renders cleanly, so both are coerced to their string form.
+export function rowToObject(row: any, table: Table): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const field of table.schema.fields) {
+    const value = row[field.name];
+    out[field.name] =
+      typeof value === "bigint"
+        ? value.toString()
+        : value != null && typeof value === "object"
+          ? String(value)
+          : value;
+  }
+  return out;
+}

--- a/examples/typescript/src/proto/flight.proto
+++ b/examples/typescript/src/proto/flight.proto
@@ -1,0 +1,70 @@
+// Minimal subset of the Apache Arrow Flight protocol (Flight.proto).
+//
+// Only the messages and RPCs this example uses are declared: GetFlightInfo
+// (to plan the query) and DoGet (to stream the Arrow result). The full
+// protocol lives at https://github.com/apache/arrow/blob/main/format/Flight.proto
+syntax = "proto3";
+
+package arrow.flight.protocol;
+
+service FlightService {
+  rpc Handshake(stream HandshakeRequest) returns (stream HandshakeResponse) {}
+  rpc GetFlightInfo(FlightDescriptor) returns (FlightInfo) {}
+  rpc GetSchema(FlightDescriptor) returns (SchemaResult) {}
+  rpc DoGet(Ticket) returns (stream FlightData) {}
+}
+
+message HandshakeRequest {
+  uint64 protocol_version = 1;
+  bytes payload = 2;
+}
+
+message HandshakeResponse {
+  uint64 protocol_version = 1;
+  bytes payload = 2;
+}
+
+message SchemaResult {
+  bytes schema = 1;
+}
+
+message FlightDescriptor {
+  enum DescriptorType {
+    UNKNOWN = 0;
+    PATH = 1;
+    CMD = 2;
+  }
+  DescriptorType type = 1;
+  bytes cmd = 2;
+  repeated string path = 3;
+}
+
+message Ticket {
+  bytes ticket = 1;
+}
+
+message Location {
+  string uri = 1;
+}
+
+message FlightEndpoint {
+  Ticket ticket = 1;
+  repeated Location location = 2;
+}
+
+message FlightInfo {
+  bytes schema = 1;
+  FlightDescriptor flight_descriptor = 2;
+  repeated FlightEndpoint endpoint = 3;
+  int64 total_records = 4;
+  int64 total_bytes = 5;
+  bool ordered = 6;
+  bytes app_metadata = 7;
+}
+
+message FlightData {
+  FlightDescriptor flight_descriptor = 1;
+  bytes data_header = 2;
+  bytes app_metadata = 3;
+  bytes data_body = 1000;
+}

--- a/examples/typescript/src/proto/flightsql.proto
+++ b/examples/typescript/src/proto/flightsql.proto
@@ -1,0 +1,21 @@
+// Minimal subset of the Flight SQL protocol (FlightSql.proto).
+//
+// A SQL query is sent to the edge as a FlightDescriptor whose `cmd` is a
+// google.protobuf.Any wrapping a CommandStatementQuery. `Any` is declared
+// here as a plain message because its wire format (a string type_url and a
+// bytes value) is identical to google.protobuf.Any, so no well-known-type
+// import is needed. Full protocol:
+// https://github.com/apache/arrow/blob/main/format/FlightSql.proto
+syntax = "proto3";
+
+package arrow.flight.protocol.sql;
+
+message CommandStatementQuery {
+  string query = 1;
+  bytes transaction_id = 2;
+}
+
+message Any {
+  string type_url = 1;
+  bytes value = 2;
+}

--- a/examples/typescript/src/query.ts
+++ b/examples/typescript/src/query.ts
@@ -1,0 +1,36 @@
+// Run a single SQL statement against the Quack-on-Demand FlightSQL edge and
+// print the Arrow result.
+//
+// Run:  npm run query
+//       npm run query -- "SELECT count(*) FROM tpch1.customer"
+//
+// See client.ts for the gRPC + Arrow plumbing and src/proto/ for the protocol
+// subset. Connection settings come from QOD_* env vars (see README).
+import { QodClient, configFromEnv, rowToObject } from "./client.js";
+
+const SQL =
+  process.argv[2] ??
+  process.env.QOD_SQL ??
+  "SELECT * FROM (VALUES (1, 'duck'), (2, 'quack'), (3, 'lake')) AS t(id, label)";
+
+async function main(): Promise<void> {
+  const client = await QodClient.connect(configFromEnv());
+  console.log(`Connecting to ${client.describe()}`);
+  console.log(`SQL: ${SQL}\n`);
+
+  const table = await client.query(SQL);
+
+  const columns = table.schema.fields.map((f) => `${f.name}: ${f.type}`).join(", ");
+  console.log(`columns: ${columns}`);
+  console.log(`rows: ${table.numRows}\n`);
+  for (const row of table.toArray().slice(0, 100)) {
+    console.log(JSON.stringify(rowToObject(row, table)));
+  }
+
+  client.close();
+}
+
+main().catch((err) => {
+  console.error("\nquery failed:", err?.message ?? err);
+  process.exit(1);
+});

--- a/examples/typescript/src/tpch-queries.ts
+++ b/examples/typescript/src/tpch-queries.ts
@@ -1,0 +1,379 @@
+// The 22 TPC-H benchmark queries, with the standard validation substitution
+// parameters from the TPC-H specification (revision 2.x). Written in the DuckDB
+// SQL dialect, which the Quack nodes speak.
+//
+// Every table reference is prefixed with the `$S.` placeholder so the target
+// schema is configurable; the runner replaces `$S` with the schema name
+// (default `tpch1`). Q15, which the spec defines with a CREATE VIEW, is
+// expressed here as a single statement using a CTE so it fits one RPC.
+export interface TpchQuery {
+  id: number;
+  title: string;
+  sql: string;
+}
+
+export const TPCH_QUERIES: TpchQuery[] = [
+  {
+    id: 1,
+    title: "Pricing Summary Report",
+    sql: `
+select l_returnflag, l_linestatus,
+  sum(l_quantity) as sum_qty,
+  sum(l_extendedprice) as sum_base_price,
+  sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+  sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+  avg(l_quantity) as avg_qty,
+  avg(l_extendedprice) as avg_price,
+  avg(l_discount) as avg_disc,
+  count(*) as count_order
+from $S.lineitem
+where l_shipdate <= date '1998-12-01' - interval '90' day
+group by l_returnflag, l_linestatus
+order by l_returnflag, l_linestatus`,
+  },
+  {
+    id: 2,
+    title: "Minimum Cost Supplier",
+    sql: `
+select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
+from $S.part, $S.supplier, $S.partsupp, $S.nation, $S.region
+where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15
+  and p_type like '%BRASS' and s_nationkey = n_nationkey
+  and n_regionkey = r_regionkey and r_name = 'EUROPE'
+  and ps_supplycost = (
+    select min(ps_supplycost)
+    from $S.partsupp, $S.supplier, $S.nation, $S.region
+    where p_partkey = ps_partkey and s_suppkey = ps_suppkey
+      and s_nationkey = n_nationkey and n_regionkey = r_regionkey
+      and r_name = 'EUROPE')
+order by s_acctbal desc, n_name, s_name, p_partkey
+limit 100`,
+  },
+  {
+    id: 3,
+    title: "Shipping Priority",
+    sql: `
+select l_orderkey,
+  sum(l_extendedprice * (1 - l_discount)) as revenue,
+  o_orderdate, o_shippriority
+from $S.customer, $S.orders, $S.lineitem
+where c_mktsegment = 'BUILDING' and c_custkey = o_custkey
+  and l_orderkey = o_orderkey and o_orderdate < date '1995-03-15'
+  and l_shipdate > date '1995-03-15'
+group by l_orderkey, o_orderdate, o_shippriority
+order by revenue desc, o_orderdate
+limit 10`,
+  },
+  {
+    id: 4,
+    title: "Order Priority Checking",
+    sql: `
+select o_orderpriority, count(*) as order_count
+from $S.orders
+where o_orderdate >= date '1993-07-01'
+  and o_orderdate < date '1993-07-01' + interval '3' month
+  and exists (
+    select * from $S.lineitem
+    where l_orderkey = o_orderkey and l_commitdate < l_receiptdate)
+group by o_orderpriority
+order by o_orderpriority`,
+  },
+  {
+    id: 5,
+    title: "Local Supplier Volume",
+    sql: `
+select n_name, sum(l_extendedprice * (1 - l_discount)) as revenue
+from $S.customer, $S.orders, $S.lineitem, $S.supplier, $S.nation, $S.region
+where c_custkey = o_custkey and l_orderkey = o_orderkey
+  and l_suppkey = s_suppkey and c_nationkey = s_nationkey
+  and s_nationkey = n_nationkey and n_regionkey = r_regionkey
+  and r_name = 'ASIA' and o_orderdate >= date '1994-01-01'
+  and o_orderdate < date '1994-01-01' + interval '1' year
+group by n_name
+order by revenue desc`,
+  },
+  {
+    id: 6,
+    title: "Forecasting Revenue Change",
+    sql: `
+select sum(l_extendedprice * l_discount) as revenue
+from $S.lineitem
+where l_shipdate >= date '1994-01-01'
+  and l_shipdate < date '1994-01-01' + interval '1' year
+  and l_discount between 0.06 - 0.01 and 0.06 + 0.01
+  and l_quantity < 24`,
+  },
+  {
+    id: 7,
+    title: "Volume Shipping",
+    sql: `
+select supp_nation, cust_nation, l_year, sum(volume) as revenue
+from (
+  select n1.n_name as supp_nation, n2.n_name as cust_nation,
+    extract(year from l_shipdate) as l_year,
+    l_extendedprice * (1 - l_discount) as volume
+  from $S.supplier, $S.lineitem, $S.orders, $S.customer,
+       $S.nation n1, $S.nation n2
+  where s_suppkey = l_suppkey and o_orderkey = l_orderkey
+    and c_custkey = o_custkey and s_nationkey = n1.n_nationkey
+    and c_nationkey = n2.n_nationkey
+    and ((n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+      or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE'))
+    and l_shipdate between date '1995-01-01' and date '1996-12-31'
+) as shipping
+group by supp_nation, cust_nation, l_year
+order by supp_nation, cust_nation, l_year`,
+  },
+  {
+    id: 8,
+    title: "National Market Share",
+    sql: `
+select o_year,
+  sum(case when nation = 'BRAZIL' then volume else 0 end) / sum(volume) as mkt_share
+from (
+  select extract(year from o_orderdate) as o_year,
+    l_extendedprice * (1 - l_discount) as volume, n2.n_name as nation
+  from $S.part, $S.supplier, $S.lineitem, $S.orders, $S.customer,
+       $S.nation n1, $S.nation n2, $S.region
+  where p_partkey = l_partkey and s_suppkey = l_suppkey
+    and l_orderkey = o_orderkey and o_custkey = c_custkey
+    and c_nationkey = n1.n_nationkey and n1.n_regionkey = r_regionkey
+    and r_name = 'AMERICA' and s_nationkey = n2.n_nationkey
+    and o_orderdate between date '1995-01-01' and date '1996-12-31'
+    and p_type = 'ECONOMY ANODIZED STEEL'
+) as all_nations
+group by o_year
+order by o_year`,
+  },
+  {
+    id: 9,
+    title: "Product Type Profit Measure",
+    sql: `
+select nation, o_year, sum(amount) as sum_profit
+from (
+  select n_name as nation, extract(year from o_orderdate) as o_year,
+    l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+  from $S.part, $S.supplier, $S.lineitem, $S.partsupp, $S.orders, $S.nation
+  where s_suppkey = l_suppkey and ps_suppkey = l_suppkey
+    and ps_partkey = l_partkey and p_partkey = l_partkey
+    and o_orderkey = l_orderkey and s_nationkey = n_nationkey
+    and p_name like '%green%'
+) as profit
+group by nation, o_year
+order by nation, o_year desc`,
+  },
+  {
+    id: 10,
+    title: "Returned Item Reporting",
+    sql: `
+select c_custkey, c_name,
+  sum(l_extendedprice * (1 - l_discount)) as revenue,
+  c_acctbal, n_name, c_address, c_phone, c_comment
+from $S.customer, $S.orders, $S.lineitem, $S.nation
+where c_custkey = o_custkey and l_orderkey = o_orderkey
+  and o_orderdate >= date '1993-10-01'
+  and o_orderdate < date '1993-10-01' + interval '3' month
+  and l_returnflag = 'R' and c_nationkey = n_nationkey
+group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment
+order by revenue desc
+limit 20`,
+  },
+  {
+    id: 11,
+    title: "Important Stock Identification",
+    sql: `
+select ps_partkey, sum(ps_supplycost * ps_availqty) as value
+from $S.partsupp, $S.supplier, $S.nation
+where ps_suppkey = s_suppkey and s_nationkey = n_nationkey
+  and n_name = 'GERMANY'
+group by ps_partkey
+having sum(ps_supplycost * ps_availqty) > (
+  select sum(ps_supplycost * ps_availqty) * 0.0001000000
+  from $S.partsupp, $S.supplier, $S.nation
+  where ps_suppkey = s_suppkey and s_nationkey = n_nationkey
+    and n_name = 'GERMANY')
+order by value desc`,
+  },
+  {
+    id: 12,
+    title: "Shipping Modes and Order Priority",
+    sql: `
+select l_shipmode,
+  sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH'
+    then 1 else 0 end) as high_line_count,
+  sum(case when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH'
+    then 1 else 0 end) as low_line_count
+from $S.orders, $S.lineitem
+where o_orderkey = l_orderkey and l_shipmode in ('MAIL', 'SHIP')
+  and l_commitdate < l_receiptdate and l_shipdate < l_commitdate
+  and l_receiptdate >= date '1994-01-01'
+  and l_receiptdate < date '1994-01-01' + interval '1' year
+group by l_shipmode
+order by l_shipmode`,
+  },
+  {
+    id: 13,
+    title: "Customer Distribution",
+    sql: `
+select c_count, count(*) as custdist
+from (
+  select c_custkey, count(o_orderkey) as c_count
+  from $S.customer left outer join $S.orders
+    on c_custkey = o_custkey and o_comment not like '%special%requests%'
+  group by c_custkey
+) as c_orders
+group by c_count
+order by custdist desc, c_count desc`,
+  },
+  {
+    id: 14,
+    title: "Promotion Effect",
+    sql: `
+select 100.00 * sum(case when p_type like 'PROMO%'
+    then l_extendedprice * (1 - l_discount) else 0 end)
+  / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from $S.lineitem, $S.part
+where l_partkey = p_partkey and l_shipdate >= date '1995-09-01'
+  and l_shipdate < date '1995-09-01' + interval '1' month`,
+  },
+  {
+    id: 15,
+    title: "Top Supplier",
+    sql: `
+with revenue (supplier_no, total_revenue) as (
+  select l_suppkey, sum(l_extendedprice * (1 - l_discount))
+  from $S.lineitem
+  where l_shipdate >= date '1996-01-01'
+    and l_shipdate < date '1996-01-01' + interval '3' month
+  group by l_suppkey
+)
+select s_suppkey, s_name, s_address, s_phone, total_revenue
+from $S.supplier, revenue
+where s_suppkey = supplier_no
+  and total_revenue = (select max(total_revenue) from revenue)
+order by s_suppkey`,
+  },
+  {
+    id: 16,
+    title: "Parts/Supplier Relationship",
+    sql: `
+select p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
+from $S.partsupp, $S.part
+where p_partkey = ps_partkey and p_brand <> 'Brand#45'
+  and p_type not like 'MEDIUM POLISHED%'
+  and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+  and ps_suppkey not in (
+    select s_suppkey from $S.supplier
+    where s_comment like '%Customer%Complaints%')
+group by p_brand, p_type, p_size
+order by supplier_cnt desc, p_brand, p_type, p_size`,
+  },
+  {
+    id: 17,
+    title: "Small-Quantity-Order Revenue",
+    sql: `
+select sum(l_extendedprice) / 7.0 as avg_yearly
+from $S.lineitem, $S.part
+where p_partkey = l_partkey and p_brand = 'Brand#23'
+  and p_container = 'MED BOX'
+  and l_quantity < (
+    select 0.2 * avg(l_quantity)
+    from $S.lineitem where l_partkey = p_partkey)`,
+  },
+  {
+    id: 18,
+    title: "Large Volume Customer",
+    sql: `
+select c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice,
+  sum(l_quantity)
+from $S.customer, $S.orders, $S.lineitem
+where o_orderkey in (
+    select l_orderkey from $S.lineitem
+    group by l_orderkey having sum(l_quantity) > 300)
+  and c_custkey = o_custkey and o_orderkey = l_orderkey
+group by c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
+order by o_totalprice desc, o_orderdate
+limit 100`,
+  },
+  {
+    id: 19,
+    title: "Discounted Revenue",
+    sql: `
+select sum(l_extendedprice * (1 - l_discount)) as revenue
+from $S.lineitem, $S.part
+where (p_partkey = l_partkey and p_brand = 'Brand#12'
+    and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+    and l_quantity >= 1 and l_quantity <= 1 + 10 and p_size between 1 and 5
+    and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON')
+  or (p_partkey = l_partkey and p_brand = 'Brand#23'
+    and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+    and l_quantity >= 10 and l_quantity <= 10 + 10 and p_size between 1 and 10
+    and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON')
+  or (p_partkey = l_partkey and p_brand = 'Brand#34'
+    and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+    and l_quantity >= 20 and l_quantity <= 20 + 10 and p_size between 1 and 15
+    and l_shipmode in ('AIR', 'AIR REG') and l_shipinstruct = 'DELIVER IN PERSON')`,
+  },
+  {
+    id: 20,
+    title: "Potential Part Promotion",
+    sql: `
+select s_name, s_address
+from $S.supplier, $S.nation
+where s_suppkey in (
+    select ps_suppkey from $S.partsupp
+    where ps_partkey in (
+        select p_partkey from $S.part where p_name like 'forest%')
+      and ps_availqty > (
+        select 0.5 * sum(l_quantity) from $S.lineitem
+        where l_partkey = ps_partkey and l_suppkey = ps_suppkey
+          and l_shipdate >= date '1994-01-01'
+          and l_shipdate < date '1994-01-01' + interval '1' year))
+  and s_nationkey = n_nationkey and n_name = 'CANADA'
+order by s_name`,
+  },
+  {
+    id: 21,
+    title: "Suppliers Who Kept Orders Waiting",
+    sql: `
+select s_name, count(*) as numwait
+from $S.supplier, $S.lineitem l1, $S.orders, $S.nation
+where s_suppkey = l1.l_suppkey and o_orderkey = l1.l_orderkey
+  and o_orderstatus = 'F' and l1.l_receiptdate > l1.l_commitdate
+  and exists (
+    select * from $S.lineitem l2
+    where l2.l_orderkey = l1.l_orderkey and l2.l_suppkey <> l1.l_suppkey)
+  and not exists (
+    select * from $S.lineitem l3
+    where l3.l_orderkey = l1.l_orderkey and l3.l_suppkey <> l1.l_suppkey
+      and l3.l_receiptdate > l3.l_commitdate)
+  and s_nationkey = n_nationkey and n_name = 'SAUDI ARABIA'
+group by s_name
+order by numwait desc, s_name
+limit 100`,
+  },
+  {
+    id: 22,
+    title: "Global Sales Opportunity",
+    sql: `
+select cntrycode, count(*) as numcust, sum(c_acctbal) as totacctbal
+from (
+  select substring(c_phone from 1 for 2) as cntrycode, c_acctbal
+  from $S.customer
+  where substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17')
+    and c_acctbal > (
+      select avg(c_acctbal) from $S.customer
+      where c_acctbal > 0.00
+        and substring(c_phone from 1 for 2) in ('13', '31', '23', '29', '30', '18', '17'))
+    and not exists (
+      select * from $S.orders where o_custkey = c_custkey)
+) as custsale
+group by cntrycode
+order by cntrycode`,
+  },
+];
+
+// Resolve the `$S.` schema placeholder in a query to a concrete schema name.
+export function qualify(sql: string, schema: string): string {
+  return sql.replaceAll("$S", schema).trim();
+}

--- a/examples/typescript/src/tpch.ts
+++ b/examples/typescript/src/tpch.ts
@@ -1,0 +1,67 @@
+// Run the 22 TPC-H benchmark queries against the Quack-on-Demand FlightSQL edge
+// and report the row count, latency, and first-row preview for each.
+//
+// Run:  npm run tpch                  # all 22 queries
+//       npm run tpch -- 1 6 14        # just queries 1, 6 and 14
+//
+// The target schema defaults to `tpch1` (override with QOD_TPCH_SCHEMA); all
+// other connection settings come from the same QOD_* env vars query.ts uses
+// (see README). The defaults connect as the superuser admin to acme/bi.
+import { Table } from "apache-arrow";
+import { QodClient, configFromEnv, rowToObject } from "./client.js";
+import { TPCH_QUERIES, qualify } from "./tpch-queries.js";
+
+const SCHEMA = process.env.QOD_TPCH_SCHEMA ?? "tpch1";
+
+// Optional positional args select a subset of queries by id.
+const selected = process.argv.slice(2).map(Number).filter((n) => !Number.isNaN(n));
+const queries =
+  selected.length > 0
+    ? TPCH_QUERIES.filter((q) => selected.includes(q.id))
+    : TPCH_QUERIES;
+
+function previewRow(table: Table): string {
+  if (table.numRows === 0) return "(no rows)";
+  return JSON.stringify(rowToObject(table.toArray()[0], table));
+}
+
+async function main(): Promise<void> {
+  const client = await QodClient.connect(configFromEnv());
+  console.log(`Connecting to ${client.describe()}`);
+  console.log(`Running ${queries.length} TPC-H query(ies) against schema '${SCHEMA}'\n`);
+
+  let ok = 0;
+  let failed = 0;
+  let totalMs = 0;
+
+  for (const q of queries) {
+    const label = `Q${String(q.id).padStart(2, "0")} ${q.title}`;
+    const sql = qualify(q.sql, SCHEMA);
+    const startedNs = process.hrtime.bigint();
+    try {
+      const table = await client.query(sql);
+      const ms = Number(process.hrtime.bigint() - startedNs) / 1e6;
+      totalMs += ms;
+      ok += 1;
+      console.log(
+        `${label.padEnd(42)} ${ms.toFixed(0).padStart(6)} ms  ` +
+          `${String(table.numRows).padStart(6)} rows  ${previewRow(table)}`,
+      );
+    } catch (err: any) {
+      failed += 1;
+      console.log(`${label.padEnd(42)} FAILED  ${err?.message ?? err}`);
+    }
+  }
+
+  console.log(
+    `\n${ok} ok, ${failed} failed, ${totalMs.toFixed(0)} ms total ` +
+      `(${(totalMs / Math.max(ok, 1)).toFixed(0)} ms avg)`,
+  );
+  client.close();
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("\ntpch run failed:", err?.message ?? err);
+  process.exit(1);
+});

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Add a runnable TypeScript example under examples/typescript that connects to the FlightSQL edge over raw gRPC (Node has no first-party Flight SQL driver), runs SQL, and decodes the Arrow result stream with apache-arrow.

- src/client.ts: reusable QodClient (TLS with self-signed cert pinning, per-RPC header auth incl. superuser, Any-wrapped CommandStatementQuery, FlightData -> Arrow IPC reassembly, Decimal/Int64 row formatting)
- src/query.ts: single-query runner (npm run query)
- src/tpch.ts + src/tpch-queries.ts: the 22 standard TPC-H queries (spec validation parameters, DuckDB dialect, configurable schema) with per-query timing, row count, and preview (npm run tpch)
- src/proto: minimal Flight + FlightSQL protocol subset
- README: macOS/Linux and Windows (PowerShell + cmd) invocation

Verified end-to-end against a live edge: all 22 queries pass against acme/bi.