### PR TITLE
chore(examples/n8n): publish-ready packaging + lint

### DIFF
--- a/.github/workflows/n8n-node.yml
+++ b/.github/workflows/n8n-node.yml
@@ -1,0 +1,35 @@
+name: n8n node
+
+# Lint + build the n8n community node example on changes under examples/n8n.
+# The package has no committed lockfile (gitignored) and n8n-workflow pulls a
+# native dev dependency, so we use `npm install --ignore-scripts` (enough for
+# the eslint + tsc checks; runtime deps are pure JS).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/n8n/**'
+      - '.github/workflows/n8n-node.yml'
+  pull_request:
+    paths:
+      - 'examples/n8n/**'
+      - '.github/workflows/n8n-node.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/n8n
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install --ignore-scripts
+      - run: npm run lint
+      - run: npm run build

--- a/examples/n8n/.eslintrc.js
+++ b/examples/n8n/.eslintrc.js
@@ -1,0 +1,43 @@
+/**
+ * ESLint config for the n8n community node, using eslint-plugin-n8n-nodes-base
+ * so the package meets n8n's node/credential conventions before publishing.
+ */
+module.exports = {
+	root: true,
+	env: { node: true, es2021: true },
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		sourceType: 'module',
+		extraFileExtensions: ['.json'],
+	},
+	ignorePatterns: ['.eslintrc.js', 'scripts/**', '**/*.js', '**/node_modules/**', 'dist/**'],
+	overrides: [
+		{
+			files: ['package.json'],
+			plugins: ['eslint-plugin-n8n-nodes-base'],
+			extends: ['plugin:n8n-nodes-base/community'],
+			rules: {
+				'n8n-nodes-base/community-package-json-name-still-default': 'error',
+				// This package is Apache-2.0 (matching the parent repo), not the MIT
+				// the plugin nudges community nodes toward.
+				'n8n-nodes-base/community-package-json-license-not-default': 'off',
+			},
+		},
+		{
+			files: ['./credentials/**/*.ts'],
+			plugins: ['eslint-plugin-n8n-nodes-base'],
+			extends: ['plugin:n8n-nodes-base/credentials'],
+			rules: {
+				// documentationUrl is a full HTTPS URL (which the companion
+				// cred-class-field-documentation-url-not-http-url rule requires). The
+				// -miscased rule contradicts it by camel-casing valid URLs, so disable it.
+				'n8n-nodes-base/cred-class-field-documentation-url-miscased': 'off',
+			},
+		},
+		{
+			files: ['./nodes/**/*.ts'],
+			plugins: ['eslint-plugin-n8n-nodes-base'],
+			extends: ['plugin:n8n-nodes-base/nodes'],
+		},
+	],
+};

--- a/examples/n8n/LICENSE
+++ b/examples/n8n/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/n8n/README.md
+++ b/examples/n8n/README.md
@@ -63,6 +63,23 @@ cd ~/.n8n/custom && npm link n8n-nodes-quack-on-demand
 # then restart n8n
 ```
 
+## Publishing to npm
+
+This package is set up to publish as a community node (installable on
+self-hosted n8n). It is **not eligible for n8n verification / n8n Cloud**: verified
+nodes may not declare runtime dependencies, and this node bundles `@grpc/grpc-js`,
+`@grpc/proto-loader`, `apache-arrow`, and `protobufjs`.
+
+```bash
+npm install
+npm run lint     # n8n node conventions (eslint-plugin-n8n-nodes-base)
+npm run build    # emits dist/ and copies the icon
+npm publish      # publishConfig.access is already "public"
+```
+
+`prepublishOnly` re-runs build and lint. After publishing, install it from
+**Settings → Community Nodes** using the package name `n8n-nodes-quack-on-demand`.
+
 ## Notes and limitations
 
 - **Self-hosted only in practice.** A Code node cannot `require` these npm

--- a/examples/n8n/nodes/QuackOnDemand/QuackOnDemand.node.ts
+++ b/examples/n8n/nodes/QuackOnDemand/QuackOnDemand.node.ts
@@ -76,7 +76,7 @@ export class QuackOnDemand implements INodeType {
 				typeOptions: { loadOptionsMethod: 'getSchemas' },
 				default: '',
 				description:
-					'Schema to filter by. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Leave empty for all schemas.',
+					'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 				displayOptions: { show: { operation: ['listTables'] } },
 			},
 			{

--- a/examples/n8n/package.json
+++ b/examples/n8n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-quack-on-demand",
   "version": "0.1.0",
-  "description": "n8n community node to run SQL against a Quack on Demand FlightSQL edge",
+  "description": "n8n community node to run SQL and browse the catalog on a Quack on Demand FlightSQL edge",
   "keywords": [
     "n8n-community-node-package",
     "quack-on-demand",
@@ -10,16 +10,36 @@
     "arrow"
   ],
   "license": "Apache-2.0",
+  "author": {
+    "name": "Starlake",
+    "url": "https://starlake.ai"
+  },
   "homepage": "https://github.com/starlake-ai/quack-on-demand",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/starlake-ai/quack-on-demand.git",
+    "directory": "examples/n8n"
+  },
+  "bugs": {
+    "url": "https://github.com/starlake-ai/quack-on-demand/issues"
+  },
+  "engines": {
+    "node": ">=18.10"
+  },
   "main": "index.js",
   "scripts": {
     "build": "tsc && node scripts/copy-icons.mjs",
     "dev": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "lint": "eslint nodes credentials package.json",
+    "lintfix": "eslint nodes credentials package.json --fix",
+    "prepublishOnly": "npm run build && npm run lint"
   },
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "n8n": {
     "n8nNodesApiVersion": 1,
     "credentials": [
@@ -40,6 +60,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.10",
+    "@typescript-eslint/parser": "^7.16.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-n8n-nodes-base": "^1.16.3",
     "n8n-workflow": "^1.60.0",
     "typescript": "^5.5.3"
   }


### PR DESCRIPTION
Prepares the n8n community node for `npm publish` (self-hosted install). Follow-up to #51.

## Changes

- **package.json**: `author`, `repository` (with `directory: examples/n8n`), `bugs`, `engines`, and `publishConfig.access: public`; `lint` / `lintfix` scripts and eslint devDeps; `prepublishOnly` now runs build + lint.
- **.eslintrc.js**: `eslint-plugin-n8n-nodes-base` (community + credentials + nodes rulesets). Two rules disabled with justification:
  - `community-package-json-license-not-default` - the package is Apache-2.0 to match the parent repo, not MIT.
  - `cred-class-field-documentation-url-miscased` - it camel-cases valid HTTPS URLs, contradicting `cred-class-field-documentation-url-not-http-url`.
- **LICENSE**: ship the Apache-2.0 text inside the package.
- **README**: a Publishing section, and an explicit note that verification / n8n Cloud is **not** available because the node declares runtime dependencies (gRPC, Arrow). Verified nodes may not have runtime deps.
- **Node**: canonical dynamic-options description string to satisfy the linter.

## Verification

- `npm run lint` passes (exit 0).
- `npm run build` clean.
- `npm pack --dry-run` ships `dist/` (compiled node + credentials + icon), `LICENSE`, `README.md`, `index.js`, `package.json`.
- Smoke-tested against a live edge after the changes: getSchemas with pattern `tpch%` returns `tpch1`, and `SELECT 1` returns one row.

Publishing itself (`npm publish`) is intentionally left to the maintainer's npm account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)