### PR TITLE
examples/n8n: catalog operations via FlightSQL commands

### DIFF
--- a/examples/n8n/README.md
+++ b/examples/n8n/README.md
@@ -10,11 +10,23 @@ and decodes the Arrow result stream with `apache-arrow`. The gRPC stack is
 bundles cleanly. The Flight protocol is inlined, so there is no `.proto` asset
 to ship.
 
-## Node
+## Operations
 
-**Quack on Demand → Execute Query.** Enter a SQL statement; the node runs it
-once per input item and emits one output item per result row. Int64 and Decimal
-columns are returned as strings so they serialize cleanly into n8n items.
+Each operation maps to a Flight SQL command the edge implements natively (no raw
+SQL workarounds). Int64 and Decimal columns are returned as strings so they
+serialize cleanly into n8n items.
+
+| Operation | Flight SQL command | Result columns |
+| --------- | ------------------ | -------------- |
+| **Execute Query** | `CommandStatementQuery` | your query's columns |
+| **List Catalogs** | `CommandGetCatalogs` | `catalog_name` |
+| **List Schemas** | `CommandGetDbSchemas` | `catalog_name`, `db_schema_name` |
+| **List Tables** | `CommandGetTables` | `catalog_name`, `db_schema_name`, `table_name`, `table_type` |
+
+- **Execute Query** runs once per input item and emits one output item per row.
+- **List Schemas** / **List Tables** accept optional LIKE filters (e.g. `tpch%`).
+- **List Tables** offers a **Schema** dropdown populated from the edge's schemas
+  (via `CommandGetDbSchemas`), so you can browse without typing SQL.
 
 ## Credentials
 

--- a/examples/n8n/nodes/QuackOnDemand/QodClient.ts
+++ b/examples/n8n/nodes/QuackOnDemand/QodClient.ts
@@ -14,9 +14,6 @@ import * as protobuf from 'protobufjs';
 import * as tls from 'node:tls';
 import { tableFromIPC, Table } from 'apache-arrow';
 
-const ANY_TYPE_URL =
-	'type.googleapis.com/arrow.flight.protocol.sql.CommandStatementQuery';
-
 // Minimal slice of Apache Arrow Flight (Flight.proto): only the messages and
 // RPCs this client uses.
 const FLIGHT_PROTO = `
@@ -72,6 +69,24 @@ message CommandStatementQuery {
   bytes transaction_id = 2;
 }
 
+// Catalog metadata commands. The edge implements all of these (it resolves them
+// against DuckDB's information_schema server-side); the client just wraps them
+// in an Any and rides the same GetFlightInfo/DoGet path as a statement query.
+message CommandGetCatalogs {}
+
+message CommandGetDbSchemas {
+  optional string catalog = 1;
+  optional string db_schema_filter_pattern = 2;
+}
+
+message CommandGetTables {
+  optional string catalog = 1;
+  optional string db_schema_filter_pattern = 2;
+  optional string table_name_filter_pattern = 3;
+  repeated string table_types = 4;
+  bool include_schema = 5;
+}
+
 message Any {
   string type_url = 1;
   bytes value = 2;
@@ -89,6 +104,19 @@ export interface QodConfig {
 	tls: boolean;
 	tlsVerify: boolean;
 }
+
+export interface SchemaFilter {
+	catalog?: string;
+	schemaPattern?: string;
+}
+
+export interface TableFilter {
+	catalog?: string;
+	schemaPattern?: string;
+	tablePattern?: string;
+}
+
+export type Row = Record<string, unknown>;
 
 interface FlightClient extends grpc.Client {
 	GetFlightInfo(
@@ -157,8 +185,8 @@ export class QodClient {
 	private constructor(
 		private readonly client: FlightClient,
 		private readonly cfg: QodConfig,
+		private readonly root: protobuf.Root,
 		private readonly any: protobuf.Type,
-		private readonly cmd: protobuf.Type,
 	) {}
 
 	static async connect(cfg: QodConfig): Promise<QodClient> {
@@ -188,8 +216,7 @@ export class QodClient {
 		const client: FlightClient = new FlightService(`${cfg.host}:${cfg.port}`, creds, options);
 
 		const any = root.lookupType('arrow.flight.protocol.sql.Any');
-		const cmd = root.lookupType('arrow.flight.protocol.sql.CommandStatementQuery');
-		return new QodClient(client, cfg, any, cmd);
+		return new QodClient(client, cfg, root, any);
 	}
 
 	private static async credentials(cfg: QodConfig): Promise<grpc.ChannelCredentials> {
@@ -214,19 +241,25 @@ export class QodClient {
 		return md;
 	}
 
-	// Build the FlightDescriptor.cmd: an Any-wrapped CommandStatementQuery.
-	private command(sql: string): Buffer {
-		const inner = this.cmd.encode({ query: sql }).finish();
+	// Wrap a Flight SQL command message in a protobuf Any (the FlightDescriptor.cmd
+	// payload). `typeName` is the fully-qualified proto name, which is also the
+	// Any type_url suffix the edge dispatches on.
+	private pack(typeName: string, payload: Row): Buffer {
+		const messageType = this.root.lookupType(typeName);
+		const value = messageType.encode(payload).finish();
 		// protobufjs exposes proto fields as camelCase, so `type_url` is `typeUrl`.
-		const any = this.any.encode({ typeUrl: ANY_TYPE_URL, value: inner }).finish();
+		const any = this.any
+			.encode({ typeUrl: `type.googleapis.com/${typeName}`, value })
+			.finish();
 		return Buffer.from(any);
 	}
 
-	// Run one SQL statement and return the rows as plain objects.
-	async query(sql: string): Promise<Array<Record<string, unknown>>> {
+	// GetFlightInfo(cmd) then DoGet every endpoint, reassembling the Arrow IPC
+	// stream and returning the decoded rows. Shared by every command below.
+	private async runCommand(cmd: Buffer): Promise<Row[]> {
 		const info = await new Promise<any>((resolve, reject) => {
 			this.client.GetFlightInfo(
-				{ type: 'CMD', cmd: this.command(sql) },
+				{ type: 'CMD', cmd },
 				this.metadata(),
 				(err, resp) => (err ? reject(err) : resolve(resp)),
 			);
@@ -251,6 +284,39 @@ export class QodClient {
 
 		const table = tableFromIPC(Buffer.concat([...messages, EOS]));
 		return table.toArray().map((row) => rowToObject(row, table));
+	}
+
+	// Run one SQL statement (CommandStatementQuery) and return the rows.
+	async query(sql: string): Promise<Row[]> {
+		return this.runCommand(
+			this.pack('arrow.flight.protocol.sql.CommandStatementQuery', { query: sql }),
+		);
+	}
+
+	// List catalogs (CommandGetCatalogs). Columns: catalog_name.
+	async getCatalogs(): Promise<Row[]> {
+		return this.runCommand(this.pack('arrow.flight.protocol.sql.CommandGetCatalogs', {}));
+	}
+
+	// List schemas (CommandGetDbSchemas). Columns: catalog_name, db_schema_name.
+	// Filters are LIKE patterns server-side (an exact name matches itself).
+	async getSchemas(filter: SchemaFilter = {}): Promise<Row[]> {
+		const payload: Row = {};
+		if (filter.catalog) payload.catalog = filter.catalog;
+		if (filter.schemaPattern) payload.dbSchemaFilterPattern = filter.schemaPattern;
+		return this.runCommand(
+			this.pack('arrow.flight.protocol.sql.CommandGetDbSchemas', payload),
+		);
+	}
+
+	// List tables (CommandGetTables). Columns: catalog_name, db_schema_name,
+	// table_name, table_type.
+	async getTables(filter: TableFilter = {}): Promise<Row[]> {
+		const payload: Row = {};
+		if (filter.catalog) payload.catalog = filter.catalog;
+		if (filter.schemaPattern) payload.dbSchemaFilterPattern = filter.schemaPattern;
+		if (filter.tablePattern) payload.tableNameFilterPattern = filter.tablePattern;
+		return this.runCommand(this.pack('arrow.flight.protocol.sql.CommandGetTables', payload));
 	}
 
 	close(): void {

--- a/examples/n8n/nodes/QuackOnDemand/QuackOnDemand.node.ts
+++ b/examples/n8n/nodes/QuackOnDemand/QuackOnDemand.node.ts
@@ -1,7 +1,9 @@
 import {
 	IDataObject,
 	IExecuteFunctions,
+	ILoadOptionsFunctions,
 	INodeExecutionData,
+	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
 	NodeOperationError,
@@ -16,8 +18,8 @@ export class QuackOnDemand implements INodeType {
 		icon: 'file:qod.svg',
 		group: ['transform'],
 		version: 1,
-		subtitle: '={{ "Execute query" }}',
-		description: 'Run SQL against a Quack on Demand FlightSQL edge',
+		subtitle: '={{ $parameter["operation"] }}',
+		description: 'Run SQL and browse the catalog on a Quack on Demand FlightSQL edge',
 		defaults: { name: 'Quack on Demand' },
 		inputs: ['main'],
 		outputs: ['main'],
@@ -35,6 +37,24 @@ export class QuackOnDemand implements INodeType {
 						description: 'Run a SQL statement and return the rows',
 						action: 'Execute a SQL query',
 					},
+					{
+						name: 'List Catalogs',
+						value: 'listCatalogs',
+						description: 'List catalogs via the FlightSQL GetCatalogs command',
+						action: 'List catalogs',
+					},
+					{
+						name: 'List Schemas',
+						value: 'listSchemas',
+						description: 'List schemas via the FlightSQL GetDbSchemas command',
+						action: 'List schemas',
+					},
+					{
+						name: 'List Tables',
+						value: 'listTables',
+						description: 'List tables via the FlightSQL GetTables command',
+						action: 'List tables',
+					},
 				],
 				default: 'executeQuery',
 			},
@@ -47,30 +67,101 @@ export class QuackOnDemand implements INodeType {
 				placeholder: 'SELECT * FROM tpch1.customer LIMIT 100',
 				required: true,
 				description: 'The SQL statement to run. Runs once per input item.',
+				displayOptions: { show: { operation: ['executeQuery'] } },
+			},
+			{
+				displayName: 'Schema Name or ID',
+				name: 'schema',
+				type: 'options',
+				typeOptions: { loadOptionsMethod: 'getSchemas' },
+				default: '',
+				description:
+					'Schema to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Leave empty for all schemas.',
+				displayOptions: { show: { operation: ['listTables'] } },
+			},
+			{
+				displayName: 'Schema Filter',
+				name: 'schemaPattern',
+				type: 'string',
+				default: '',
+				placeholder: 'tpch%',
+				description: 'Optional LIKE pattern to filter schema names. Leave empty for all schemas.',
+				displayOptions: { show: { operation: ['listSchemas'] } },
+			},
+			{
+				displayName: 'Table Filter',
+				name: 'tablePattern',
+				type: 'string',
+				default: '',
+				placeholder: 'cust%',
+				description: 'Optional LIKE pattern to filter table names. Leave empty for all tables.',
+				displayOptions: { show: { operation: ['listTables'] } },
 			},
 		],
 	};
 
+	methods = {
+		loadOptions: {
+			// Populate the "Schema" dropdown for List Tables by asking the edge for
+			// its schemas over the FlightSQL GetDbSchemas command.
+			async getSchemas(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+				const client = await QodClient.connect(await credentialsToConfig(this));
+				try {
+					const rows = await client.getSchemas();
+					return rows
+						.map((r) => String(r.db_schema_name ?? ''))
+						.filter((name) => name.length > 0)
+						.map((name) => ({ name, value: name }));
+				} finally {
+					client.close();
+				}
+			},
+		},
+	};
+
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
-		const cfg = await credentialsToConfig(this);
-
-		const client = await QodClient.connect(cfg);
+		const operation = this.getNodeParameter('operation', 0) as string;
+		const client = await QodClient.connect(await credentialsToConfig(this));
 		const out: INodeExecutionData[] = [];
+
+		const emit = (rows: Array<Record<string, unknown>>, item: number) => {
+			for (const row of rows) {
+				out.push({ json: row as IDataObject, pairedItem: { item } });
+			}
+		};
+
 		try {
+			// The catalog operations take no per-item input, so run them once.
+			if (operation !== 'executeQuery') {
+				try {
+					if (operation === 'listCatalogs') {
+						emit(await client.getCatalogs(), 0);
+					} else if (operation === 'listSchemas') {
+						const schemaPattern = (this.getNodeParameter('schemaPattern', 0) as string) || undefined;
+						emit(await client.getSchemas({ schemaPattern }), 0);
+					} else if (operation === 'listTables') {
+						const schemaPattern = (this.getNodeParameter('schema', 0) as string) || undefined;
+						const tablePattern = (this.getNodeParameter('tablePattern', 0) as string) || undefined;
+						emit(await client.getTables({ schemaPattern, tablePattern }), 0);
+					}
+				} catch (error) {
+					if (!this.continueOnFail()) {
+						throw new NodeOperationError(this.getNode(), error as Error);
+					}
+					out.push({ json: { error: (error as Error).message } });
+				}
+				return [out];
+			}
+
+			// Execute Query: run the statement once per input item.
 			for (let i = 0; i < items.length; i++) {
 				const sql = this.getNodeParameter('query', i) as string;
 				try {
-					const rows = await client.query(sql);
-					for (const row of rows) {
-						out.push({ json: row as IDataObject, pairedItem: { item: i } });
-					}
+					emit(await client.query(sql), i);
 				} catch (error) {
 					if (this.continueOnFail()) {
-						out.push({
-							json: { error: (error as Error).message },
-							pairedItem: { item: i },
-						});
+						out.push({ json: { error: (error as Error).message }, pairedItem: { item: i } });
 						continue;
 					}
 					throw new NodeOperationError(this.getNode(), error as Error, { itemIndex: i });
@@ -84,7 +175,9 @@ export class QuackOnDemand implements INodeType {
 	}
 }
 
-async function credentialsToConfig(ctx: IExecuteFunctions): Promise<QodConfig> {
+async function credentialsToConfig(
+	ctx: IExecuteFunctions | ILoadOptionsFunctions,
+): Promise<QodConfig> {
 	const c = await ctx.getCredentials('quackOnDemandApi');
 	return {
 		host: c.host as string,


### PR DESCRIPTION
Extends the n8n community node so it speaks the Flight SQL **catalog commands** the edge implements natively, instead of being limited to `CommandStatementQuery`. This addresses the misconception (seen by a node user) that the edge only implements `CommandGetCatalogs` and that schema/table listing needs raw `information_schema` SQL. The edge implements the full set; the node just needed to send the commands.

## Changes

- **`QodClient`**: refactored to a generic `pack()` + `runCommand()` over `GetFlightInfo` + `DoGet`, then added:
  - `getCatalogs()` → `CommandGetCatalogs`
  - `getSchemas({ catalog?, schemaPattern? })` → `CommandGetDbSchemas`
  - `getTables({ catalog?, schemaPattern?, tablePattern? })` → `CommandGetTables`

  The three command messages are inlined in the proto (no `.proto` asset shipped).
- **Node**: `List Catalogs`, `List Schemas`, `List Tables` operations alongside `Execute Query`, plus a **Schema** dropdown (`loadOptions`) populated via `CommandGetDbSchemas` so users can browse without SQL.
- **README**: operation-to-command mapping table.

## Naming note

The wire command for schemas is **`CommandGetDbSchemas`**, not `CommandGetSchemas` (which does not exist in the Flight SQL protocol). The client-facing verb is `getSchemas`, but the message on the wire is `CommandGetDbSchemas` - matching the edge handler `getFlightInfoSchemas(command: FlightSql.CommandGetDbSchemas, ...)`.

## Verification

Built clean and run against a live edge (`acme/bi`, superuser):

- `GetCatalogs` → `acme_tpch`
- `GetDbSchemas` → `main`, `tpch1`, ...; pattern `tpch%` → `tpch1`
- `GetTables` (schema `tpch1`) → the 8 TPC-H tables
- `CommandStatementQuery` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)