### PR TITLE
Windows: run-jar.ps1 full parity with run-jar.sh + PowerShell demo loaders

### DIFF
--- a/guides/RUNNING.md
+++ b/guides/RUNNING.md
@@ -131,8 +131,9 @@ has PowerShell twins and the node-spawn path is a PowerShell mirror of
 - Windows PowerShell 5+ (ships with Windows) — used to spawn Quack nodes
 - A reachable **PostgreSQL 16+** (native Windows install, a container, or a
   network host). `psql` is *optional* — the manager provisions its own
-  control-plane and tenant DBs; when `psql` is present `run-jar.ps1` also runs
-  a reachability probe.
+  control-plane and tenant DBs; when `psql` is present `run-jar.ps1` additionally
+  runs a reachability probe, enforces the PG16+ version gate, creates the
+  control-plane DB up-front, and enables the `NUKE=1` / `LOAD_*` flows.
 - DuckDB is **self-installed** by `run-jar.ps1` (CLI + `duckdb.dll`, v1.5.4,
   `windows-amd64`) into `.duckdb\<version>\` and prepended to `PATH`. A
   system `duckdb` on `PATH` is ignored — an ABI/feature mismatch (e.g. the
@@ -141,9 +142,13 @@ has PowerShell twins and the node-spawn path is a PowerShell mirror of
 **Run** (from a PowerShell prompt at the repo root):
 
 ```powershell
-# Uses the newest distrib\quack-on-demand-assembly-*.jar (or `sbt assembly`
-# when none is present / $env:BUILD='1'). Override knobs with the same QOD_*
-# env vars as the bash path.
+# run-jar.ps1 is at parity with run-jar.sh: it resolves the jar from Maven
+# Central (QOD_VERSION, default latest release; 'latest-snapshot' for the newest
+# snapshot), caches it under %USERPROFILE%\.cache\quack-on-demand\ (sha1-checked),
+# and falls back to the newest distrib\quack-on-demand-assembly-*.jar or
+# `sbt assembly` (bootstrapping sbt into .sbt-bootstrap\ if missing). $env:BUILD='1'
+# forces a local build. It runs a PG16 gate, creates the control-plane DB, and
+# does a port preflight before booting. Same QOD_* / PROXY_* env vars as bash.
 $env:QOD_PG_HOST     = 'localhost'
 $env:QOD_PG_PASSWORD = 'hunter2'
 $env:QOD_ADMIN_PASSWORD = 'change-me'
@@ -151,6 +156,19 @@ $env:QOD_ADMIN_PASSWORD = 'change-me'
 ```
 
 Stop with `.\scripts\stop-jar.ps1`.
+
+**Demo seeds** work the same as the bash path — `run-jar.ps1` runs the PowerShell
+loaders (`load-{tpch,tpcds,ssb}-dbgen.ps1`) in the background before the JVM:
+
+```powershell
+$env:LOAD_TPCH = '1'; .\scripts\run-jar.ps1                    # TPC-H SF=1 into acme/acme_tpch
+$env:NUKE = '1'; $env:LOAD_TPC = '1'; .\scripts\run-jar.ps1    # wipe state, then reseed all three
+```
+
+`LOAD_TPCDS=N`, `LOAD_SSB=N`, and the `LOAD_TPC=N` shortcut behave as on Unix;
+`NUKE=1` drops the control-plane + demo tenant-db databases and wipes `ducklake\`,
+`state\`, `certs\` first (requires `psql`). Each loader also runs standalone
+(`$env:SF=10; .\scripts\load-tpch-dbgen.ps1`).
 
 **Client path.** Two ways the manager talks to the Quack nodes:
 - **Native wire (default, fastest)** — needs `native\windows-x86_64\quackwire.dll`

--- a/scripts/_load-common.ps1
+++ b/scripts/_load-common.ps1
@@ -1,0 +1,276 @@
+<#
+.SYNOPSIS
+  Shared helpers for the load-*-dbgen.ps1 demo seeders (PowerShell twins of the
+  load-*-dbgen.sh scripts). Dot-sourced by each loader; defines functions only,
+  no global side effects.
+
+.DESCRIPTION
+  Each loader (TPC-H / TPC-DS / SSB) resolves the same configuration, provisions
+  the target Postgres database, detects a remote DATA_PATH, runs an idempotency
+  probe, and finally streams a generated SQL script to the DuckDB CLI. Only the
+  generation body (which dbgen/dsdgen call + which tables are created) differs.
+
+  DuckDB invocation. The bash loaders use `duckdb < file.sql`, but Windows
+  PowerShell 5.1 has no `<` input redirection, so we run the script with
+  `duckdb -c ".read '<file>'"` instead - `.read` executes the file (including
+  the .print / .mode dot-commands) in one session and exits.
+
+  Memory limit. The bash loaders auto-derive a DuckDB memory_limit from the
+  cgroup cap so dbgen at high SF spills instead of getting OOM-killed inside a
+  container. On Windows the native path has no cgroup, so we only honour an
+  explicit $env:MEMORY_LIMIT and otherwise leave DuckDB's default.
+#>
+
+Set-StrictMode -Version Latest
+
+# Resolve the DuckDB CLI: $env:DUCKDB_BIN wins (matches spawn-quack-node.ps1),
+# then `duckdb(.exe)` on PATH (run-jar.ps1 prepends its self-installed cache).
+function Get-DuckDbExe {
+  if ($env:DUCKDB_BIN -and (Test-Path -LiteralPath $env:DUCKDB_BIN)) { return $env:DUCKDB_BIN }
+  $cmd = Get-Command duckdb.exe, duckdb -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($cmd) { return $cmd.Source }
+  Write-Error @"
+duckdb CLI not on PATH (and DUCKDB_BIN unset).
+Install DuckDB (https://duckdb.org/docs/installation/) or run the loader through
+scripts/run-jar.ps1, which self-installs the pinned duckdb.exe and puts it on PATH.
+"@
+  exit 1
+}
+
+# Env-or-default helper (mirrors bash `${VAR:-default}`). Treats empty string as
+# unset so `$env:FOO=''` falls through to the default, like bash.
+function Get-EnvOr([string]$Name, [string]$Default) {
+  $v = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrEmpty($v)) { return $Default }
+  return $v
+}
+
+# Resolve the shared config block. $DefaultDbName / $DefaultSchema are the
+# per-loader defaults (acme_tpch/tpch1, globex_tpcds/tpcds1, acme_tpch/ssb1).
+function Resolve-LoadConfig {
+  param(
+    [Parameter(Mandatory)] [string]$DefaultDbName,
+    [Parameter(Mandatory)] [string]$DefaultSchema
+  )
+  $repoDir = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+  $cfg = [ordered]@{
+    PgHost      = Get-EnvOr 'PG_HOST' 'localhost'
+    PgPort      = Get-EnvOr 'PG_PORT' '5432'
+    PgUser      = Get-EnvOr 'PG_USER' 'postgres'
+    PgPass      = Get-EnvOr 'PG_PASS' 'azizam'
+    PgAdminDb   = Get-EnvOr 'PG_ADMIN_DB' 'postgres'
+    DbName      = Get-EnvOr 'DB_NAME' $DefaultDbName
+    Schema      = Get-EnvOr 'SCHEMA_NAME' $DefaultSchema
+    Sf          = Get-EnvOr 'SF' '1'
+    # DuckDB spill dir. dbgen/dsdgen at high SF spills here rather than the
+    # cwd-relative ./.tmp/ default; create it up-front so the load never aborts
+    # mid-flight with "Cannot open file .tmp/...".
+    TempDir     = Get-EnvOr 'TEMP_DIR' (Join-Path $repoDir '.tmp\duckdb-load')
+    # No cgroup on native Windows: honour an explicit cap, else DuckDB default.
+    MemoryLimit = [Environment]::GetEnvironmentVariable('MEMORY_LIMIT')
+    # DATA_PATH default is CWD-anchored (matches run-docker.sh + the bash loader)
+    # so a native loader and a same-CWD docker run agree on the absolute string
+    # DuckLake persists in its catalog.
+    DataPath    = Get-EnvOr 'DATA_PATH' (Join-Path (Get-Location).Path "ducklake\$(Get-EnvOr 'DB_NAME' $DefaultDbName)")
+    RepoDir     = $repoDir
+  }
+  New-Item -ItemType Directory -Force -Path $cfg.TempDir | Out-Null
+  return [pscustomobject]$cfg
+}
+
+# Sanity: DuckDB rejects a 2-part identifier "<db>".<table> as ambiguous when a
+# catalog and schema share a name, so SCHEMA_NAME must differ from DB_NAME.
+function Assert-LoadSanity($cfg) {
+  if ($cfg.Schema -eq $cfg.DbName) {
+    Write-Error "SCHEMA_NAME ($($cfg.Schema)) must differ from DB_NAME ($($cfg.DbName)); DuckDB treats ""$($cfg.DbName)"".<table> as ambiguous when a catalog and schema share a name."
+    exit 1
+  }
+}
+
+# Provision the target Postgres database if psql is present and it is missing.
+# Lets the loader run BEFORE the manager (the order run-jar.ps1 uses). Skipped
+# silently when psql is absent - the ATTACH will surface the error itself.
+function Initialize-PgDatabase($cfg) {
+  $psql = Get-Command psql -ErrorAction SilentlyContinue
+  if (-not $psql) { return }
+  $env:PGPASSWORD = $cfg.PgPass
+  $exists = (& psql -h $cfg.PgHost -p $cfg.PgPort -U $cfg.PgUser -d $cfg.PgAdminDb `
+      -tAc "SELECT 1 FROM pg_database WHERE datname = '$($cfg.DbName)'" 2>$null | Out-String).Trim()
+  if ($exists -ne '1') {
+    Write-Host "load: creating Postgres database $($cfg.DbName)"
+    & psql -h $cfg.PgHost -p $cfg.PgPort -U $cfg.PgUser -d $cfg.PgAdminDb `
+      -tAc "CREATE DATABASE ""$($cfg.DbName)""" *> $null
+    if ($LASTEXITCODE -ne 0) {
+      Write-Warning "CREATE DATABASE $($cfg.DbName) failed; ATTACH below may fail"
+    }
+  }
+}
+
+# Detect a remote DATA_PATH (s3/gs/r2/azure) and emit the matching DuckDB
+# extension + SECRET SQL. For local paths, create the dir and canonicalize (the
+# exact string DuckLake persists). Returns @{ Sql; DataPath }.
+function Resolve-Storage($cfg) {
+  $dp = $cfg.DataPath
+  $storageSql = ''
+  $isRemote = $false
+
+  switch -Regex ($dp) {
+    '^(s3|s3a|gs|r2)://' {
+      $isRemote = $true
+      $storageSql = "INSTALL httpfs; LOAD httpfs;"
+      if ($env:QOD_S3_ACCESS_KEY_ID -and $env:QOD_S3_SECRET_ACCESS_KEY) {
+        $ep = $env:QOD_S3_ENDPOINT
+        if ($ep) { $ep = $ep -replace '^https?://','' -replace '/$','' }
+        $storageSql += @"
+
+CREATE OR REPLACE SECRET quack_s3 (
+  TYPE s3,
+  KEY_ID '$($env:QOD_S3_ACCESS_KEY_ID)',
+  SECRET '$($env:QOD_S3_SECRET_ACCESS_KEY)',
+  REGION '$(Get-EnvOr 'QOD_S3_REGION' 'us-east-1')',
+  ENDPOINT '$ep',
+  URL_STYLE '$(Get-EnvOr 'QOD_S3_URL_STYLE' 'path')',
+  USE_SSL $(Get-EnvOr 'QOD_S3_USE_SSL' 'true')
+);
+"@
+      }
+      break
+    }
+    '^(az|azure|abfss)://' {
+      $isRemote = $true
+      $storageSql = "INSTALL azure; LOAD azure;"
+      if ($env:QOD_AZURE_CONNECTION_STRING) {
+        $storageSql += @"
+
+CREATE OR REPLACE SECRET quack_azure (
+  TYPE azure,
+  CONNECTION_STRING '$($env:QOD_AZURE_CONNECTION_STRING)'
+);
+"@
+      }
+      break
+    }
+  }
+
+  if (-not $isRemote) {
+    New-Item -ItemType Directory -Force -Path $dp | Out-Null
+    $dp = (Resolve-Path -LiteralPath $dp).Path
+  }
+  return [pscustomobject]@{ Sql = $storageSql; DataPath = $dp }
+}
+
+# The DuckLake ATTACH statement shared by the probe and the load script.
+function Get-AttachSql($cfg) {
+  "ATTACH 'ducklake:postgres:host=$($cfg.PgHost) port=$($cfg.PgPort) dbname=$($cfg.DbName) user=$($cfg.PgUser) password=$($cfg.PgPass)' AS $($cfg.DbName)`n  (DATA_PATH '$($cfg.DataPath)');"
+}
+
+# Stream SQL to the DuckDB CLI via `-c ".read '<tempfile>'"`. Writes the temp
+# file as UTF-8 WITHOUT a BOM (a leading BOM would make DuckDB choke on the
+# first statement). Returns @{ ExitCode; Output; Error }.
+#
+# Two modes, both avoiding the PowerShell 5.1 native-stderr trap (`2>$null` /
+# `2>&1` on a native exe wraps each stderr line in a terminating
+# NativeCommandError under ErrorActionPreference=Stop):
+#   -Quiet  : run under System.Diagnostics.Process with redirected stdout/stderr
+#             so an expected error (e.g. probe's "table does not exist") is
+#             captured as plain text, never thrown. Output/Error are buffered.
+#   default : call the exe directly with NO redirection so it inherits the
+#             console and streams .print progress live; check $LASTEXITCODE.
+function Invoke-DuckDb {
+  param([Parameter(Mandatory)] [string]$Sql, [switch]$Quiet)
+  $duck = Get-DuckDbExe
+  $tmp = Join-Path ([IO.Path]::GetTempPath()) ("qod-load-" + [Guid]::NewGuid().ToString('N') + ".sql")
+  [IO.File]::WriteAllText($tmp, $Sql, (New-Object System.Text.UTF8Encoding($false)))
+  $argLine = '-c ".read ''{0}''"' -f ($tmp -replace '\\','/')
+  try {
+    if ($Quiet) {
+      $psi = New-Object System.Diagnostics.ProcessStartInfo
+      $psi.FileName = $duck
+      $psi.Arguments = $argLine
+      $psi.RedirectStandardOutput = $true
+      $psi.RedirectStandardError  = $true
+      $psi.UseShellExecute = $false
+      $psi.CreateNoWindow  = $true
+      $p = [System.Diagnostics.Process]::Start($psi)
+      $out = $p.StandardOutput.ReadToEnd()
+      $err = $p.StandardError.ReadToEnd()
+      $p.WaitForExit()
+      return @{ ExitCode = $p.ExitCode; Output = $out; Error = $err }
+    } else {
+      # Direct, unredirected: DuckDB streams straight to the console. Pipe to
+      # Out-Host so those lines go to the console and do NOT leak into this
+      # function's return value (which must be just the hashtable). Native
+      # non-zero exit does NOT trip ErrorActionPreference, so check it by hand.
+      & $duck -c ".read '$($tmp -replace '\\','/')'" | Out-Host
+      return @{ ExitCode = $LASTEXITCODE; Output = ''; Error = '' }
+    }
+  } finally {
+    Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+  }
+}
+
+# Idempotency probe. Two steps mirroring the bash loaders:
+#   1. count(*) on $ProbeTable - hits DuckLake metadata only. >0 => "loaded".
+#   2. LIMIT 1 - forces an actual parquet open; catches the case where the
+#      catalog claims rows but ./ducklake was wiped (stale metadata).
+# Returns $true when the schema is already populated and reachable (=> skip).
+function Test-AlreadyLoaded {
+  param($cfg, [string]$StorageSql, [Parameter(Mandatory)] [string]$ProbeTable, [string]$ProbeColumn = '*')
+  $attach = Get-AttachSql $cfg
+  $countSql = @"
+INSTALL ducklake; LOAD ducklake;
+INSTALL postgres; LOAD postgres;
+$StorageSql
+$attach
+.mode csv
+.headers off
+SELECT count(*) FROM $($cfg.DbName).$($cfg.Schema).$ProbeTable;
+"@
+  $res = Invoke-DuckDb -Sql $countSql -Quiet
+  $existing = ($res.Output -replace '[^0-9]','')
+  if (-not ($existing -match '^\d+$') -or [int64]$existing -le 0) { return $false }
+
+  # count(*) says rows exist; verify the parquet files are actually reachable.
+  $fileSql = @"
+INSTALL ducklake; LOAD ducklake;
+INSTALL postgres; LOAD postgres;
+$StorageSql
+$attach
+.mode csv
+.headers off
+SELECT $ProbeColumn FROM $($cfg.DbName).$($cfg.Schema).$ProbeTable LIMIT 1;
+"@
+  $probe = Invoke-DuckDb -Sql $fileSql -Quiet
+  if ($probe.ExitCode -ne 0 -and $probe.Output -match 'Cannot open file') {
+    Write-Error @"
+catalog claims $existing rows in $($cfg.DbName).$($cfg.Schema).$ProbeTable but the
+parquet files it references are missing on disk. The Postgres catalog got out of
+sync with the data files (most likely ./ducklake was wiped while pgdata was kept).
+Re-create both from scratch (NUKE=1) or drop the stale schema:
+  DROP SCHEMA $($cfg.DbName).$($cfg.Schema) CASCADE;
+"@
+    exit 1
+  }
+  Write-Host "already loaded: $($cfg.DbName).$($cfg.Schema).$ProbeTable has $existing rows; skipping."
+  Write-Host "(delete the schema or override SCHEMA_NAME to force a reload)"
+  return $true
+}
+
+# Print the standard config banner + spill/memory line.
+function Write-LoadBanner($cfg, [string]$ScaleNote) {
+  Write-Host "postgres:    $($cfg.PgUser)@$($cfg.PgHost):$($cfg.PgPort)/$($cfg.DbName)"
+  Write-Host "catalog:     $($cfg.DbName).$($cfg.Schema)"
+  Write-Host "data path:   $($cfg.DataPath)"
+  Write-Host "scale:       SF=$($cfg.Sf)$(if ($ScaleNote) { " ($ScaleNote)" })"
+  Write-Host "memory:      $(if ($cfg.MemoryLimit) { $cfg.MemoryLimit } else { 'DuckDB default' }) (spill dir: $($cfg.TempDir))"
+  Write-Host ""
+}
+
+# The SET temp_directory + optional memory_limit preamble every generation
+# script opens with.
+function Get-PreambleSql($cfg) {
+  $sql = "SET temp_directory='$($cfg.TempDir -replace '\\','/')';`n"
+  if ($cfg.MemoryLimit) { $sql += "SET memory_limit='$($cfg.MemoryLimit)';`n" }
+  return $sql
+}

--- a/scripts/load-ssb-dbgen.ps1
+++ b/scripts/load-ssb-dbgen.ps1
@@ -1,0 +1,189 @@
+<#
+.SYNOPSIS
+  Seed a DuckLake tenant-db with the SSB (Star Schema Benchmark) derived from
+  DuckDB's TPC-H dbgen() (PowerShell twin of scripts/load-ssb-dbgen.sh).
+
+.DESCRIPTION
+  1. ATTACH the DuckLake catalog (Postgres metadata + local/remote data files)
+  2. CREATE SCHEMA $SCHEMA_NAME if missing
+  3. INSTALL/LOAD tpch, CALL dbgen(sf=$SF) into the in-memory catalog
+  4. Derive the 5 SSB tables (lineorder, customer, supplier, part, dwdate) into
+     $DB_NAME.$SCHEMA_NAME
+
+  The star schema is served alongside the TPC-H tables from the same acme
+  tenant-db (default DB_NAME acme_tpch, SCHEMA_NAME ssb1). See
+  scripts/load-tpch-dbgen.ps1 for the path-matching warning and env-var contract.
+
+.EXAMPLE
+  .\scripts\load-ssb-dbgen.ps1                   # SF=1 into acme_tpch.ssb1
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_load-common.ps1')
+
+$cfg = Resolve-LoadConfig -DefaultDbName 'acme_tpch' -DefaultSchema 'ssb1'
+Assert-LoadSanity $cfg
+Initialize-PgDatabase $cfg
+$storage = Resolve-Storage $cfg
+$cfg.DataPath = $storage.DataPath
+
+Write-LoadBanner $cfg "approx $([int]$cfg.Sf * 6)M lineorder rows"
+
+if (Test-AlreadyLoaded -cfg $cfg -StorageSql $storage.Sql -ProbeTable 'lineorder' -ProbeColumn 'lo_orderkey') {
+  exit 0
+}
+
+$attach = Get-AttachSql $cfg
+$preamble = Get-PreambleSql $cfg
+$db = $cfg.DbName
+$sc = $cfg.Schema
+
+# dbgen() only writes to native DuckDB catalogs, not DuckLake. Generate TPC-H
+# into the in-memory database, then derive each SSB table into the DuckLake
+# schema. DROP first so a previous partial run is overwritten cleanly.
+$sql = @"
+$preamble
+INSTALL ducklake; LOAD ducklake;
+INSTALL postgres; LOAD postgres;
+INSTALL tpch;     LOAD tpch;
+$($storage.Sql)
+
+$attach
+
+CREATE SCHEMA IF NOT EXISTS $db.$sc;
+
+.print ''
+.print '== Generating TPC-H SF=$($cfg.Sf) (in-memory) as the SSB source =='
+.print ''
+CALL dbgen(sf = $($cfg.Sf));
+
+.print ''
+.print '== Deriving SSB star schema into DuckLake $db.$sc =='
+
+-- customer: TPC-H customer joined to nation/region; c_city is the SSB 10-char
+-- city (9-char nation prefix + digit, key mod 10 as the digit).
+DROP TABLE IF EXISTS $db.$sc.customer;
+CREATE TABLE $db.$sc.customer AS
+SELECT
+  c.c_custkey,
+  c.c_name,
+  c.c_address,
+  substr(rpad(n.n_name, 9, ' '), 1, 9) || CAST(c.c_custkey % 10 AS VARCHAR) AS c_city,
+  n.n_name AS c_nation,
+  r.r_name AS c_region,
+  c.c_phone,
+  c.c_mktsegment
+FROM memory.main.customer c
+JOIN memory.main.nation n ON c.c_nationkey = n.n_nationkey
+JOIN memory.main.region r ON n.n_regionkey = r.r_regionkey;
+
+-- supplier: same shape as customer.
+DROP TABLE IF EXISTS $db.$sc.supplier;
+CREATE TABLE $db.$sc.supplier AS
+SELECT
+  s.s_suppkey,
+  s.s_name,
+  s.s_address,
+  substr(rpad(n.n_name, 9, ' '), 1, 9) || CAST(s.s_suppkey % 10 AS VARCHAR) AS s_city,
+  n.n_name AS s_nation,
+  r.r_name AS s_region,
+  s.s_phone
+FROM memory.main.supplier s
+JOIN memory.main.nation n ON s.s_nationkey = n.n_nationkey
+JOIN memory.main.region r ON n.n_regionkey = r.r_regionkey;
+
+-- part: TPC-H p_brand is 'Brand#XY'. SSB rolls up brand1 (MFGR#XYZZ) ->
+-- category (MFGR#XY) -> mfgr (MFGR#X); p_color is the first token of p_name.
+DROP TABLE IF EXISTS $db.$sc.part;
+CREATE TABLE $db.$sc.part AS
+SELECT
+  p_partkey,
+  p_name,
+  'MFGR#' || substr(p_brand, 7, 1) AS p_mfgr,
+  'MFGR#' || substr(p_brand, 7, 2) AS p_category,
+  'MFGR#' || substr(p_brand, 7, 2) || CAST(p_partkey % 40 + 1 AS VARCHAR) AS p_brand1,
+  split_part(p_name, ' ', 1) AS p_color,
+  p_type,
+  p_size,
+  p_container
+FROM memory.main.part;
+
+-- dwdate: one row per calendar day over TPC-H's order date range.
+-- d_daynuminweek is 1(Sunday)..7(Saturday) per the SSB spec.
+DROP TABLE IF EXISTS $db.$sc.dwdate;
+CREATE TABLE $db.$sc.dwdate AS
+SELECT
+  CAST(strftime(d, '%Y%m%d') AS INTEGER)               AS d_datekey,
+  strftime(d, '%B %d, %Y')                             AS d_date,
+  dayname(d)                                           AS d_dayofweek,
+  monthname(d)                                         AS d_month,
+  CAST(year(d) AS INTEGER)                             AS d_year,
+  CAST(year(d) * 100 + month(d) AS INTEGER)            AS d_yearmonthnum,
+  strftime(d, '%b%Y')                                  AS d_yearmonth,
+  CAST(dayofweek(d) + 1 AS INTEGER)                    AS d_daynuminweek,
+  CAST(day(d) AS INTEGER)                              AS d_daynuminmonth,
+  CAST(dayofyear(d) AS INTEGER)                        AS d_daynuminyear,
+  CAST(month(d) AS INTEGER)                            AS d_monthnuminyear,
+  CAST(weekofyear(d) AS INTEGER)                       AS d_weeknuminyear,
+  CASE
+    WHEN month(d) = 12 OR (month(d) = 11 AND day(d) >= 15) THEN 'Christmas'
+    WHEN month(d) IN (6, 7, 8)                             THEN 'Summer'
+    WHEN month(d) IN (3, 4, 5)                             THEN 'Spring'
+    WHEN month(d) IN (9, 10, 11)                           THEN 'Fall'
+    ELSE 'Winter'
+  END                                                  AS d_sellingseason,
+  CASE WHEN dayofweek(d) = 6 THEN 1 ELSE 0 END         AS d_lastdayinweekfl,
+  CASE WHEN d = last_day(d) THEN 1 ELSE 0 END          AS d_lastdayinmonthfl,
+  CASE WHEN (month(d) = 12 AND day(d) = 25)
+         OR (month(d) = 1  AND day(d) = 1)
+         OR (month(d) = 7  AND day(d) = 4) THEN 1 ELSE 0 END AS d_holidayfl,
+  CASE WHEN dayofweek(d) IN (0, 6) THEN 0 ELSE 1 END   AS d_weekdayfl
+FROM (
+  SELECT CAST(gs.d AS DATE) AS d
+  FROM generate_series(DATE '1992-01-01', DATE '1998-12-31', INTERVAL 1 DAY) AS gs(d)
+);
+
+-- lineorder: lineitem denormalized with its order header; lo_discount and
+-- lo_tax become integer percentages, lo_supplycost comes from partsupp.
+DROP TABLE IF EXISTS $db.$sc.lineorder;
+CREATE TABLE $db.$sc.lineorder AS
+SELECT
+  l.l_orderkey                                         AS lo_orderkey,
+  l.l_linenumber                                       AS lo_linenumber,
+  o.o_custkey                                          AS lo_custkey,
+  l.l_partkey                                          AS lo_partkey,
+  l.l_suppkey                                          AS lo_suppkey,
+  CAST(strftime(o.o_orderdate, '%Y%m%d') AS INTEGER)   AS lo_orderdate,
+  o.o_orderpriority                                    AS lo_orderpriority,
+  o.o_shippriority                                     AS lo_shippriority,
+  CAST(l.l_quantity AS INTEGER)                        AS lo_quantity,
+  l.l_extendedprice                                    AS lo_extendedprice,
+  o.o_totalprice                                       AS lo_ordtotalprice,
+  CAST(round(l.l_discount * 100) AS INTEGER)           AS lo_discount,
+  round(l.l_extendedprice * (1 - l.l_discount), 2)     AS lo_revenue,
+  ps.ps_supplycost                                     AS lo_supplycost,
+  CAST(round(l.l_tax * 100) AS INTEGER)                AS lo_tax,
+  CAST(strftime(l.l_commitdate, '%Y%m%d') AS INTEGER)  AS lo_commitdate,
+  l.l_shipmode                                         AS lo_shipmode
+FROM memory.main.lineitem l
+JOIN memory.main.orders o
+  ON l.l_orderkey = o.o_orderkey
+JOIN memory.main.partsupp ps
+  ON l.l_partkey = ps.ps_partkey AND l.l_suppkey = ps.ps_suppkey;
+
+USE $db.$sc;
+
+.print ''
+.print '== Final state =='
+SHOW TABLES;
+SELECT 'lineorder' AS tbl, count(*) AS rows FROM lineorder
+UNION ALL SELECT 'customer', count(*) FROM customer
+UNION ALL SELECT 'supplier', count(*) FROM supplier
+UNION ALL SELECT 'part',     count(*) FROM part
+UNION ALL SELECT 'dwdate',   count(*) FROM dwdate;
+"@
+
+$r = Invoke-DuckDb -Sql $sql
+exit $r.ExitCode

--- a/scripts/load-tpcds-dbgen.ps1
+++ b/scripts/load-tpcds-dbgen.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+  Seed a DuckLake tenant-db with TPC-DS using DuckDB's built-in dsdgen()
+  (PowerShell twin of scripts/load-tpcds-dbgen.sh).
+
+.DESCRIPTION
+  1. ATTACH the DuckLake catalog (Postgres metadata + local/remote data files)
+  2. CREATE SCHEMA $SCHEMA_NAME if missing
+  3. INSTALL/LOAD tpcds, CALL dsdgen(sf=$SF) into the in-memory catalog
+  4. CTAS the 24 TPC-DS tables into $DB_NAME.$SCHEMA_NAME
+
+  See scripts/load-tpch-dbgen.ps1 for the path-matching warning and the shared
+  env-var contract. Defaults here: DB_NAME(globex_tpcds) SCHEMA_NAME(tpcds1).
+
+.EXAMPLE
+  .\scripts\load-tpcds-dbgen.ps1                 # SF=1 into globex_tpcds.tpcds1
+.EXAMPLE
+  $env:SF=10; .\scripts\load-tpcds-dbgen.ps1     # larger workload
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_load-common.ps1')
+
+$cfg = Resolve-LoadConfig -DefaultDbName 'globex_tpcds' -DefaultSchema 'tpcds1'
+Assert-LoadSanity $cfg
+Initialize-PgDatabase $cfg
+$storage = Resolve-Storage $cfg
+$cfg.DataPath = $storage.DataPath
+
+Write-LoadBanner $cfg "approx $([int]$cfg.Sf * 3)M store_sales rows"
+
+if (Test-AlreadyLoaded -cfg $cfg -StorageSql $storage.Sql -ProbeTable 'store_sales' -ProbeColumn 'ss_sold_date_sk') {
+  exit 0
+}
+
+$attach = Get-AttachSql $cfg
+$preamble = Get-PreambleSql $cfg
+
+# dsdgen() only writes to native DuckDB catalogs, not DuckLake. Generate into the
+# in-memory database, then CTAS each of the 24 tables into the DuckLake schema.
+$tables = @(
+  'call_center','catalog_page','catalog_returns','catalog_sales','customer',
+  'customer_address','customer_demographics','date_dim','household_demographics',
+  'income_band','inventory','item','promotion','reason','ship_mode','store',
+  'store_returns','store_sales','time_dim','warehouse','web_page','web_returns',
+  'web_sales','web_site'
+)
+$ctas = ($tables | ForEach-Object {
+  "DROP TABLE IF EXISTS $($cfg.DbName).$($cfg.Schema).$_;`n" +
+  "CREATE TABLE $($cfg.DbName).$($cfg.Schema).$_ AS SELECT * FROM memory.main.$_;"
+}) -join "`n"
+
+$sql = @"
+$preamble
+INSTALL ducklake; LOAD ducklake;
+INSTALL postgres; LOAD postgres;
+INSTALL tpcds;    LOAD tpcds;
+$($storage.Sql)
+
+$attach
+
+CREATE SCHEMA IF NOT EXISTS $($cfg.DbName).$($cfg.Schema);
+
+.print ''
+.print '== Generating TPC-DS SF=$($cfg.Sf) (in-memory) =='
+.print 'Creates 24 tables including store_sales, catalog_sales, web_sales, inventory, ...'
+.print ''
+CALL dsdgen(sf = $($cfg.Sf));
+
+.print ''
+.print '== Copying into DuckLake $($cfg.DbName).$($cfg.Schema) =='
+$ctas
+
+USE $($cfg.DbName).$($cfg.Schema);
+
+.print ''
+.print '== Final state =='
+SHOW TABLES;
+SELECT 'store_sales'     AS tbl, count(*) AS rows FROM store_sales
+UNION ALL SELECT 'catalog_sales',  count(*) FROM catalog_sales
+UNION ALL SELECT 'web_sales',      count(*) FROM web_sales
+UNION ALL SELECT 'store_returns',  count(*) FROM store_returns
+UNION ALL SELECT 'catalog_returns',count(*) FROM catalog_returns
+UNION ALL SELECT 'web_returns',    count(*) FROM web_returns
+UNION ALL SELECT 'inventory',      count(*) FROM inventory
+UNION ALL SELECT 'customer',       count(*) FROM customer
+UNION ALL SELECT 'item',           count(*) FROM item
+UNION ALL SELECT 'date_dim',       count(*) FROM date_dim;
+"@
+
+$r = Invoke-DuckDb -Sql $sql
+exit $r.ExitCode

--- a/scripts/load-tpch-dbgen.ps1
+++ b/scripts/load-tpch-dbgen.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+  Seed a DuckLake tenant-db with TPC-H using DuckDB's built-in dbgen()
+  (PowerShell twin of scripts/load-tpch-dbgen.sh).
+
+.DESCRIPTION
+  1. ATTACH the DuckLake catalog (Postgres metadata + local/remote data files)
+  2. CREATE SCHEMA $SCHEMA_NAME if missing
+  3. INSTALL/LOAD tpch, CALL dbgen(sf=$SF) into the in-memory catalog
+  4. CTAS the 8 TPC-H tables into $DB_NAME.$SCHEMA_NAME
+
+  *** PATH-MATCHING WARNING *** DuckLake stores DATA_PATH as an ABSOLUTE path in
+  the Postgres catalog; every Quack node later reads files from that exact
+  string. The loader and the manager MUST see the same path. On a single
+  Windows host (native loader + native manager) the default works. See the bash
+  twin's header for the Docker cross-path caveats.
+
+  Overrides via env vars (defaults): PG_HOST(localhost) PG_PORT(5432)
+  PG_USER(postgres) PG_PASS(azizam) DB_NAME(acme_tpch) SCHEMA_NAME(tpch1)
+  DATA_PATH(<cwd>\ducklake\$DB_NAME) SF(1) DUCKDB_BIN TEMP_DIR MEMORY_LIMIT.
+
+.EXAMPLE
+  .\scripts\load-tpch-dbgen.ps1                  # SF=1 into acme_tpch.tpch1
+.EXAMPLE
+  $env:SF=10; .\scripts\load-tpch-dbgen.ps1      # larger workload
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '_load-common.ps1')
+
+$cfg = Resolve-LoadConfig -DefaultDbName 'acme_tpch' -DefaultSchema 'tpch1'
+Assert-LoadSanity $cfg
+Initialize-PgDatabase $cfg
+$storage = Resolve-Storage $cfg
+$cfg.DataPath = $storage.DataPath
+
+Write-LoadBanner $cfg "approx $([int]$cfg.Sf * 6)M lineitem rows"
+
+if (Test-AlreadyLoaded -cfg $cfg -StorageSql $storage.Sql -ProbeTable 'lineitem' -ProbeColumn 'l_orderkey') {
+  exit 0
+}
+
+$attach = Get-AttachSql $cfg
+$preamble = Get-PreambleSql $cfg
+
+# dbgen() only writes to native DuckDB catalogs, not DuckLake. Generate into the
+# default in-memory database, then CTAS each table into the DuckLake schema.
+# DROP first so a previous partial run is overwritten cleanly.
+$tables = @('region','nation','customer','supplier','part','partsupp','orders','lineitem')
+$ctas = ($tables | ForEach-Object {
+  "DROP TABLE IF EXISTS $($cfg.DbName).$($cfg.Schema).$_;`n" +
+  "CREATE TABLE $($cfg.DbName).$($cfg.Schema).$_ AS SELECT * FROM memory.main.$_;"
+}) -join "`n"
+
+$sql = @"
+$preamble
+INSTALL ducklake; LOAD ducklake;
+INSTALL postgres; LOAD postgres;
+INSTALL tpch;     LOAD tpch;
+$($storage.Sql)
+
+$attach
+
+CREATE SCHEMA IF NOT EXISTS $($cfg.DbName).$($cfg.Schema);
+
+.print ''
+.print '== Generating TPC-H SF=$($cfg.Sf) (in-memory) =='
+.print 'Creates 8 tables: region, nation, customer, supplier, part, partsupp, orders, lineitem'
+.print ''
+CALL dbgen(sf = $($cfg.Sf));
+
+.print ''
+.print '== Copying into DuckLake $($cfg.DbName).$($cfg.Schema) =='
+$ctas
+
+USE $($cfg.DbName).$($cfg.Schema);
+
+.print ''
+.print '== Final state =='
+SHOW TABLES;
+SELECT 'lineitem' AS tbl, count(*) AS rows FROM lineitem
+UNION ALL SELECT 'orders',   count(*) FROM orders
+UNION ALL SELECT 'customer', count(*) FROM customer
+UNION ALL SELECT 'partsupp', count(*) FROM partsupp
+UNION ALL SELECT 'part',     count(*) FROM part
+UNION ALL SELECT 'supplier', count(*) FROM supplier
+UNION ALL SELECT 'nation',   count(*) FROM nation
+UNION ALL SELECT 'region',   count(*) FROM region;
+"@
+
+$r = Invoke-DuckDb -Sql $sql
+exit $r.ExitCode

--- a/scripts/run-jar.ps1
+++ b/scripts/run-jar.ps1
@@ -1,29 +1,58 @@
 <#
 .SYNOPSIS
   Run the quack-on-demand manager from the assembly uber-jar on Windows.
+  PowerShell twin of scripts/run-jar.sh, at feature parity.
 
 .DESCRIPTION
-  PowerShell port of the essential path in scripts/run-jar.sh. It:
-    1. Anchors the working directory at the repo root.
-    2. Self-installs the DuckDB CLI + libduckdb (windows-amd64) into
-       .duckdb\<version>\{bin,lib} and prepends both to $env:PATH. On Windows
-       the dynamic loader resolves dependent DLLs (quackwire.dll -> duckdb.dll)
-       via PATH, so this replaces LD_LIBRARY_PATH / DYLD_LIBRARY_PATH.
-    3. Resolves the assembly jar (newest under distrib\, or `sbt assembly`
-       when BUILD=1 / none present).
-    4. Probes Postgres when a psql client is available.
-    5. Runs `java -Darrow.allocation.manager.type=Unsafe -jar <jar>`.
+  Two modes, picked via $env:BUILD:
+    BUILD=0 (default) - resolve the jar from Maven Central
+                        (ai.starlake:quack-on-demand_3:<QOD_VERSION>), cache it
+                        under $JAR_CACHE_DIR (sha1-checked), run `java -jar`.
+                        Falls back to a local distrib\ jar / `sbt assembly` when
+                        the artifact isn't published yet.
+    BUILD=1           - run `sbt assembly` from this checkout (bootstrapping sbt
+                        into .sbt-bootstrap\ if it isn't on PATH) and run the
+                        freshly-built jar in distrib\.
 
-  All quack-on-demand settings come from QOD_* / PROXY_* env vars, same as the
-  bash path. The Add-Opens JVM flags ship in the jar manifest (JEP 261).
+  Boot extras (parity with run-jar.sh):
+    - DuckDB CLI + libduckdb self-install (windows-amd64) onto PATH
+    - Postgres reachability probe + PG16 version gate (when psql present)
+    - NUKE=1 teardown (drop control-plane + demo tenant-db DBs, wipe local dirs)
+    - idempotent CREATE DATABASE of the control-plane DB
+    - optional TPC-H / TPC-DS / SSB demo seeds (LOAD_*), run in the background
+      via the load-*-dbgen.ps1 loaders before the JVM starts
+    - port preflight (REST/Flight in-use + orphan node-range detection)
 
-  Env knobs:
-    BUILD=1                run `sbt assembly` first (requires sbt + npm)
+  On Windows the dynamic loader resolves dependent DLLs (quackwire.dll ->
+  duckdb.dll) via PATH, so prepending the duckdb cache bin\+lib\ replaces
+  LD_LIBRARY_PATH / DYLD_LIBRARY_PATH. All quack-on-demand settings come from
+  QOD_* / PROXY_* env vars; the Add-Opens JVM flags ship in the jar manifest.
+
+  Env knobs (superset shared with run-jar.sh):
+    BUILD=1                run `sbt assembly` first (requires sbt + npm; sbt is
+                           auto-bootstrapped if missing)
+    QOD_VERSION            artifact version to download (default = latest release;
+                           `latest-snapshot` = newest Central snapshot; ignored
+                           when BUILD=1)
+    JAR_CACHE_DIR          download cache (default $HOME\.cache\quack-on-demand)
+    NUKE=1                 wipe local state (control-plane DB, demo tenant-dbs,
+                           ducklake\, state\, certs\) before booting. Irreversible.
+    LOAD_TPCH=N            seed TPC-H SF=N into acme/acme_tpch (schema tpch1)
+    LOAD_TPCDS=N           seed TPC-DS SF=N into globex/globex_tpcds (tpcds1)
+    LOAD_SSB=N             seed SSB SF=N into acme/acme_tpch (schema ssb1)
+    LOAD_TPC=N             legacy shortcut for LOAD_TPCH=LOAD_TPCDS=LOAD_SSB=N
     DUCKDB_VERSION         pin a DuckDB release (default: derived from build.sbt)
     DUCKDB_CACHE_DIR       relocate the duckdb cache (default: <repo>\.duckdb)
     QOD_NATIVE_CLIENT      false = embedded DuckDB-JDBC path (no quackwire.dll)
     JAVA_HOME              uses `java` on PATH if unset
     JAVA_OPTS              extra JVM flags (e.g. -Xmx2g)
+
+.EXAMPLE
+  .\scripts\run-jar.ps1                                  # latest release
+.EXAMPLE
+  $env:QOD_VERSION='latest-snapshot'; .\scripts\run-jar.ps1
+.EXAMPLE
+  $env:NUKE='1'; $env:LOAD_TPCH='1'; .\scripts\run-jar.ps1
 #>
 [CmdletBinding()]
 param()
@@ -34,9 +63,20 @@ $RepoDir    = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $DistribDir = Join-Path $RepoDir 'distrib'
 Set-Location $RepoDir
 
-# Anchor the DuckLake data path to the repo unless the caller set it.
+$GroupPath   = 'ai/starlake'
+$Artifact    = 'quack-on-demand_3'
+$JarCacheDir = if ($env:JAR_CACHE_DIR) { $env:JAR_CACHE_DIR } else { Join-Path $HOME '.cache\quack-on-demand' }
+
+# Anchor the DuckLake data path to the repo unless the caller set it. The LOAD_*
+# blocks below derive per-tenant-db paths as <dir-of-this>\<tenant-db>.
 if ([string]::IsNullOrEmpty($env:QOD_DUCKLAKE_DATA_PATH)) {
   $env:QOD_DUCKLAKE_DATA_PATH = Join-Path $RepoDir 'ducklake\data'
+}
+
+function Get-EnvOr([string]$Name, [string]$Default) {
+  $v = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrEmpty($v)) { return $Default }
+  return $v
 }
 
 # ---- DuckDB CLI + libduckdb self-install (windows-amd64) ------------------
@@ -50,7 +90,7 @@ function Resolve-DuckDbVersion {
   return '1.5.4'
 }
 
-function Ensure-DuckDb {
+function Install-DuckDb {
   $version = Resolve-DuckDbVersion
   $cacheRoot = if ([string]::IsNullOrEmpty($env:DUCKDB_CACHE_DIR)) { Join-Path $RepoDir '.duckdb' } else { $env:DUCKDB_CACHE_DIR }
   $cache  = Join-Path $cacheRoot $version
@@ -65,6 +105,8 @@ function Ensure-DuckDb {
     $ver = & $duckExe -version 2>$null | Select-Object -First 1
     if ($ver -match "v$([regex]::Escape($version))") {
       Write-Host "duckdb: cached v$version -> $duckExe"
+      # Expose to the loaders + JNI client explicitly.
+      $env:DUCKDB_BIN = $duckExe
       return
     }
   }
@@ -89,8 +131,40 @@ function Ensure-DuckDb {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
   }
   Write-Host "duckdb: ready -> $duckExe (v$version)"
+  $env:DUCKDB_BIN = $duckExe
 }
-Ensure-DuckDb
+Install-DuckDb
+
+# ---- Demo seed controls (parity with run-jar.sh) -------------------------
+$LoadTpch  = Get-EnvOr 'LOAD_TPCH'  (Get-EnvOr 'LOAD_TPC' '')
+$LoadTpcds = Get-EnvOr 'LOAD_TPCDS' (Get-EnvOr 'LOAD_TPC' '')
+$LoadSsb   = Get-EnvOr 'LOAD_SSB'   (Get-EnvOr 'LOAD_TPC' '')
+foreach ($pair in @(@('LOAD_TPCH',$LoadTpch), @('LOAD_TPCDS',$LoadTpcds), @('LOAD_SSB',$LoadSsb))) {
+  if ($pair[1] -and ($pair[1] -notmatch '^[0-9]+$' -or [int]$pair[1] -lt 1)) {
+    Write-Error "$($pair[0]) must be a positive integer scale factor (got: '$($pair[1])')."
+    exit 1
+  }
+}
+
+# ---- sbt bootstrap (download into .sbt-bootstrap\ when not on PATH) --------
+$SbtBootstrapVersion = Get-EnvOr 'SBT_BOOTSTRAP_VERSION' '1.12.11'
+function Resolve-Sbt {
+  $sbt = Get-Command sbt, sbt.bat -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($sbt) { return $sbt.Source }
+  $root   = Join-Path $RepoDir '.sbt-bootstrap'
+  $sbtDir = Join-Path $root "sbt-$SbtBootstrapVersion"
+  $sbtBat = Join-Path $sbtDir 'sbt\bin\sbt.bat'
+  if (Test-Path $sbtBat) { Write-Host "using bootstrapped sbt: $sbtBat"; return $sbtBat }
+  Write-Host "sbt not on PATH; downloading sbt-$SbtBootstrapVersion into $root\ ..."
+  New-Item -ItemType Directory -Force -Path $sbtDir | Out-Null
+  $zip = Join-Path $root "sbt-$SbtBootstrapVersion.zip"
+  Invoke-WebRequest -Uri "https://github.com/sbt/sbt/releases/download/v$SbtBootstrapVersion/sbt-$SbtBootstrapVersion.zip" -OutFile $zip
+  Expand-Archive -Path $zip -DestinationPath $sbtDir -Force
+  Remove-Item -Force $zip -ErrorAction SilentlyContinue
+  if (-not (Test-Path $sbtBat)) { Write-Error "bootstrapped sbt did not produce $sbtBat"; exit 1 }
+  Write-Host "bootstrapped sbt -> $sbtBat"
+  return $sbtBat
+}
 
 # ---- Resolve jar ----
 function Get-LocalJar {
@@ -99,72 +173,293 @@ function Get-LocalJar {
     Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
 }
 
-function Invoke-SbtAssembly {
-  $sbt = Get-Command sbt -ErrorAction SilentlyContinue
-  if ($null -eq $sbt) {
-    Write-Error "sbt not on PATH and no jar in $DistribDir. Install sbt + npm, or drop a prebuilt assembly jar into distrib\."
-    exit 1
-  }
+function Invoke-Build {
+  $sbt = Resolve-Sbt
   Write-Host "running 'sbt assembly' (local build)..."
-  & $sbt.Source assembly
+  # Note: unlike run-jar.sh, we don't rebuild the Windows quackwire.dll here (it
+  # needs MSVC/CMake and is gated behind QOD_WITH_WINDOWS_NATIVE). sbt assembly
+  # resolves the native classifiers already staged in the repo / Central. To
+  # build the dll, see the "Run on Windows" section of the install guide.
+  & $sbt assembly
   if ($LASTEXITCODE -ne 0) { Write-Error "sbt assembly failed"; exit 1 }
+  $jar = Get-LocalJar
+  if (-not $jar) { Write-Error "sbt assembly did not produce a jar in $DistribDir"; exit 1 }
+  return $jar
+}
+
+function Use-LocalJarOrBuild {
+  $jar = Get-LocalJar
+  if ($jar) {
+    Write-Host "using existing local jar: $jar"
+    Write-Host "  (set BUILD=1 to force a fresh build)"
+    return $jar
+  }
+  return (Invoke-Build)
+}
+
+function Get-LocalSnapshotVersion {
+  $vf = Join-Path $RepoDir 'version.sbt'
+  if (-not (Test-Path $vf)) { return $null }
+  $line = Select-String -Path $vf -Pattern 'ThisBuild\s*/\s*version\s*:=' | Select-Object -First 1
+  if ($line -and $line.Line -match '"([^"]+)"') { return $Matches[1] }
+  return $null
+}
+
+function Get-MavenMetaValue([string]$Url, [string]$Tag) {
+  try {
+    $xml = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
+    if ($xml.Content -match "<$Tag>([^<]+)</$Tag>") { return $Matches[1] }
+  } catch { }
+  return $null
+}
+
+# Returns $true when the cached jar's sha1 matches the remote sidecar.
+function Test-JarCurrent([string]$Jar, [string]$Sha1Url) {
+  if (-not (Test-Path $Jar)) { return $false }
+  try {
+    $remote = (Invoke-WebRequest -Uri $Sha1Url -UseBasicParsing -TimeoutSec 10 -ErrorAction Stop).Content
+    $remote = ($remote -replace '\s','').Substring(0, 40).ToLower()
+  } catch { return $false }
+  $local = (Get-FileHash -Algorithm SHA1 -LiteralPath $Jar).Hash.ToLower()
+  return ($local -eq $remote)
 }
 
 $Jar = $null
 if ($env:BUILD -eq '1') {
   Write-Host "BUILD=1: local build"
-  Invoke-SbtAssembly
-  $Jar = Get-LocalJar
+  $Jar = Invoke-Build
 } else {
-  $Jar = Get-LocalJar
-  if ($null -eq $Jar) {
-    Write-Host "no jar in distrib\; building from source..."
-    Invoke-SbtAssembly
-    $Jar = Get-LocalJar
+  New-Item -ItemType Directory -Force -Path $JarCacheDir | Out-Null
+  $version = Get-EnvOr 'QOD_VERSION' 'latest'
+  switch ($version) {
+    'latest' {
+      $version = Get-MavenMetaValue "https://repo1.maven.org/maven2/$GroupPath/$Artifact/maven-metadata.xml" 'release'
+      if ($version) {
+        Write-Host "resolved latest release: $version"
+      } else {
+        $version = Get-LocalSnapshotVersion
+        if ($version -and $version.EndsWith('-SNAPSHOT')) {
+          Write-Host "no release on Maven Central; trying snapshot $version (from version.sbt)"
+        } else {
+          Write-Warning "no release on Maven Central and no snapshot detected; falling back to local jar / build."
+          $version = ''
+        }
+      }
+    }
+    'latest-snapshot' {
+      $version = Get-MavenMetaValue "https://central.sonatype.com/repository/maven-snapshots/$GroupPath/$Artifact/maven-metadata.xml" 'latest'
+      if (-not $version) { $version = Get-LocalSnapshotVersion }
+      if ($version) { Write-Host "resolved latest snapshot: $version" }
+      else { Write-Warning "no snapshot found and no version.sbt detected; falling back to local jar / build." }
+    }
+  }
+
+  if ([string]::IsNullOrEmpty($version)) {
+    $Jar = Use-LocalJarOrBuild
+  } elseif ($version.EndsWith('-SNAPSHOT')) {
+    $baseUrl = "https://central.sonatype.com/repository/maven-snapshots/$GroupPath/$Artifact/$version"
+    $Jar     = Join-Path $JarCacheDir "$Artifact-$version.jar"
+    $jarUrl  = "$baseUrl/$Artifact-$version.jar"
+    if (Test-JarCurrent $Jar "$jarUrl.sha1") {
+      Write-Host "snapshot $version cached (sha1 matches Central); skipping download."
+    } else {
+      Write-Host "downloading snapshot $version..."
+      try { Invoke-WebRequest -Uri $jarUrl -OutFile $Jar -TimeoutSec 600 -ErrorAction Stop }
+      catch { Write-Warning "snapshot download failed; falling back to local jar / build."; $Jar = Use-LocalJarOrBuild }
+    }
   } else {
-    Write-Host "using existing local jar: $Jar"
-    Write-Host "  (set BUILD=1 to force a fresh build)"
+    $baseUrl = "https://repo1.maven.org/maven2/$GroupPath/$Artifact/$version"
+    $Jar     = Join-Path $JarCacheDir "$Artifact-$version.jar"
+    $jarUrl  = "$baseUrl/$Artifact-$version.jar"
+    if (Test-JarCurrent $Jar "$jarUrl.sha1") {
+      Write-Host "release $version cached (sha1 matches Central); skipping download."
+    } else {
+      Write-Host "downloading $version from Maven Central..."
+      try { Invoke-WebRequest -Uri $jarUrl -OutFile $Jar -TimeoutSec 600 -ErrorAction Stop }
+      catch { Write-Warning "release download failed; falling back to local jar / build."; $Jar = Use-LocalJarOrBuild }
+    }
   }
 }
-if ($null -eq $Jar) { Write-Error "ERROR: no assembly jar found in $DistribDir"; exit 1 }
+if (-not $Jar -or -not (Test-Path $Jar)) { Write-Error "no assembly jar available"; exit 1 }
 Write-Host "jar: $Jar"
 
 # ---- Resolve java ----
 $JavaBin = if (-not [string]::IsNullOrEmpty($env:JAVA_HOME)) { Join-Path $env:JAVA_HOME 'bin\java.exe' } else { 'java' }
 if (-not (Get-Command $JavaBin -ErrorAction SilentlyContinue)) {
-  Write-Error "ERROR: java not found. Install JDK 21+ or set JAVA_HOME."; exit 1
+  Write-Error "java not found. Install JDK 21+ or set JAVA_HOME."; exit 1
 }
-Write-Host ("java: " + ((& $JavaBin -version 2>&1 | Select-Object -First 1)))
+# `java -version` prints to stderr; the 2>&1 merge would wrap it in a terminating
+# NativeCommandError under ErrorActionPreference=Stop, so drop to Continue for
+# just this capture.
+$javaVer = & { $ErrorActionPreference = 'Continue'; (& $JavaBin -version 2>&1 | Select-Object -First 1) }
+Write-Host ("java: " + $javaVer)
 
-# ---- Optional Postgres probe (only when a psql client is present) ----
-$pgHost   = if ($env:QOD_PG_HOST) { $env:QOD_PG_HOST } else { 'localhost' }
-$pgPort   = if ($env:QOD_PG_PORT) { $env:QOD_PG_PORT } else { '5432' }
-$pgUser   = if ($env:QOD_PG_USER) { $env:QOD_PG_USER } else { 'postgres' }
-$pgAdmin  = if ($env:QOD_PG_ADMIN_DB) { $env:QOD_PG_ADMIN_DB } else { 'postgres' }
-$pgPass   = if ($env:QOD_PG_PASSWORD) { $env:QOD_PG_PASSWORD } else { 'azizam' }
-$psql = Get-Command psql -ErrorAction SilentlyContinue
-if ($psql) {
+# ---- Postgres probe + PG16 gate (only when psql present) ----
+$stateMode = Get-EnvOr 'QOD_STATE_STORAGE' 'postgres'
+$pgHost    = Get-EnvOr 'QOD_PG_HOST' 'localhost'
+$pgPort    = Get-EnvOr 'QOD_PG_PORT' '5432'
+$pgUser    = Get-EnvOr 'QOD_PG_USER' 'postgres'
+$pgPass    = Get-EnvOr 'QOD_PG_PASSWORD' 'azizam'
+$pgAdminDb = Get-EnvOr 'QOD_PG_ADMIN_DB' 'postgres'
+$pgDbName  = Get-EnvOr 'QOD_PG_DBNAME' 'qod'
+$pgReachable = $false
+
+# Run a psql -tAc query; returns trimmed stdout ('' on any failure). Uses a
+# Process object to dodge the PS 5.1 native-stderr-wrapping trap.
+function Invoke-Psql([string]$Db, [string]$Sql) {
+  $psql = Get-Command psql -ErrorAction SilentlyContinue
+  if (-not $psql) { return $null }
   $env:PGPASSWORD = $pgPass
-  & psql -h $pgHost -p $pgPort -U $pgUser -d $pgAdmin -tAc 'SELECT 1' *> $null
-  if ($LASTEXITCODE -eq 0) {
-    Write-Host "postgres: OK ($pgUser@${pgHost}:$pgPort)"
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName  = $psql.Source
+  $psi.Arguments = "-h $pgHost -p $pgPort -U $pgUser -d $Db -tAc `"$Sql`""
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError  = $true
+  $psi.UseShellExecute = $false
+  $psi.CreateNoWindow  = $true
+  $p = [System.Diagnostics.Process]::Start($psi)
+  $out = $p.StandardOutput.ReadToEnd()
+  $null = $p.StandardError.ReadToEnd()
+  $p.WaitForExit()
+  if ($p.ExitCode -ne 0) { return $null }
+  return $out.Trim()
+}
+
+if ($stateMode -eq 'postgres' -and (Get-Command psql -ErrorAction SilentlyContinue)) {
+  if ((Invoke-Psql $pgAdminDb 'SELECT 1') -eq '1') {
+    $pgMajor = Invoke-Psql $pgAdminDb 'SHOW server_version_num'
+    if (-not $pgMajor -or [int]$pgMajor -lt 160000) {
+      Write-Error "Postgres at $pgUser@${pgHost}:$pgPort reports server_version_num=$pgMajor (need >= 160000 / PG 16). This project requires Postgres 16+."
+      exit 1
+    }
+    Write-Host "postgres: OK ($pgUser@${pgHost}:$pgPort, server_version_num=$pgMajor)  [state storage]"
+    $pgReachable = $true
   } else {
     Write-Warning "cannot reach Postgres at $pgUser@${pgHost}:$pgPort; the manager will fail at startup if it cannot persist state."
   }
-} else {
+} elseif ($stateMode -eq 'postgres') {
   Write-Host "postgres: psql not on PATH; skipping reachability probe (manager still needs a reachable PG 16+)."
 }
 
+# ---- Optional nuke: tear down + wipe before starting ----
+if ($env:NUKE -eq '1') {
+  Write-Host "NUKE=1: tearing down state..."
+  $restPort = Get-EnvOr 'QOD_ON_DEMAND_PORT' '20900'
+  try {
+    Invoke-WebRequest -Uri "http://localhost:$restPort/health" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop | Out-Null
+    Write-Host "  stopping running manager"
+    & (Join-Path $PSScriptRoot 'stop-jar.ps1') *> $null
+  } catch { }
+  if ($stateMode -eq 'postgres' -and $pgReachable -and $pgDbName) {
+    Write-Host "  dropping Postgres database: $pgDbName (control plane)"
+    Invoke-Psql $pgAdminDb "DROP DATABASE IF EXISTS ""$pgDbName"" WITH (FORCE)" | Out-Null
+    foreach ($demo in @('acme_tpch','globex_tpcds')) {
+      Write-Host "  dropping Postgres database: $demo (demo tenant-db)"
+      Invoke-Psql $pgAdminDb "DROP DATABASE IF EXISTS ""$demo"" WITH (FORCE)" | Out-Null
+    }
+  } elseif ($stateMode -eq 'postgres') {
+    Write-Warning "  Postgres unreachable; skipping DB drop (local wipes still proceed)"
+  }
+  foreach ($d in @((Join-Path $RepoDir 'ducklake'), (Join-Path $RepoDir 'state'), (Join-Path $RepoDir 'certs'))) {
+    if (Test-Path $d) { Write-Host "  wiping $d"; Remove-Item -Recurse -Force $d }
+  }
+}
+
+# ---- Bootstrap control-plane DB (idempotent) ----
+if ($stateMode -eq 'postgres' -and $pgReachable -and $pgDbName) {
+  if ((Invoke-Psql $pgAdminDb "SELECT 1 FROM pg_database WHERE datname='$pgDbName'") -eq '1') {
+    Write-Host "catalog db: '$pgDbName' already exists"
+  } else {
+    Write-Host "catalog db: creating '$pgDbName' in $pgAdminDb..."
+    Invoke-Psql $pgAdminDb "CREATE DATABASE ""$pgDbName""" | Out-Null
+  }
+}
+
+# ---- Optional: TPC demo loaders (background, before the JVM starts) ----
+if ($LoadTpch -or $LoadTpcds -or $LoadSsb) {
+  if ([string]::IsNullOrEmpty($env:QOD_BOOTSTRAP_YAML)) {
+    $env:QOD_BOOTSTRAP_YAML = Join-Path $RepoDir 'src\main\resources\bootstrap-demo.yaml'
+  }
+  Write-Host "load-tpc: TPC-H=$(if($LoadTpch){$LoadTpch}else{'skip'}), TPC-DS=$(if($LoadTpcds){$LoadTpcds}else{'skip'}), SSB=$(if($LoadSsb){$LoadSsb}else{'skip'}), bootstrap=$($env:QOD_BOOTSTRAP_YAML)"
+  $ducklakeParent = Split-Path -Parent $env:QOD_DUCKLAKE_DATA_PATH
+
+  # Launch one loader in the background. Sets the loader's env-var contract, then
+  # Start-Process (which snapshots the env synchronously) so sequential launches
+  # with different DB_NAME/SF don't race. PATH + DUCKDB_BIN are inherited.
+  function Start-Loader([string]$Script, [string]$DbName, [string]$Schema, [string]$Sf, [string]$DataPath) {
+    $env:PG_HOST=$pgHost; $env:PG_PORT=$pgPort; $env:PG_USER=$pgUser; $env:PG_PASS=$pgPass; $env:PG_ADMIN_DB=$pgAdminDb
+    $env:DB_NAME=$DbName; $env:SCHEMA_NAME=$Schema; $env:SF=$Sf; $env:DATA_PATH=$DataPath
+    Start-Process -FilePath 'powershell.exe' `
+      -ArgumentList @('-NoProfile','-NonInteractive','-ExecutionPolicy','Bypass','-File',(Join-Path $PSScriptRoot $Script)) `
+      -NoNewWindow | Out-Null
+  }
+
+  if ($LoadTpch)  { Start-Loader 'load-tpch-dbgen.ps1'  'acme_tpch'    'tpch1'  $LoadTpch  (Join-Path $ducklakeParent 'acme_tpch') }
+  if ($LoadTpcds) { Start-Loader 'load-tpcds-dbgen.ps1' 'globex_tpcds' 'tpcds1' $LoadTpcds (Join-Path $ducklakeParent 'globex_tpcds') }
+  if ($LoadSsb)   { Start-Loader 'load-ssb-dbgen.ps1'   'acme_tpch'    'ssb1'   $LoadSsb   (Join-Path $ducklakeParent 'acme_tpch') }
+  # Clear the loader-scoped vars so they don't leak into the JVM's environment.
+  foreach ($n in 'DB_NAME','SCHEMA_NAME','SF','DATA_PATH','PG_HOST','PG_PORT','PG_USER','PG_PASS','PG_ADMIN_DB') {
+    Remove-Item "Env:$n" -ErrorAction SilentlyContinue
+  }
+}
+
 # ---- Effective settings ----
-$restHost = if ($env:QOD_ON_DEMAND_HOST) { $env:QOD_ON_DEMAND_HOST } else { '0.0.0.0' }
-$restPort = if ($env:QOD_ON_DEMAND_PORT) { $env:QOD_ON_DEMAND_PORT } else { '20900' }
-$flightPort = if ($env:PROXY_PORT) { $env:PROXY_PORT } else { '31338' }
+$restHost   = Get-EnvOr 'QOD_ON_DEMAND_HOST' '0.0.0.0'
+$restPort   = Get-EnvOr 'QOD_ON_DEMAND_PORT' '20900'
+$flightHost = Get-EnvOr 'PROXY_HOST' '0.0.0.0'
+$flightPort = Get-EnvOr 'PROXY_PORT' '31338'
 Write-Host "REST + UI:  http://${restHost}:$restPort/ui/"
-Write-Host "FlightSQL:  ${flightPort}  (TLS=$(if ($env:PROXY_TLS_ENABLED) { $env:PROXY_TLS_ENABLED } else { 'true' }))"
-Write-Host "Runtime:    $(if ($env:QOD_RUNTIME_TYPE) { $env:QOD_RUNTIME_TYPE } else { 'local' })"
+Write-Host "FlightSQL:  ${flightHost}:$flightPort  (TLS=$(Get-EnvOr 'PROXY_TLS_ENABLED' 'true'))"
+Write-Host "State:      $stateMode"
+Write-Host "Runtime:    $(Get-EnvOr 'QOD_RUNTIME_TYPE' 'local')"
 Write-Host ""
 
+# ---- Port preflight ----
+# Abort if the REST/Flight ports are held; WARN on orphan listeners inside the
+# node port range (stale Quack nodes there cause silent 'Authentication failed'
+# at query time because the port allocator does not probe the OS).
+function Get-PortListeners([int]$Port) {
+  try { return @(Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop) }
+  catch { return @() }
+}
+if (Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue) {
+  foreach ($p in @([int]$restPort, [int]$flightPort)) {
+    # Wrap in @() at the call site: PowerShell unrolls a function's 1-element
+    # array return, so without this $held would be a bare CimInstance (no .Count).
+    $held = @(Get-PortListeners $p)
+    if ($held.Count -gt 0) {
+      $pids = ($held | Select-Object -ExpandProperty OwningProcess -Unique) -join ', '
+      Write-Error "port $p already in use (pid(s): $pids). Stop the holder (.\scripts\stop-jar.ps1) and retry."
+      exit 1
+    }
+  }
+  $minPort = [int](Get-EnvOr 'QOD_MIN_PORT' '21900')
+  $maxPort = [int](Get-EnvOr 'QOD_MAX_PORT' '22500')
+  try {
+    $orphans = @(Get-NetTCPConnection -State Listen -ErrorAction Stop |
+      Where-Object { $_.LocalPort -ge $minPort -and $_.LocalPort -le $maxPort })
+  } catch { $orphans = @() }
+  if ($orphans.Count -gt 0) {
+    $desc = ($orphans | ForEach-Object { "  :$($_.LocalPort) pid=$($_.OwningProcess)" } | Sort-Object -Unique) -join "`n"
+    Write-Error @"
+orphan listener(s) inside the configured node port range [$minPort, $maxPort]:
+$desc
+These are almost certainly stale Quack node processes from a prior run. The
+manager's port allocator does not probe the OS - re-leasing one of these ports
+leads to silent 'Authentication failed' errors at query time. Kill them and
+retry (.\scripts\stop-jar.ps1).
+"@
+    exit 1
+  }
+} else {
+  Write-Warning "Get-NetTCPConnection unavailable; skipping port preflight."
+}
+
 # ---- Run ----
+# The assembly jar carries Add-Opens in its manifest (JEP 261) so Arrow's unsafe
+# allocator works on Java 17+ without extra flags. The system property pins the
+# allocator - without it Arrow picks netty and crashes (NoSuchFieldError:
+# chunkSize).
 $javaArgs = @('-Darrow.allocation.manager.type=Unsafe')
 if (-not [string]::IsNullOrEmpty($env:JAVA_OPTS)) { $javaArgs += ($env:JAVA_OPTS -split '\s+') }
 $javaArgs += @('-jar', $Jar)

--- a/scripts/tpch-load-test/tpch-load-test.py
+++ b/scripts/tpch-load-test/tpch-load-test.py
@@ -34,6 +34,16 @@ from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List
 
+# The results block uses U+2500 box-drawing separators. On Windows the console
+# defaults to cp1252, which cannot encode them, so a fully successful run would
+# still die with UnicodeEncodeError at print time. Force UTF-8 on our streams
+# (no-op where they already are, e.g. Linux/macOS or PYTHONUTF8=1).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except (AttributeError, ValueError):
+        pass
+
 
 # Default workload: a curated TPCH-H subset. These are the canonical
 # benchmark queries (Q1, Q3, Q5, Q6, Q10, Q12, Q14) with the standard

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -73,7 +73,7 @@ The manager runs natively on Windows - no WSL, no Docker. The bash launchers hav
 
 - **JDK 21+** (`java` on `PATH`, or `JAVA_HOME` set).
 - **Windows PowerShell 5+** (ships with Windows) - used to spawn Quack nodes.
-- **PostgreSQL 16+** reachable from the host (native install, a container, or a network host). `psql` is *optional* - the manager provisions its own control-plane and tenant databases; when `psql` is present `run-jar.ps1` also runs a reachability probe.
+- **PostgreSQL 16+** reachable from the host (native install, a container, or a network host). `psql` is *optional* - the manager provisions its own control-plane and tenant databases; when `psql` is present `run-jar.ps1` additionally runs a reachability probe, enforces the PG16+ version gate, creates the control-plane database up-front, and enables the `NUKE=1` / `LOAD_*` flows below.
 - **DuckDB is self-installed** by `run-jar.ps1` (CLI + `duckdb.dll`, v1.5.4, `windows-amd64`) into `.duckdb\<version>\` and prepended to `PATH`. A system `duckdb` on `PATH` is ignored - an ABI/feature mismatch (for example a `winget` 0.10.x build) would fail node spawn.
 
 **Run** (from a PowerShell prompt at the repo root):
@@ -85,7 +85,16 @@ $env:QOD_ADMIN_PASSWORD = 'change-me'
 .\scripts\run-jar.ps1
 ```
 
-`run-jar.ps1` uses the newest `distrib\quack-on-demand-assembly-*.jar` (or runs `sbt assembly` when none is present or `$env:BUILD='1'`). All the same `QOD_*` / `PROXY_*` environment variables apply. Stop with `.\scripts\stop-jar.ps1`.
+`run-jar.ps1` is at feature parity with the bash `run-jar.sh`. By default it resolves the jar from Maven Central (`QOD_VERSION`, default latest release; `latest-snapshot` for the newest snapshot), caches it under `%USERPROFILE%\.cache\quack-on-demand\` with a sha1 check, and falls back to the newest `distrib\quack-on-demand-assembly-*.jar` or `sbt assembly` (bootstrapping `sbt` into `.sbt-bootstrap\` if it isn't on `PATH`) when nothing is published. Set `$env:BUILD='1'` to force a local `sbt assembly`. Before starting the JVM it runs a Postgres reachability probe + PG16 gate, creates the control-plane database if missing, and does a port preflight (aborting if the REST/FlightSQL ports are held or a stale Quack node is squatting the node-port range). All the same `QOD_*` / `PROXY_*` environment variables apply. Stop with `.\scripts\stop-jar.ps1`.
+
+**Seeding the demo datasets.** The same seed flags as the bash path work on Windows - `run-jar.ps1` runs the PowerShell demo loaders (`load-{tpch,tpcds,ssb}-dbgen.ps1`) in the background before the JVM starts:
+
+```powershell
+$env:LOAD_TPCH = '1'; .\scripts\run-jar.ps1                       # TPC-H SF=1 into acme/acme_tpch
+$env:NUKE = '1'; $env:LOAD_TPCH = '1'; .\scripts\run-jar.ps1      # wipe state, then fresh boot + seed
+```
+
+`LOAD_TPCDS=N` (globex/globex_tpcds) and `LOAD_SSB=N` (acme, schema `ssb1`) behave the same; `LOAD_TPC=N` is the legacy shortcut for all three. `NUKE=1` drops the control-plane and demo tenant-db databases and wipes `ducklake\`, `state\`, and `certs\` before booting (irreversible; requires `psql`). Each loader can also be run standalone (e.g. `$env:SF=10; .\scripts\load-tpch-dbgen.ps1`).
 
 **Client path.** Two ways the manager talks to the Quack nodes:
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -132,6 +132,10 @@ python3 ./scripts/tpch-load-test/tpch-load-test.py \
 
 `--tenant` and `--pool` are required (or set `LT_TENANT` / `LT_POOL`); the demo bootstrap creates tenants `acme` and `globex`, each with a pool named `bi`. The `--insecure` flag skips certificate verification for the auto-generated self-signed cert. The `--superuser` flag adds the `superuser=true` gRPC header so the bootstrap `admin` user (which lives in `qodstate_user` with `tenant IS NULL`) authenticates against the system realm; drop it when running as a tenant-scoped user.
 
+:::note Windows
+Run the Python ADBC client from a neutral working directory (e.g. your home folder), **not** the repository root. Windows includes the current directory in the DLL search path, so a native `arrow`/`duckdb` DLL sitting in the checkout can get loaded into the client process ahead of the one shipped with `adbc_driver_flightsql` and crash it. The runner itself already forces UTF-8 output so the results table renders in a `cp1252` console.
+:::
+
 To switch workload, pass `--workload tpcds` (or set `LT_WORKLOAD=tpcds`). The runner ships two curated benchmarks:
 
 | Workload | Default schema | Default tenant/pool wiring | Tables touched |


### PR DESCRIPTION
Follow-up to the merged Windows native support (#58). Brings `run-jar.ps1` to feature parity with `run-jar.sh` and adds PowerShell twins of the three `dbgen` demo seeders so `LOAD_TPCH`/`LOAD_TPCDS`/`LOAD_SSB` work natively on Windows.

## `run-jar.ps1` gains
- Maven Central / `latest-snapshot` jar download + cache + sha1 check (`QOD_VERSION`), falling back to a local `distrib\` jar or `sbt assembly`
- `sbt` auto-bootstrap into `.sbt-bootstrap\` when it isn't on PATH
- Postgres **PG16 version gate** (was only a `SELECT 1` reachability probe)
- idempotent `CREATE DATABASE` of the control-plane DB
- `NUKE=1` teardown (drop control-plane + demo tenant-db DBs, wipe `ducklake\`/`state\`/`certs\`)
- `LOAD_TPCH`/`TPCDS`/`SSB`/`LOAD_TPC` orchestration, launching the loaders in the background before the JVM
- port preflight (REST/Flight in-use + orphan node-range detection)

## New scripts
`_load-common.ps1` (shared config / PG provisioning / DuckLake ATTACH / idempotency probe / duckdb invocation) plus `load-{tpch,tpcds,ssb}-dbgen.ps1` mirroring their `.sh` twins.

## Windows specifics
- DuckDB is driven via `duckdb -c ".read '<file>'"` (PowerShell 5.1 has no `<` stdin redirection)
- all native-exe calls avoid the PS 5.1 `2>&1`/`2>$null` `NativeCommandError` trap (Process objects for captured output; `ErrorActionPreference=Continue` for the `java -version` banner)
- no cgroup memory auto-derivation (native Windows has none); honours an explicit `MEMORY_LIMIT` only

## Also
- `tpch-load-test.py`: force UTF-8 stdout/stderr so the results table prints on a `cp1252` console (a fully successful run previously died with `UnicodeEncodeError` on the `───` separators)
- docs: install.md, quickstart.md (incl. a Windows note about running the ADBC client from a neutral cwd — the current-directory DLL-search clash), guides/RUNNING.md

## Verification (live Windows host, published snapshot)
`NUKE=1 LOAD_TPCH=1 .\scripts\run-jar.ps1` nuked state, recreated the control-plane DB, imported the demo bootstrap (3 pools / 6 nodes), the background loader seeded **6,001,215 lineitem rows** into DuckLake, a FlightSQL query returned that count, an **80/80 load test** passed, and `stop-jar.ps1` tore everything down with no orphaned `duckdb.exe`. All three loaders were also verified standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)