### PR TITLE
qod demo: self-contained one-command demo (embedded PG + seeded minimal demo)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,6 +203,7 @@ lazy val root = (project in file("."))
       Dependencies.hikariCp,
       Dependencies.jbcrypt,
       Dependencies.postgresql,
+      Dependencies.embeddedPostgres,
       Dependencies.liquibaseCore,
       Dependencies.catsCore,
       Dependencies.blobstoreCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,6 +59,9 @@ object Dependencies {
   val hikariCp              = "com.zaxxer" % "HikariCP" % Versions.hikariCp
   val jbcrypt               = "at.favre.lib" % "bcrypt" % Versions.jbcrypt
   val postgresql            = "org.postgresql" % "postgresql" % Versions.postgresql
+  // Ephemeral embedded Postgres for `qod demo` - downloads a bundled native PG
+  // binary on first run (see io.zonky.test.db.postgres.embedded.EmbeddedPostgres).
+  val embeddedPostgres = "io.zonky.test" % "embedded-postgres" % Versions.embeddedPostgres
   // Liquibase applies YAML changelogs under `db/changelog/` at startup -
   // one source of truth for the `qodstate_*` control-plane schema.
   val liquibaseCore         = "org.liquibase" % "liquibase-core" % Versions.liquibase

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -21,6 +21,7 @@ object Versions {
   val hikariCp       = "6.2.1"
   val jbcrypt        = "0.10.2"
   val postgresql     = "42.7.4"
+  val embeddedPostgres = "2.0.7"
   val wireMock       = "3.9.2"
   val blobstore      = "0.10.1"
   val starlakeJdbc   = "0.7"

--- a/src/main/resources/bootstrap-demo-minimal.yaml
+++ b/src/main/resources/bootstrap-demo-minimal.yaml
@@ -69,7 +69,7 @@ users:
     username: alice
     password: demo-alice
     role: admin
-    roles: [analyst, tenant_admin]
+    roles: [analyst]
     poolGrants:
       - { pool: bi }
 

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -168,7 +168,15 @@ object Main extends IOApp with LazyLogging:
     val authCfg    = source.at("quack-flightsql.auth").loadOrThrow[AuthenticationConfig]
     val aclCfg     = source.at("quack-flightsql.acl").loadOrThrow[AclConfig]
     val metricsCfg = source.at("quack-on-demand.metrics").loadOrThrow[MetricsConfig]
+    bootManager(mgrCfg, edgeCfg, authCfg, aclCfg, metricsCfg)
 
+  private def bootManager(
+      mgrCfg: ManagerConfig,
+      edgeCfg: FlightConfig,
+      authCfg: AuthenticationConfig,
+      aclCfg: AclConfig,
+      metricsCfg: MetricsConfig
+  ): IO[ExitCode] =
     HaPreconditions
       .validate(
         mgrCfg.ha.enabled,

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -158,6 +158,8 @@ object Main extends IOApp with LazyLogging:
           val store  = PostgresControlPlaneStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
           ai.starlake.quack.cli.ManifestCli.importFrom(store, System.in)
         }.map(rc => if rc == 0 then ExitCode.Success else ExitCode.Error)
+      case "demo" :: rest =>
+        ai.starlake.quack.ondemand.demo.DemoRunner.runDemo(rest)
       case _ =>
         normalManagerRun
 
@@ -170,7 +172,7 @@ object Main extends IOApp with LazyLogging:
     val metricsCfg = source.at("quack-on-demand.metrics").loadOrThrow[MetricsConfig]
     bootManager(mgrCfg, edgeCfg, authCfg, aclCfg, metricsCfg)
 
-  private def bootManager(
+  private[quack] def bootManager(
       mgrCfg: ManagerConfig,
       edgeCfg: FlightConfig,
       authCfg: AuthenticationConfig,
@@ -1285,7 +1287,7 @@ object Main extends IOApp with LazyLogging:
       val leaderDutiesDone       = new java.util.concurrent.atomic.AtomicBoolean(false)
       def leaderDuties: IO[Unit] =
         DemoBootstrapHook.run(
-          env = sys.env.get,
+          env = k => sys.env.get(k).orElse(sys.props.get(k)),
           readFile = path =>
             if path.startsWith("classpath:") then
               val resource = path.stripPrefix("classpath:")

--- a/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/cls/JsqltranspilerRewriter.scala
@@ -171,7 +171,23 @@ final class JsqltranspilerRewriter extends SchemaAwareSqlRewriter:
             val expr     = si.getExpression
             val replaced = visitor.visit(expr)
             if replaced ne expr then
-              si.asInstanceOf[SelectItem[Expression]].setExpression(replaced)
+              val item = si.asInstanceOf[SelectItem[Expression]]
+              item.setExpression(replaced)
+              // A bare `SELECT c_phone` (no explicit AS) relies on the projected Column's own name
+              // for the result-set's field name. Masking replaces that Column with a value
+              // expression (e.g. the literal `'***'`), which has no name of its own -- DuckDB would
+              // otherwise synthesize one from the expression text, changing the column name a
+              // client sees out from under it (breaking `SELECT c_phone ...` -> a result column NOT
+              // named `c_phone`). Preserve the original name as an explicit alias so masking is
+              // transparent to the caller. Only for a directly-masked top-level Column: an explicit
+              // user alias (`SELECT c_phone AS foo`) is left alone, and a masked column nested
+              // inside a function/CASE/etc. keeps whatever name that enclosing expression gets --
+              // there's no bare column name to preserve there.
+              if item.getAlias == null then
+                expr match
+                  case col: net.sf.jsqlparser.schema.Column =>
+                    item.setAlias(new net.sf.jsqlparser.expression.Alias(col.getColumnName))
+                  case _ => ()
               changed.set(true)
             visitor.topLevelOverride = None
             idx += 1

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoBanner.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoBanner.scala
@@ -1,0 +1,28 @@
+package ai.starlake.quack.ondemand.demo
+
+/** The `qod demo` startup banner. Scaled to the minimal demo's story: row + column security on a
+  * governed catalog, connecting as the seeded analyst.
+  */
+object DemoBanner:
+
+  def render(restPort: Int, flightPort: Int, dataPath: String, rows: String): String =
+    s"""|
+        |QoD - demo mode  (no TLS, open REST, ephemeral catalog, demo credentials)
+        |
+        |  DuckLake:   $dataPath (tenant acme, $rows TPC-H rows)
+        |  Flight SQL: grpc://localhost:$flightPort   (TLS off)
+        |  Admin UI:   http://localhost:$restPort
+        |
+        |  Connect as the analyst (row + column security applied):
+        |
+        |  from adbc_driver_flightsql import dbapi
+        |  conn = dbapi.connect("grpc://localhost:$flightPort",
+        |                       db_kwargs={"username": "alice", "password": "demo-alice"})
+        |
+        |  Try: SELECT c_name, c_phone, c_mktsegment FROM acme_tpch.tpch1.customer LIMIT 5
+        |       -- c_phone comes back masked ('***'); only BUILDING-segment rows appear
+        |       -- reconnect as acme-admin / demo-acme-admin and run it again: full data
+        |       -- then SELECT from a table alice has no grant on: denied
+        |
+        |  Ctrl-C stops the demo and deletes $dataPath's parent (ephemeral).
+        |""".stripMargin

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoConfig.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoConfig.scala
@@ -1,0 +1,40 @@
+package ai.starlake.quack.ondemand.demo
+
+import ai.starlake.quack.{FlightConfig, ManagerConfig}
+import ai.starlake.quack.edge.config.AclConfig
+
+/** The effective demo configs produced by [[DemoConfig.overlay]]. */
+final case class DemoConfigs(manager: ManagerConfig, flight: FlightConfig, acl: AclConfig)
+
+/** Produces the demo posture by copying the base configs with demo overrides.
+  *
+  * Guardrail 1: this overlay is the ONLY place the insecure demo settings (TLS off, REST open) are
+  * produced, and it is called ONLY from [[DemoRunner.runDemo]]. `normalManagerRun` never invokes
+  * it, so a normal boot cannot acquire the demo posture. Case-class `copy` returns new instances;
+  * the base configs are never mutated.
+  */
+object DemoConfig:
+
+  def overlay(
+      baseManager: ManagerConfig,
+      baseFlight: FlightConfig,
+      baseAcl: AclConfig,
+      pg: PgCoords,
+      home: DemoHome
+  ): DemoConfigs =
+    val metastore = baseManager.defaultMetastore.copy(
+      pgHost = pg.host,
+      pgPort = pg.port.toString,
+      pgUser = pg.user,
+      pgPassword = pg.password,
+      dbName = "qod",
+      dataPath = home.dataPath.toString
+    )
+    val manager = baseManager.copy(
+      runtimeType = "local",
+      apiKey = None,
+      defaultMetastore = metastore
+    )
+    val flight = baseFlight.copy(tlsEnabled = false, port = 31338)
+    val acl    = baseAcl.copy(enabled = true)
+    DemoConfigs(manager, flight, acl)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoConfig.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoConfig.scala
@@ -33,7 +33,16 @@ object DemoConfig:
     val manager = baseManager.copy(
       runtimeType = "local",
       apiKey = None,
-      defaultMetastore = metastore
+      defaultMetastore = metastore,
+      // The demo must run unmodified on any host: the JNI native client
+      // (`quackwire`) is an ABI-pinned, opt-in-classifier native lib (see
+      // CLAUDE.md "JVM forking" / "native installers") that can fail to load
+      // on a glibc it wasn't built against (observed: `UnsatisfiedLinkError:
+      // GLIBC_2.32 not found`). The plain HTTP client (`QuackHttpClient`'s
+      // non-native path) is the documented fallback for exactly this case, so
+      // the demo pins it rather than inheriting whatever `QOD_NATIVE_CLIENT`
+      // happens to be set to in the operator's shell.
+      nativeClient = false
     )
     val flight = baseFlight.copy(tlsEnabled = false, port = 31338)
     val acl    = baseAcl.copy(enabled = true)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoHome.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoHome.scala
@@ -1,0 +1,48 @@
+package ai.starlake.quack.ondemand.demo
+
+import java.nio.file.{Files, Path, Paths}
+import scala.jdk.CollectionConverters.*
+
+/** Ephemeral root for a `qod demo` run. Everything a demo touches lives under `root` so teardown is
+  * a single recursive delete.
+  */
+final case class DemoHome(root: Path, pgDir: Path, dataPath: Path, nativeDir: Path):
+
+  /** Best-effort recursive delete (deepest-first). Teardown must not throw on a partially-created
+    * or locked tree.
+    */
+  def deleteRecursively(): Unit =
+    if Files.exists(root) then
+      Files
+        .walk(root)
+        .sorted(java.util.Comparator.reverseOrder())
+        .iterator()
+        .asScala
+        .foreach(p =>
+          try Files.deleteIfExists(p)
+          catch { case _: Throwable => () }
+        )
+
+object DemoHome:
+
+  /** System property that pins where the DuckDB / quack JNI native is unpacked (Guardrail 2). */
+  val NativeExtractionProp = "duckdb.jni.tmpdir"
+
+  private def defaultRoot: Path =
+    val tmp = sys.env.getOrElse("TMPDIR", System.getProperty("java.io.tmpdir"))
+    Paths.get(tmp, "qod-demo")
+
+  /** Create the demo home (from `explicit`, else `QOD_DEMO_HOME`, else `${TMPDIR}/qod-demo`) and
+    * its subdirs, then pin the native-extraction system property to `nativeDir`.
+    */
+  def create(explicit: Option[String]): DemoHome =
+    val root = explicit
+      .orElse(sys.env.get("QOD_DEMO_HOME"))
+      .map(Paths.get(_))
+      .getOrElse(defaultRoot)
+    val pgDir     = root.resolve("pg")
+    val dataPath  = root.resolve("ducklake")
+    val nativeDir = root.resolve("native")
+    List(root, pgDir, dataPath, nativeDir).foreach(Files.createDirectories(_))
+    System.setProperty(NativeExtractionProp, nativeDir.toString)
+    DemoHome(root, pgDir, dataPath, nativeDir)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoHome.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoHome.scala
@@ -25,15 +25,29 @@ final case class DemoHome(root: Path, pgDir: Path, dataPath: Path, nativeDir: Pa
 
 object DemoHome:
 
-  /** System property that pins where the DuckDB / quack JNI native is unpacked (Guardrail 2). */
-  val NativeExtractionProp = "duckdb.jni.tmpdir"
+  // NOTE (final-review Fix 1): a prior revision of this object set a
+  // `duckdb.jni.tmpdir` system property here, intending to pin where the DuckDB JNI native gets
+  // unpacked (the design doc's "Guardrail 2"). That property is never read by anything -- the
+  // DuckDB JDBC driver (`org.duckdb.DuckDBNative.unpackAndLoad`) always unpacks via
+  // `Files.createTempFile("libduckdb_java", ".so")`, which resolves against the JVM's
+  // `jdk.internal.util.StaticProperty` snapshot of `java.io.tmpdir` taken at VM start -- not the
+  // live `System.getProperty`/`System.setProperty` value. Verified empirically (Java 21): calling
+  // `System.setProperty("java.io.tmpdir", ...)` at any point *after* the JVM has started, however
+  // early in `main`, has zero effect on where `Files.createTempFile` lands; only a `-D` flag passed
+  // at JVM launch does. The demo has no way to pass JVM flags to its own already-running process, so
+  // this pin is not achievable in-process. Rather than keep an assertion on a property nothing
+  // reads, the property-set was removed here; the native `.so` extracts to the ambient
+  // `java.io.tmpdir` and self-cleans via `File.deleteOnExit()` inside DuckDB's own unpack code. See
+  // `docs/superpowers/specs/2026-07-16-qod-demo-self-contained-design.md` Guardrail 2 for the
+  // corrected claim. `nativeDir` is kept as a real, created-and-deleted subdir of the demo home for
+  // shape/symmetry with `pgDir`/`dataPath`, even though nothing writes into it today.
 
   private def defaultRoot: Path =
     val tmp = sys.env.getOrElse("TMPDIR", System.getProperty("java.io.tmpdir"))
     Paths.get(tmp, "qod-demo")
 
   /** Create the demo home (from `explicit`, else `QOD_DEMO_HOME`, else `${TMPDIR}/qod-demo`) and
-    * its subdirs, then pin the native-extraction system property to `nativeDir`.
+    * its subdirs.
     */
   def create(explicit: Option[String]): DemoHome =
     val root = explicit
@@ -44,5 +58,4 @@ object DemoHome:
     val dataPath  = root.resolve("ducklake")
     val nativeDir = root.resolve("native")
     List(root, pgDir, dataPath, nativeDir).foreach(Files.createDirectories(_))
-    System.setProperty(NativeExtractionProp, nativeDir.toString)
     DemoHome(root, pgDir, dataPath, nativeDir)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoPostgres.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoPostgres.scala
@@ -39,7 +39,11 @@ object DemoPostgres:
   Class.forName("org.postgresql.Driver")
 
   /** Start an embedded Postgres rooted at `dataDir` on an OS-assigned free port. zonky's default
-    * superuser is `postgres` with an empty password.
+    * superuser is `postgres`; it authenticates via `trust` (the password is not verified), so we
+    * report a non-empty placeholder password. Downstream consumers (`LiquibaseRunner`,
+    * `PostgresControlPlaneStore`, spawned Quack nodes) require a non-empty `pgPassword`
+    * (`required(_).filter(_.nonEmpty)`); an empty string fails their config gate even though trust
+    * auth would accept it. The value itself is irrelevant to the embedded server.
     */
   def start(dataDir: Path): DemoPostgres =
     val instance = EmbeddedPostgres
@@ -47,5 +51,5 @@ object DemoPostgres:
       .setOverrideWorkingDirectory(dataDir.toFile)
       .setDataDirectory(dataDir.resolve("pgdata").toFile)
       .start()
-    val coords = PgCoords("localhost", instance.getPort, "postgres", "")
+    val coords = PgCoords("localhost", instance.getPort, "postgres", "postgres")
     new DemoPostgres(instance, coords)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoPostgres.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoPostgres.scala
@@ -1,0 +1,51 @@
+package ai.starlake.quack.ondemand.demo
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+
+import java.nio.file.Path
+import java.sql.DriverManager
+
+/** Coordinates for reaching the embedded demo Postgres. */
+final case class PgCoords(host: String, port: Int, user: String, password: String):
+  def jdbcUrl(db: String): String = s"jdbc:postgresql://$host:$port/$db"
+
+/** Ephemeral embedded Postgres for `qod demo`. Wraps a zonky [[EmbeddedPostgres]] whose data
+  * directory lives under the demo home, so teardown removes it with the rest of the demo state.
+  */
+final class DemoPostgres private (instance: EmbeddedPostgres, val coords: PgCoords):
+
+  /** Idempotent `CREATE DATABASE`. Postgres has no `IF NOT EXISTS` for databases, so we probe
+    * `pg_database` first and skip when present.
+    */
+  def createDatabase(name: String): Unit =
+    val admin =
+      DriverManager.getConnection(coords.jdbcUrl("postgres"), coords.user, coords.password)
+    try
+      val exists =
+        val ps = admin.prepareStatement("SELECT 1 FROM pg_database WHERE datname = ?")
+        ps.setString(1, name)
+        try ps.executeQuery().next()
+        finally ps.close()
+      if !exists then
+        val st = admin.createStatement()
+        try st.executeUpdate(s"""CREATE DATABASE "$name"""")
+        finally st.close()
+    finally admin.close()
+
+  def stop(): Unit = instance.close()
+
+object DemoPostgres:
+
+  Class.forName("org.postgresql.Driver")
+
+  /** Start an embedded Postgres rooted at `dataDir` on an OS-assigned free port. zonky's default
+    * superuser is `postgres` with an empty password.
+    */
+  def start(dataDir: Path): DemoPostgres =
+    val instance = EmbeddedPostgres
+      .builder()
+      .setOverrideWorkingDirectory(dataDir.toFile)
+      .setDataDirectory(dataDir.resolve("pgdata").toFile)
+      .start()
+    val coords = PgCoords("localhost", instance.getPort, "postgres", "")
+    new DemoPostgres(instance, coords)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
@@ -1,0 +1,92 @@
+package ai.starlake.quack.ondemand.demo
+
+import ai.starlake.quack.Main
+import ai.starlake.quack.edge.config.AclConfig
+import ai.starlake.quack.observability.metrics.MetricsConfigCodec
+import ai.starlake.quack.{FlightConfig, ManagerConfig}
+import cats.effect.{ExitCode, IO}
+import org.slf4j.LoggerFactory
+import pureconfig.ConfigSource
+
+/** `qod demo` orchestration. Boots a fully self-contained, seeded, RBAC-secured manager on an
+  * embedded ephemeral Postgres, prints the demo banner, and tears everything down on exit.
+  *
+  * Guardrail 1: the insecure demo posture is produced by [[DemoConfig.overlay]] here and nowhere
+  * else; `normalManagerRun` never calls into this object.
+  */
+object DemoRunner:
+
+  import Main.given // camelCase ConfigReaders, matching normalManagerRun
+  import MetricsConfigCodec.given
+
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val Sf     = 0.1
+  private val DbName = "acme_tpch"
+  private val Schema = "tpch1"
+
+  def runDemo(args: List[String]): IO[ExitCode] =
+    val explicitHome = args.headOption
+    IO.blocking(setup(explicitHome)).flatMap { case (home, pg, configs) =>
+      val cleanup = IO.blocking {
+        logger.info("demo: tearing down")
+        try pg.stop()
+        finally home.deleteRecursively()
+      }
+      bootWithBanner(home, configs).guarantee(cleanup)
+    }
+
+  /** Blocking, ordered setup: home -> embedded PG -> databases -> config overlay -> seed manifest
+    * env -> data seed. Returns the pieces the boot needs.
+    */
+  private def setup(explicitHome: Option[String]): (DemoHome, DemoPostgres, DemoConfigs) =
+    val home = DemoHome.create(explicitHome)
+    val pg   = DemoPostgres.start(home.pgDir)
+    pg.createDatabase("qod")  // control plane
+    pg.createDatabase(DbName) // tenant-db DuckLake catalog
+
+    val base    = loadBase()
+    val configs = DemoConfig.overlay(base._1, base._2, base._3, pg.coords, home)
+
+    // Point DemoBootstrapHook at the bundled minimal manifest so the manager seeds the control
+    // plane on first boot. The hook's env reader is patched (Step 6b) to fall back to system
+    // properties, and its readFile already supports the `classpath:` prefix, so no file extraction
+    // is needed. The JVM cannot mutate the real process env, hence the sysprop channel.
+    System.setProperty("QOD_BOOTSTRAP_YAML", "classpath:bootstrap-demo-minimal.yaml")
+    // Liquibase must create qodstate_* before the hook imports; the manager boot does that. The
+    // hook runs inside boot after migration. Data seeding, however, needs the tenant-db catalog
+    // reachable independently -- run it now against the embedded PG.
+    DemoSeed.run(pg.coords, DbName, Schema, home, Sf) match
+      case Left(err) => sys.error(err)
+      case Right(()) => ()
+    (home, pg, configs)
+
+  private def loadBase(): (ManagerConfig, FlightConfig, AclConfig) =
+    val src = ConfigSource.default
+    (
+      src.at("quack-on-demand").loadOrThrow[ManagerConfig],
+      src.at("quack-flightsql").loadOrThrow[FlightConfig],
+      src.at("quack-flightsql.acl").loadOrThrow[AclConfig]
+    )
+
+  // NOTE (Step 6b): the manifest path is delivered via System.setProperty above; the boot-time
+  // DemoBootstrapHook call site (Main.scala:1280) must read it. Change its env reader from
+  // `env = sys.env.get` to `env = k => sys.env.get(k).orElse(sys.props.get(k))`. Additive: the real
+  // env var still wins for normal boots; only the demo path relies on the sysprop fallback.
+
+  private def bootWithBanner(home: DemoHome, configs: DemoConfigs): IO[ExitCode] =
+    val authCfg =
+      ConfigSource.default
+        .at("quack-flightsql.auth")
+        .loadOrThrow[ai.starlake.quack.edge.config.AuthenticationConfig]
+    val metricsCfg =
+      ConfigSource.default
+        .at("quack-on-demand.metrics")
+        .loadOrThrow[ai.starlake.quack.observability.metrics.MetricsConfig]
+    val banner = DemoBanner.render(
+      restPort = configs.manager.port,
+      flightPort = configs.flight.port,
+      dataPath = home.dataPath.toString,
+      rows = "~150K"
+    )
+    IO.blocking(println(banner)) *>
+      Main.bootManager(configs.manager, configs.flight, authCfg, configs.acl, metricsCfg)

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
@@ -26,21 +26,32 @@ object DemoRunner:
 
   def runDemo(args: List[String]): IO[ExitCode] =
     val explicitHome = args.headOption
-    IO.blocking(setup(explicitHome)).flatMap { case (home, pg, configs) =>
-      val cleanup = IO.blocking {
-        logger.info("demo: tearing down")
-        try pg.stop()
-        finally home.deleteRecursively()
-      }
-      bootWithBanner(home, configs).guarantee(cleanup)
+    // `home` is created up front (a cheap, side-effect-free mkdir) and `pgRef` records the embedded
+    // PG instance the moment it starts, BEFORE any later setup step (createDatabase, config load,
+    // DemoSeed) that can throw. `cleanup` is attached via `.guarantee` around the WHOLE setup+boot
+    // chain (not just the boot), so a mid-setup failure -- e.g. a bad config -- still stops PG and
+    // deletes the home instead of leaking both under ${TMPDIR}/qod-demo.
+    val home  = DemoHome.create(explicitHome)
+    val pgRef = new java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]](None)
+    val cleanup = IO.blocking {
+      logger.info("demo: tearing down")
+      try pgRef.get().foreach(_.stop())
+      finally home.deleteRecursively()
     }
+    IO.blocking(setup(home, pgRef))
+      .flatMap(configs => bootWithBanner(home, configs))
+      .guarantee(cleanup)
 
-  /** Blocking, ordered setup: home -> embedded PG -> databases -> config overlay -> seed manifest
-    * env -> data seed. Returns the pieces the boot needs.
+  /** Blocking, ordered setup: embedded PG -> databases -> config overlay -> seed manifest env ->
+    * data seed. `pgRef` is populated as soon as PG starts so `runDemo`'s cleanup can stop it even if
+    * a later step here fails.
     */
-  private def setup(explicitHome: Option[String]): (DemoHome, DemoPostgres, DemoConfigs) =
-    val home = DemoHome.create(explicitHome)
-    val pg   = DemoPostgres.start(home.pgDir)
+  private def setup(
+      home: DemoHome,
+      pgRef: java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]]
+  ): DemoConfigs =
+    val pg = DemoPostgres.start(home.pgDir)
+    pgRef.set(Some(pg))
     pg.createDatabase("qod")  // control plane
     pg.createDatabase(DbName) // tenant-db DuckLake catalog
 
@@ -58,7 +69,7 @@ object DemoRunner:
     DemoSeed.run(pg.coords, DbName, Schema, home, Sf) match
       case Left(err) => sys.error(err)
       case Right(()) => ()
-    (home, pg, configs)
+    configs
 
   private def loadBase(): (ManagerConfig, FlightConfig, AclConfig) =
     val src = ConfigSource.default

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
@@ -31,8 +31,8 @@ object DemoRunner:
     // DemoSeed) that can throw. `cleanup` is attached via `.guarantee` around the WHOLE setup+boot
     // chain (not just the boot), so a mid-setup failure -- e.g. a bad config -- still stops PG and
     // deletes the home instead of leaking both under ${TMPDIR}/qod-demo.
-    val home  = DemoHome.create(explicitHome)
-    val pgRef = new java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]](None)
+    val home    = DemoHome.create(explicitHome)
+    val pgRef   = new java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]](None)
     val cleanup = IO.blocking {
       logger.info("demo: tearing down")
       try pgRef.get().foreach(_.stop())
@@ -43,13 +43,26 @@ object DemoRunner:
       .guarantee(cleanup)
 
   /** Blocking, ordered setup: embedded PG -> databases -> config overlay -> seed manifest env ->
-    * data seed. `pgRef` is populated as soon as PG starts so `runDemo`'s cleanup can stop it even if
-    * a later step here fails.
+    * data seed. `pgRef` is populated as soon as PG starts so `runDemo`'s cleanup can stop it even
+    * if a later step here fails.
     */
   private def setup(
       home: DemoHome,
       pgRef: java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]]
   ): DemoConfigs =
+    // RLS/CLS are the whole point of the demo banner's promise, but both are read straight off
+    // `com.typesafe.config.ConfigFactory.load()` deep inside `Main.bootManager` (`cls.enabled` /
+    // `rls.enabled` under `quack-on-demand`) rather than through the `ManagerConfig` case class
+    // `DemoConfig.overlay` copies -- so that overlay can't reach them. Unlike `QOD_BOOTSTRAP_YAML`
+    // (a plain `sys.env`-reading Scala function DemoBootstrapHook owns), these are genuine HOCON
+    // keys resolved via Typesafe Config, which DOES treat JVM system properties as the
+    // highest-priority override layer -- so setting the config keys themselves (not the `QOD_*`
+    // env-var aliases) as system properties works. Done first, before `loadBase()`'s pureconfig
+    // call ever touches `ConfigFactory`, with an explicit `invalidateCaches()` as a safety net
+    // against Typesafe Config's internal system-properties snapshot caching.
+    System.setProperty("quack-on-demand.cls.enabled", "true")
+    System.setProperty("quack-on-demand.rls.enabled", "true")
+    com.typesafe.config.ConfigFactory.invalidateCaches()
     val pg = DemoPostgres.start(home.pgDir)
     pgRef.set(Some(pg))
     pg.createDatabase("qod")  // control plane
@@ -85,10 +98,27 @@ object DemoRunner:
   // env var still wins for normal boots; only the demo path relies on the sysprop fallback.
 
   private def bootWithBanner(home: DemoHome, configs: DemoConfigs): IO[ExitCode] =
-    val authCfg =
+    val baseAuthCfg =
       ConfigSource.default
         .at("quack-flightsql.auth")
         .loadOrThrow[ai.starlake.quack.edge.config.AuthenticationConfig]
+    // `auth.database.{jdbcUrl,username,password}` is templated in application.conf off
+    // `quack-on-demand.defaultMetastore.*` (HOCON substitution at parse time), so reloading it
+    // fresh from `ConfigSource.default` here re-resolves against the REAL default metastore coords
+    // -- not `configs.manager.defaultMetastore`, which only exists as an in-memory overlay produced
+    // by `DemoConfig.overlay` and was never written back to a config source. Left unpatched, the
+    // demo's DB-auth backend probes the wrong Postgres (the operator's real dev instance, if any, or
+    // a connection-refused) instead of the embedded one -- a silent Guardrail-1-adjacent gap, not
+    // the deliberate insecure-posture overlay itself. Point it at the SAME coords + `qod` database
+    // DemoConfig.overlay already put in `configs.manager.defaultMetastore`.
+    val ms      = configs.manager.defaultMetastore
+    val authCfg = baseAuthCfg.copy(
+      database = baseAuthCfg.database.copy(
+        jdbcUrl = s"jdbc:postgresql://${ms.pgHost}:${ms.pgPort}/${ms.dbName}",
+        username = ms.pgUser,
+        password = ms.pgPassword
+      )
+    )
     val metricsCfg =
       ConfigSource.default
         .at("quack-on-demand.metrics")

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoRunner.scala
@@ -24,6 +24,36 @@ object DemoRunner:
   private val DbName = "acme_tpch"
   private val Schema = "tpch1"
 
+  // Final-review Fix 2: every JVM-global system property `setup` mutates, listed once so
+  // snapshot/restore stay obviously symmetric (add here, not ad hoc at each call site, if a future
+  // change makes `setup` set another one). `Test/fork := true` runs each spec class in its own JVM,
+  // but within ONE suite class multiple tests (or, worse, a later spec sharing that fork) would
+  // otherwise inherit whatever `runDemo` last left set -- e.g. `QOD_BOOTSTRAP_YAML` pointing at the
+  // demo's minimal manifest, or cls/rls forced on -- an order-dependent flake.
+  private val MutatedSysProps = List(
+    "quack-on-demand.cls.enabled",
+    "quack-on-demand.rls.enabled",
+    "QOD_BOOTSTRAP_YAML"
+  )
+
+  /** Capture the current value (`Some`) or absence (`None`) of every property [[MutatedSysProps]]
+    * lists, so [[restoreSysProps]] can put the JVM back exactly how it found it.
+    */
+  private def snapshotSysProps(): Map[String, Option[String]] =
+    MutatedSysProps.map(k => k -> Option(System.getProperty(k))).toMap
+
+  /** Undo `setup`'s system-property mutations: re-set whatever was previously present, clear
+    * whatever was previously absent, then invalidate Typesafe Config's cache so a later boot in the
+    * same JVM (e.g. the next spec in this fork) re-reads the restored values instead of a stale
+    * snapshot.
+    */
+  private def restoreSysProps(snapshot: Map[String, Option[String]]): Unit =
+    snapshot.foreach {
+      case (k, Some(v)) => System.setProperty(k, v)
+      case (k, None)    => System.clearProperty(k)
+    }
+    com.typesafe.config.ConfigFactory.invalidateCaches()
+
   def runDemo(args: List[String]): IO[ExitCode] =
     val explicitHome = args.headOption
     // `home` is created up front (a cheap, side-effect-free mkdir) and `pgRef` records the embedded
@@ -31,12 +61,15 @@ object DemoRunner:
     // DemoSeed) that can throw. `cleanup` is attached via `.guarantee` around the WHOLE setup+boot
     // chain (not just the boot), so a mid-setup failure -- e.g. a bad config -- still stops PG and
     // deletes the home instead of leaking both under ${TMPDIR}/qod-demo.
-    val home    = DemoHome.create(explicitHome)
-    val pgRef   = new java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]](None)
-    val cleanup = IO.blocking {
+    val home          = DemoHome.create(explicitHome)
+    val propsSnapshot = snapshotSysProps() // captured BEFORE `setup` sets any of MutatedSysProps
+    val pgRef         = new java.util.concurrent.atomic.AtomicReference[Option[DemoPostgres]](None)
+    val cleanup       = IO.blocking {
       logger.info("demo: tearing down")
       try pgRef.get().foreach(_.stop())
-      finally home.deleteRecursively()
+      finally
+        try home.deleteRecursively()
+        finally restoreSysProps(propsSnapshot)
     }
     IO.blocking(setup(home, pgRef))
       .flatMap(configs => bootWithBanner(home, configs))

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoSeed.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoSeed.scala
@@ -1,0 +1,66 @@
+package ai.starlake.quack.ondemand.demo
+
+import org.slf4j.LoggerFactory
+
+import scala.sys.process.*
+
+/** Seeds the demo tenant-db with a small TPC-H dataset via DuckDB's built-in `dbgen()`. Mirrors
+  * `scripts/load-tpch-dbgen.sh`: ATTACH the DuckLake-over-Postgres catalog, create the schema, then
+  * `CALL dbgen(...)` into the default in-memory database and `CREATE TABLE ... AS SELECT *` each of
+  * the 8 TPC-H tables into the DuckLake schema.
+  *
+  * `dbgen()` only writes to a native DuckDB catalog (validated against real DuckLake-over-Postgres:
+  * `CALL dbgen(sf = ..., catalog = ..., schema = ...)` and `USE db.schema; CALL dbgen(sf = ...)`
+  * both fail with `Invalid Input Error: dbgen is only supported for DuckDB database files`), so it
+  * cannot target an ATTACHed DuckLake catalog directly - hence the CTAS copy step below.
+  *
+  * Runs the loader in the same process/host as the manager, so the DuckLake absolute-`DATA_PATH`
+  * matching requirement holds by construction.
+  */
+object DemoSeed:
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val Tables =
+    List("region", "nation", "customer", "supplier", "part", "partsupp", "orders", "lineitem")
+
+  /** The DuckDB init script. `dataPath` MUST be the same absolute path the manager's nodes read. */
+  def buildInitSql(
+      pg: PgCoords,
+      dbName: String,
+      schema: String,
+      dataPath: String,
+      sf: Double
+  ): String =
+    val ctas = Tables
+      .map(t => s"CREATE TABLE $dbName.$schema.$t AS SELECT * FROM memory.main.$t;")
+      .mkString("\n")
+    s"""INSTALL ducklake; LOAD ducklake;
+       |INSTALL postgres; LOAD postgres;
+       |INSTALL tpch;     LOAD tpch;
+       |ATTACH 'ducklake:postgres:host=${pg.host} port=${pg.port} dbname=$dbName user=${pg.user} password=${pg.password}' AS $dbName
+       |  (DATA_PATH '$dataPath');
+       |CREATE SCHEMA IF NOT EXISTS $dbName.$schema;
+       |CALL dbgen(sf = $sf);
+       |$ctas
+       |""".stripMargin
+
+  /** Pipe the init script into the `duckdb` CLI. Returns Left with captured stderr on failure. */
+  def run(
+      pg: PgCoords,
+      dbName: String,
+      schema: String,
+      home: DemoHome,
+      sf: Double,
+      duckdb: String = "duckdb"
+  ): Either[String, Unit] =
+    val sql = buildInitSql(pg, dbName, schema, home.dataPath.toString, sf)
+    val err = new StringBuilder
+    logger.info(s"demo seed: dbgen sf=$sf into $dbName.$schema at ${home.dataPath}")
+    val exit =
+      try
+        (Seq(duckdb) #< new java.io.ByteArrayInputStream(sql.getBytes("UTF-8")))
+          .!(ProcessLogger(_ => (), e => err.append(e).append('\n')))
+      catch case t: Throwable => err.append(t.getMessage); -1
+    if exit == 0 then Right(())
+    else Left(s"demo seed failed (exit $exit): ${err.toString.trim}")

--- a/src/main/scala/ai/starlake/quack/ondemand/demo/DemoSeed.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/demo/DemoSeed.scala
@@ -2,7 +2,7 @@ package ai.starlake.quack.ondemand.demo
 
 import org.slf4j.LoggerFactory
 
-import scala.sys.process.*
+import java.nio.file.Files
 
 /** Seeds the demo tenant-db with a small TPC-H dataset via DuckDB's built-in `dbgen()`. Mirrors
   * `scripts/load-tpch-dbgen.sh`: ATTACH the DuckLake-over-Postgres catalog, create the schema, then
@@ -45,22 +45,95 @@ object DemoSeed:
        |$ctas
        |""".stripMargin
 
-  /** Pipe the init script into the `duckdb` CLI. Returns Left with captured stderr on failure. */
+  /** A `DROP SCHEMA ... CASCADE` inserted right before the `CREATE SCHEMA` line of
+    * [[buildInitSql]]'s output. Used only by retry attempts in [[run]]: the observed flake (below)
+    * can leave a fully-populated schema behind even though the CLI itself reported a nonzero exit,
+    * and the plain `CREATE TABLE ... AS SELECT` in [[buildInitSql]] is not safe to replay against a
+    * schema that already has those tables. Rebuilding via string substitution (rather than a second
+    * hand-maintained template) keeps this in lockstep with [[buildInitSql]] and leaves that
+    * method's output -- and the tests pinned to its exact text -- untouched.
+    */
+  private def buildRetryInitSql(
+      pg: PgCoords,
+      dbName: String,
+      schema: String,
+      dataPath: String,
+      sf: Double
+  ): String =
+    val createSchema   = s"CREATE SCHEMA IF NOT EXISTS $dbName.$schema;"
+    val dropThenCreate =
+      s"DROP SCHEMA IF EXISTS $dbName.$schema CASCADE;\n$createSchema"
+    buildInitSql(pg, dbName, schema, dataPath, sf).replace(createSchema, dropThenCreate)
+
+  /** Run the `duckdb` CLI against `sql` once. Returns the process exit code and captured stderr.
+    *
+    * Uses `java.lang.ProcessBuilder` with stdin/stderr fully redirected to/from files rather than
+    * `scala.sys.process`'s pipe-plus-feeder-thread plumbing (`#<` + `ProcessLogger`): the latter
+    * was observed to intermittently report a bogus nonzero exit for a `duckdb` run that actually
+    * completed every statement (see [[run]]'s doc). File redirection needs no extra threads and was
+    * reliable across repeated trials in the same environment where the pipe form flaked, so it's
+    * the safer primitive here even though the two should be behaviorally equivalent.
+    */
+  private def runOnce(duckdb: String, sql: String): (Int, String) =
+    val sqlFile = Files.createTempFile("qod-demo-seed-", ".sql")
+    val errFile = Files.createTempFile("qod-demo-seed-", ".err")
+    try
+      Files.writeString(sqlFile, sql)
+      val pb = new java.lang.ProcessBuilder(duckdb)
+      pb.redirectInput(sqlFile.toFile)
+      pb.redirectOutput(java.lang.ProcessBuilder.Redirect.DISCARD)
+      pb.redirectError(errFile.toFile)
+      val exit = pb.start().waitFor()
+      val err  = scala.util.Try(Files.readString(errFile)).getOrElse("")
+      (exit, err.trim)
+    catch case t: Throwable => (-1, Option(t.getMessage).getOrElse(t.toString))
+    finally
+      scala.util.Try(Files.deleteIfExists(sqlFile))
+      scala.util.Try(Files.deleteIfExists(errFile))
+      ()
+
+  /** Run the init script through the `duckdb` CLI, retrying on failure. Returns Left with the last
+    * captured stderr if every attempt fails.
+    *
+    * Observed on this project's dev/CI hosts: `duckdb`, invoked as a child process of the manager's
+    * JVM, occasionally reports a nonzero / `-1` exit with EMPTY stderr even though every statement
+    * in the script actually completed (the DuckLake schema is fully populated afterwards) -- i.e.
+    * the work succeeds but the reported exit status doesn't. Root cause not pinned down; a bounded
+    * retry is the pragmatic mitigation on top of the file-redirected [[runOnce]]. Retries use
+    * [[buildRetryInitSql]] (`DROP SCHEMA ... CASCADE` before recreating) so a retry after a
+    * "phantom failure" -- where the schema is already fully populated -- doesn't itself fail on
+    * `CREATE TABLE ... already exists`.
+    */
   def run(
       pg: PgCoords,
       dbName: String,
       schema: String,
       home: DemoHome,
       sf: Double,
-      duckdb: String = "duckdb"
+      duckdb: String = "duckdb",
+      maxAttempts: Int = 3
   ): Either[String, Unit] =
-    val sql = buildInitSql(pg, dbName, schema, home.dataPath.toString, sf)
-    val err = new StringBuilder
-    logger.info(s"demo seed: dbgen sf=$sf into $dbName.$schema at ${home.dataPath}")
-    val exit =
-      try
-        (Seq(duckdb) #< new java.io.ByteArrayInputStream(sql.getBytes("UTF-8")))
-          .!(ProcessLogger(_ => (), e => err.append(e).append('\n')))
-      catch case t: Throwable => err.append(t.getMessage); -1
-    if exit == 0 then Right(())
-    else Left(s"demo seed failed (exit $exit): ${err.toString.trim}")
+    // `PoolSupervisor.effectiveMetastoreFor` derives a DuckLake tenant-db's dataPath by replacing
+    // the LAST path segment of `defaultMetastore.dataPath` (== `home.dataPath` here, per
+    // DemoConfig.overlay) with the tenant-db's name (`PoolSupervisor.replaceLastSegment`) -- e.g.
+    // `.../ducklake` -> `.../acme_tpch`, NOT a subdirectory of `.../ducklake`. Seeding must ATTACH
+    // at that SAME computed path, or the manager's own node later ATTACHes a physically different
+    // (empty) directory and reports `Catalog "acme_tpch" does not exist!` even though the seed
+    // "succeeded" against the wrong path. See DuckLake's absolute-DATA_PATH matching requirement
+    // (class doc above).
+    val dataPath = ai.starlake.quack.ondemand.PoolSupervisor.replaceLastSegment(
+      home.dataPath.toString,
+      dbName
+    )
+    val firstSql      = buildInitSql(pg, dbName, schema, dataPath, sf)
+    lazy val retrySql = buildRetryInitSql(pg, dbName, schema, dataPath, sf)
+    logger.info(s"demo seed: dbgen sf=$sf into $dbName.$schema at $dataPath")
+    @scala.annotation.tailrec
+    def attempt(n: Int, sql: String): Either[String, Unit] =
+      val (exit, err) = runOnce(duckdb, sql)
+      if exit == 0 then Right(())
+      else if n < maxAttempts then
+        logger.warn(s"demo seed: attempt $n/$maxAttempts failed (exit $exit): $err -- retrying")
+        attempt(n + 1, retrySql)
+      else Left(s"demo seed failed after $maxAttempts attempts (exit $exit): $err")
+    attempt(1, firstSql)

--- a/src/main/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackend.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackend.scala
@@ -35,6 +35,15 @@ final class LocalQuackBackend(
     // Defaults from application.conf apply first; per-pool entries from
     // CreatePoolRequest.metastore override them.
     val env = pb.environment()
+    // When running from an installed app-image (QOD_APP_HOME set), prepend the bundled duckdb bin
+    // so spawn-quack-node.sh's `command -v duckdb` resolves it. Additive: no-op in dev/source runs.
+    LocalQuackBackend.duckdbPathPrefix(sys.env.get("QOD_APP_HOME")).foreach { prefix =>
+      val current = Option(env.get("PATH")).getOrElse("")
+      env.put(
+        "PATH",
+        if current.isEmpty then prefix else s"$prefix${java.io.File.pathSeparator}$current"
+      )
+    }
     defaultMetastore.foreach { case (k, v) => env.put(k, v) }
     spec.metastore.foreach { case (k, v) => env.put(k, v) }
     env.put("kind", spec.kindWire)
@@ -153,6 +162,13 @@ object LocalQuackBackend:
     * this constant is the in-repo fallback so the test suite and zero-config dev runs keep working.
     */
   val DefaultSpawnScript: String = "./scripts/spawn-quack-node.sh"
+
+  /** Directory to prepend to the spawned node's PATH so it resolves the bundled `duckdb`. Set only
+    * when `QOD_APP_HOME` is present (installed app-image); `None` for repo/dev runs, which rely on
+    * `duckdb` already being on PATH.
+    */
+  def duckdbPathPrefix(appHome: Option[String]): Option[String] =
+    appHome.filter(_.nonEmpty).map(h => s"$h/duckdb/bin")
 
   /** In-repo Windows fallback spawn script (a PowerShell mirror of
     * `spawn-quack-node.sh`). Production passes `mgrCfg.spawnScriptWindows`

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoBannerSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoBannerSpec.scala
@@ -1,0 +1,21 @@
+package ai.starlake.quack.ondemand.demo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DemoBannerSpec extends AnyFlatSpec with Matchers:
+
+  "DemoBanner.render" should "name the insecure caveats, a demo user snippet, and the RLS/CLS beat" in {
+    val b =
+      DemoBanner.render(restPort = 20900, flightPort = 31338, dataPath = "/demo", rows = "~150K")
+    b should include("demo mode")
+    b should include("no TLS")    // caveat
+    b should include("ephemeral") // caveat
+    b should include("grpc://localhost:31338")
+    b should include("http://localhost:20900")
+    b should include("username") // runnable connect snippet uses a seeded demo user
+    b should include("c_phone")  // CLS beat
+    b should include("masked")   // CLS beat
+    b should include("BUILDING") // RLS beat
+    b should include("denied")   // denial beat
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoConfigSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoConfigSpec.scala
@@ -1,0 +1,47 @@
+package ai.starlake.quack.ondemand.demo
+
+import ai.starlake.quack.edge.config.AclConfig
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import pureconfig.ConfigSource
+
+import java.nio.file.Paths
+
+class DemoConfigSpec extends AnyFlatSpec with Matchers:
+
+  // Load the real defaults exactly as normalManagerRun does, to prove the overlay
+  // transforms a genuine base config (not a hand-built stub).
+  import ai.starlake.quack.Main.given
+  private val baseManager =
+    ConfigSource.default.at("quack-on-demand").loadOrThrow[ai.starlake.quack.ManagerConfig]
+  private val baseFlight =
+    ConfigSource.default.at("quack-flightsql").loadOrThrow[ai.starlake.quack.FlightConfig]
+  private val baseAcl =
+    ConfigSource.default.at("quack-flightsql.acl").loadOrThrow[AclConfig]
+
+  private val home =
+    DemoHome(Paths.get("/x"), Paths.get("/x/pg"), Paths.get("/x/dl"), Paths.get("/x/native"))
+  private val pg = PgCoords("localhost", 54321, "postgres", "")
+
+  "DemoConfig.overlay" should "force the approved demo posture" in {
+    val out = DemoConfig.overlay(baseManager, baseFlight, baseAcl, pg, home)
+    out.manager.defaultMetastore.pgHost shouldBe "localhost"
+    out.manager.defaultMetastore.pgPort shouldBe "54321"
+    out.manager.defaultMetastore.pgUser shouldBe "postgres"
+    out.manager.defaultMetastore.pgPassword shouldBe ""
+    out.manager.defaultMetastore.dbName shouldBe "qod"
+    out.manager.defaultMetastore.dataPath shouldBe "/x/dl"
+    out.manager.runtimeType shouldBe "local"
+    out.manager.apiKey shouldBe None     // REST open
+    out.flight.tlsEnabled shouldBe false // TLS off
+    out.flight.port shouldBe 31338
+    out.acl.enabled shouldBe true // ACL kept on
+  }
+
+  it should "leave the base configs untouched (Guardrail 1: no in-place mutation)" in {
+    val beforeTls = baseFlight.tlsEnabled
+    val beforeKey = baseManager.apiKey
+    DemoConfig.overlay(baseManager, baseFlight, baseAcl, pg, home)
+    baseFlight.tlsEnabled shouldBe beforeTls
+    baseManager.apiKey shouldBe beforeKey
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoConfigSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoConfigSpec.scala
@@ -32,8 +32,9 @@ class DemoConfigSpec extends AnyFlatSpec with Matchers:
     out.manager.defaultMetastore.dbName shouldBe "qod"
     out.manager.defaultMetastore.dataPath shouldBe "/x/dl"
     out.manager.runtimeType shouldBe "local"
-    out.manager.apiKey shouldBe None     // REST open
-    out.flight.tlsEnabled shouldBe false // TLS off
+    out.manager.apiKey shouldBe None        // REST open
+    out.manager.nativeClient shouldBe false // portable HTTP client fallback, not the JNI native lib
+    out.flight.tlsEnabled shouldBe false    // TLS off
     out.flight.port shouldBe 31338
     out.acl.enabled shouldBe true // ACL kept on
   }

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoDifferentiatorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoDifferentiatorSpec.scala
@@ -1,0 +1,214 @@
+package ai.starlake.quack.ondemand.demo
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.google.protobuf.{Any => ProtoAny}
+import org.apache.arrow.flight.sql.FlightSqlClient
+import org.apache.arrow.flight.sql.impl.FlightSql
+import org.apache.arrow.flight.{
+  FlightCallHeaders,
+  FlightClient,
+  FlightDescriptor,
+  HeaderCallOption,
+  Location
+}
+import org.apache.arrow.memory.RootAllocator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.Base64
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration.*
+import scala.jdk.CollectionConverters.*
+
+/** End-to-end proof of the `qod demo` differentiator: a fully self-contained boot (embedded
+  * Postgres, TPC-H seed, RBAC import, real FlightSQL edge + Quack node) actually enforces row-level
+  * security (RLS) and column-level security (CLS) for the seeded `analyst` role, and denies access
+  * to a table outside a role's grants.
+  *
+  * This is a slow, real-infra integration spec (embedded Postgres download/boot + `dbgen` + a
+  * spawned Quack node process), guarded the same way [[DemoPostgresSpec]] /
+  * `TestPostgres.ensureReachable()` guard their live-infra specs: cancel (not fail) rather than
+  * false-negative the suite when `duckdb` is unavailable on the host.
+  *
+  * Reuses the project's real Arrow Flight / FlightSQL wire client (`org.apache.arrow.flight.sql`,
+  * already a main dependency -- see [[ai.starlake.quack.security.FlightSqlRealClientSpec]] for the
+  * sibling pattern of driving [[ai.starlake.quack.edge.FlightEdgeServer]] over real gRPC with
+  * `HeaderCallOption`-carried `tenant` / `pool` / `authorization` headers) rather than hand-rolling
+  * a new client. Unlike that harness (which stubs the Quack backend), this spec drives the FULL
+  * stack end to end, so [[queryFlight]] fetches and decodes real result rows via
+  * [[org.apache.arrow.flight.sql.FlightSqlClient.getStream]] instead of stopping at the handshake.
+  */
+class DemoDifferentiatorSpec extends AnyFlatSpec with Matchers:
+
+  private val Tenant     = "acme"
+  private val Pool       = "bi"
+  private val FlightPort = 31338
+
+  private def duckdbAvailable: Boolean =
+    scala.util
+      .Try(
+        scala.sys.process
+          .Process(Seq("duckdb", "-version"))
+          .!(scala.sys.process.ProcessLogger(_ => ()))
+      )
+      .getOrElse(1) == 0
+
+  "qod demo" should "apply RLS/CLS for the analyst and deny ungranted tables" in {
+    if !duckdbAvailable then cancel("duckdb CLI not on PATH; skipping demo integration test")
+
+    val home  = java.nio.file.Files.createTempDirectory("demo-diff-spec")
+    val fiber = DemoRunner.runDemo(List(home.toString)).start.unsafeRunSync()
+    try
+      // 1. Wait until FlightSQL :31338 answers a handshake-free RPC (GetSqlInfo needs no auth --
+      //    see FlightSqlRealClientSpec "serve GetSqlInfo without any Authorization header"). A full
+      //    boot here means: embedded PG start, control-plane migrate, RBAC manifest import,
+      //    TPC-H dbgen seed, and a spawned Quack node -- budget generously.
+      waitForFlightReady(FlightPort, 150.seconds)
+
+      // 2. alice (analyst): c_phone masked to '***', only BUILDING rows. The Quack node may still
+      //    be warming up after Flight starts accepting connections, so retry transient failures.
+      val aliceRows = queryFlightRetrying(
+        FlightPort,
+        "alice",
+        "demo-alice",
+        "SELECT c_phone, c_mktsegment FROM acme_tpch.tpch1.customer LIMIT 50",
+        90.seconds
+      )
+      aliceRows should not be empty
+      aliceRows.map(_("c_phone")).toSet shouldBe Set("***")           // CLS mask
+      aliceRows.map(_("c_mktsegment")).toSet shouldBe Set("BUILDING") // RLS filter
+
+      // 3. acme-admin: full, unmasked, multi-segment data (no analyst policies on this role).
+      val adminRows = queryFlightRetrying(
+        FlightPort,
+        "acme-admin",
+        "demo-acme-admin",
+        "SELECT c_phone, c_mktsegment FROM acme_tpch.tpch1.customer LIMIT 50",
+        60.seconds
+      )
+      adminRows should not be empty
+      adminRows.map(_("c_phone")).toSet should not contain "***"
+      adminRows.map(_("c_mktsegment")).toSet.size should be > 1
+
+      // 4. alice querying a table she has no grant on (lineitem): denied. The ACL gate runs before
+      //    any node dispatch (see FlightSqlRouter.execute), so this doesn't need node warm-up
+      //    retries the way the two SELECTs above do.
+      val ex = intercept[Exception] {
+        queryFlight(
+          FlightPort,
+          "alice",
+          "demo-alice",
+          "SELECT * FROM acme_tpch.tpch1.lineitem LIMIT 1"
+        )
+      }
+      ex.getMessage.toLowerCase should include("denied")
+    finally
+      fiber.cancel.unsafeRunSync()
+      // best-effort dir cleanup; runDemo's guarantee also removes its own home
+      DemoHome(home, home, home, home).deleteRecursively()
+  }
+
+  // ---------------------------------------------------------------------
+  // FlightSQL wire helpers -- built on org.apache.arrow.flight(.sql), the
+  // same real client used by FlightSqlRealClientSpec. No hand-rolled
+  // protocol: HeaderCallOption carries tenant/pool/authorization exactly as
+  // FlightEdgeServer.headerAuth expects, and FlightSqlClient drives the
+  // CommandStatementQuery execute + doGet dance.
+  // ---------------------------------------------------------------------
+
+  private def basicCredentials(user: String, password: String): String =
+    Base64.getEncoder.encodeToString(s"$user:$password".getBytes("UTF-8"))
+
+  private def headersOpt(user: String, password: String): HeaderCallOption =
+    val hdrs = new FlightCallHeaders()
+    hdrs.insert("tenant", Tenant)
+    hdrs.insert("pool", Pool)
+    hdrs.insert("authorization", s"Basic ${basicCredentials(user, password)}")
+    new HeaderCallOption(hdrs)
+
+  /** Poll an unauthenticated GetSqlInfo call until the FlightSQL edge answers, or fail after
+    * `timeout`. GetSqlInfo is served without any Authorization header (R5 / Power BI ODBC connect
+    * probe), so this exercises the real gRPC server without needing RBAC data to be ready yet.
+    */
+  private def waitForFlightReady(port: Int, timeout: FiniteDuration): Unit =
+    val deadline                   = System.nanoTime() + timeout.toNanos
+    var lastErr: Option[Throwable] = None
+    while System.nanoTime() < deadline do
+      val allocator = new RootAllocator()
+      val client    =
+        FlightClient.builder(allocator, Location.forGrpcInsecure("127.0.0.1", port)).build()
+      try
+        val cmd = FlightSql.CommandGetSqlInfo
+          .newBuilder()
+          .addInfo(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE)
+          .build()
+        client.getInfo(FlightDescriptor.command(ProtoAny.pack(cmd).toByteArray))
+        return
+      catch case e: Throwable => lastErr = Some(e)
+      finally
+        try client.close()
+        catch case _: Throwable => ()
+        try allocator.close()
+        catch case _: Throwable => ()
+      Thread.sleep(1000)
+    fail(
+      s"FlightSQL never became ready on 127.0.0.1:$port within $timeout" +
+        lastErr.map(e => s" (last error: ${e.getMessage})").getOrElse("")
+    )
+
+  /** Execute `sql` as `user` over a fresh Flight connection and decode the full result into a list
+    * of column-name -> stringified-value rows.
+    */
+  private def queryFlight(
+      port: Int,
+      user: String,
+      password: String,
+      sql: String
+  ): List[Map[String, String]] =
+    val allocator = new RootAllocator()
+    val rawClient =
+      FlightClient.builder(allocator, Location.forGrpcInsecure("127.0.0.1", port)).build()
+    try
+      val fsql     = new FlightSqlClient(rawClient)
+      val opt      = headersOpt(user, password)
+      val info     = fsql.execute(sql, opt)
+      val endpoint = info.getEndpoints.get(0)
+      val stream   = fsql.getStream(endpoint.getTicket, opt)
+      try
+        val fields = stream.getSchema.getFields.asScala.map(_.getName).toList
+        val rows   = ListBuffer.empty[Map[String, String]]
+        while stream.next() do
+          val root = stream.getRoot
+          for i <- 0 until root.getRowCount do
+            rows += fields
+              .map(name =>
+                name -> Option(root.getVector(name).getObject(i)).map(_.toString).getOrElse("")
+              )
+              .toMap
+        rows.toList
+      finally stream.close()
+    finally
+      rawClient.close()
+      allocator.close()
+
+  /** Like [[queryFlight]] but retries on any failure until `timeout` elapses. Covers the brief
+    * startup window where the FlightSQL edge is already accepting connections but the pool's Quack
+    * node hasn't finished spawning yet.
+    */
+  private def queryFlightRetrying(
+      port: Int,
+      user: String,
+      password: String,
+      sql: String,
+      timeout: FiniteDuration
+  ): List[Map[String, String]] =
+    val deadline           = System.nanoTime() + timeout.toNanos
+    var lastErr: Throwable = null
+    while System.nanoTime() < deadline do
+      try return queryFlight(port, user, password, sql)
+      catch
+        case e: Throwable =>
+          lastErr = e
+          Thread.sleep(2000)
+    throw new RuntimeException(s"query never succeeded within $timeout: sql='$sql'", lastErr)

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoDifferentiatorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoDifferentiatorSpec.scala
@@ -54,8 +54,19 @@ class DemoDifferentiatorSpec extends AnyFlatSpec with Matchers:
       )
       .getOrElse(1) == 0
 
+  // Final-review Fix 2: none of these are legitimately set outside a demo run, so their absence
+  // here doubles as "nothing else already polluted this JVM fork" and lets the assertion after
+  // teardown (below) be a plain null-check rather than a snapshot/compare.
+  private val DemoMutatedSysProps = List(
+    "quack-on-demand.cls.enabled",
+    "quack-on-demand.rls.enabled",
+    "QOD_BOOTSTRAP_YAML"
+  )
+
   "qod demo" should "apply RLS/CLS for the analyst and deny ungranted tables" in {
     if !duckdbAvailable then cancel("duckdb CLI not on PATH; skipping demo integration test")
+
+    DemoMutatedSysProps.foreach(k => System.getProperty(k) shouldBe null)
 
     val home  = java.nio.file.Files.createTempDirectory("demo-diff-spec")
     val fiber = DemoRunner.runDemo(List(home.toString)).start.unsafeRunSync()
@@ -65,6 +76,14 @@ class DemoDifferentiatorSpec extends AnyFlatSpec with Matchers:
       //    boot here means: embedded PG start, control-plane migrate, RBAC manifest import,
       //    TPC-H dbgen seed, and a spawned Quack node -- budget generously.
       waitForFlightReady(FlightPort, 150.seconds)
+
+      // Final-review Fix 2, mid-lifecycle half of the proof: `setup` has unconditionally run by
+      // the time Flight answers (it runs before `bootWithBanner`), so the mutated properties must
+      // be live now -- the teardown assertion in `finally` below is only meaningful if we first
+      // confirm they were actually set, not just absent because `setup` never ran.
+      System.getProperty("quack-on-demand.cls.enabled") shouldBe "true"
+      System.getProperty("quack-on-demand.rls.enabled") shouldBe "true"
+      System.getProperty("QOD_BOOTSTRAP_YAML") shouldBe "classpath:bootstrap-demo-minimal.yaml"
 
       // 2. alice (analyst): c_phone masked to '***', only BUILDING rows. The Quack node may still
       //    be warming up after Flight starts accepting connections, so retry transient failures.
@@ -104,7 +123,13 @@ class DemoDifferentiatorSpec extends AnyFlatSpec with Matchers:
       }
       ex.getMessage.toLowerCase should include("denied")
     finally
+      // `Fiber#cancel` completes only once the target fiber's finalizers -- including `runDemo`'s
+      // `.guarantee(cleanup)`, which restores the mutated system properties (Fix 2) -- have run, so
+      // no extra wait/poll is needed before the assertion right below.
       fiber.cancel.unsafeRunSync()
+      // Final-review Fix 2, teardown half of the proof: back to unset, exactly the pre-demo state
+      // asserted at the top of this test.
+      DemoMutatedSysProps.foreach(k => System.getProperty(k) shouldBe null)
       // best-effort dir cleanup; runDemo's guarantee also removes its own home
       DemoHome(home, home, home, home).deleteRecursively()
   }

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoHomeSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoHomeSpec.scala
@@ -1,0 +1,22 @@
+package ai.starlake.quack.ondemand.demo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class DemoHomeSpec extends AnyFlatSpec with Matchers:
+
+  "DemoHome.create" should "make the home + subdirs, pin the native extraction dir, and clean up" in {
+    val base = Files.createTempDirectory("demo-home-spec")
+    val home = DemoHome.create(Some(base.resolve("qod-demo").toString))
+    Files.isDirectory(home.root) shouldBe true
+    Files.isDirectory(home.pgDir) shouldBe true
+    Files.isDirectory(home.dataPath) shouldBe true
+    Files.isDirectory(home.nativeDir) shouldBe true
+    // Guardrail 2: extraction dir is pinned to the demo home, not an ambient temp.
+    sys.props(DemoHome.NativeExtractionProp) shouldBe home.nativeDir.toString
+
+    home.deleteRecursively()
+    Files.exists(home.root) shouldBe false
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoHomeSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoHomeSpec.scala
@@ -7,15 +7,17 @@ import java.nio.file.Files
 
 class DemoHomeSpec extends AnyFlatSpec with Matchers:
 
-  "DemoHome.create" should "make the home + subdirs, pin the native extraction dir, and clean up" in {
+  "DemoHome.create" should "make the home + subdirs and clean up" in {
     val base = Files.createTempDirectory("demo-home-spec")
     val home = DemoHome.create(Some(base.resolve("qod-demo").toString))
     Files.isDirectory(home.root) shouldBe true
     Files.isDirectory(home.pgDir) shouldBe true
     Files.isDirectory(home.dataPath) shouldBe true
+    // `nativeDir` is still created for shape/symmetry, but (final-review Fix 1) DuckDB's JNI
+    // native never actually unpacks there: `Files.createTempFile` resolves against the JVM's
+    // startup snapshot of `java.io.tmpdir`, which a runtime `System.setProperty` cannot redirect,
+    // so there is nothing left to assert a "pin" for here -- see the NOTE in DemoHome.scala.
     Files.isDirectory(home.nativeDir) shouldBe true
-    // Guardrail 2: extraction dir is pinned to the demo home, not an ambient temp.
-    sys.props(DemoHome.NativeExtractionProp) shouldBe home.nativeDir.toString
 
     home.deleteRecursively()
     Files.exists(home.root) shouldBe false

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoPostgresSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoPostgresSpec.scala
@@ -1,0 +1,24 @@
+package ai.starlake.quack.ondemand.demo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+import java.sql.DriverManager
+
+class DemoPostgresSpec extends AnyFlatSpec with Matchers:
+
+  "DemoPostgres" should "start, create a database, accept a connection, and stop" in {
+    val dir = Files.createTempDirectory("demo-pg-spec")
+    val pg  = DemoPostgres.start(dir)
+    try
+      pg.coords.host shouldBe "localhost"
+      pg.coords.port should be > 0
+      pg.createDatabase("qod_demo_probe")
+      pg.createDatabase("qod_demo_probe") // idempotent second call must not throw
+      val url  = s"jdbc:postgresql://${pg.coords.host}:${pg.coords.port}/qod_demo_probe"
+      val conn = DriverManager.getConnection(url, pg.coords.user, pg.coords.password)
+      try conn.isValid(2) shouldBe true
+      finally conn.close()
+    finally pg.stop()
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/demo/DemoSeedSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/demo/DemoSeedSpec.scala
@@ -1,0 +1,29 @@
+package ai.starlake.quack.ondemand.demo
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DemoSeedSpec extends AnyFlatSpec with Matchers:
+
+  "DemoSeed.buildInitSql" should "attach the DuckLake-over-Postgres catalog and dbgen at the SF" in {
+    val pg  = PgCoords("localhost", 54321, "postgres", "")
+    val sql = DemoSeed.buildInitSql(pg, "acme_tpch", "tpch1", "/demo/ducklake", 0.1)
+
+    sql should include("INSTALL ducklake")
+    sql should include("INSTALL postgres")
+    sql should include("INSTALL tpch")
+    sql should include("host=localhost port=54321 dbname=acme_tpch user=postgres")
+    sql should include("DATA_PATH '/demo/ducklake'")
+    sql should include("CREATE SCHEMA IF NOT EXISTS acme_tpch.tpch1")
+    sql should include("CALL dbgen(sf = 0.1)")
+  }
+
+  it should "CTAS each of the 8 TPC-H tables from the in-memory dbgen output into the DuckLake schema" in {
+    val pg  = PgCoords("localhost", 54321, "postgres", "")
+    val sql = DemoSeed.buildInitSql(pg, "acme_tpch", "tpch1", "/demo/ducklake", 0.1)
+
+    for table <-
+        List("region", "nation", "customer", "supplier", "part", "partsupp", "orders", "lineitem")
+    do
+      sql should include(s"CREATE TABLE acme_tpch.tpch1.$table AS SELECT * FROM memory.main.$table")
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackendPathSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackendPathSpec.scala
@@ -1,0 +1,14 @@
+package ai.starlake.quack.ondemand.runtime
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LocalQuackBackendPathSpec extends AnyFlatSpec with Matchers:
+
+  "duckdbPathPrefix" should "resolve under QOD_APP_HOME when set" in {
+    LocalQuackBackend.duckdbPathPrefix(Some("/opt/qod")) shouldBe Some("/opt/qod/duckdb/bin")
+  }
+
+  it should "be None when QOD_APP_HOME is unset (dev/source path unaffected)" in {
+    LocalQuackBackend.duckdbPathPrefix(None) shouldBe None
+  }


### PR DESCRIPTION
## What

Adds a **`qod demo`** subcommand: one command boots a fully working, seeded, RBAC-secured manager with **zero preinstalled dependencies** — no external JVM, Postgres, or DuckDB service required.

```
qod demo   # embedded PG -> seed minimal demo -> boot REST :20900 + FlightSQL :31338 -> banner -> ephemeral teardown
```

It boots an embedded ephemeral Postgres (zonky), overlays a demo config, seeds the minimal demo manifest + a small TPC-H dataset (dbgen SF 0.1), boots the real manager + a local DuckDB node, prints a connect banner, and deletes all state on exit. The differentiator lands end-to-end: connect as `alice` (analyst) → `c_phone` masked + only BUILDING rows; as `acme-admin` → full data; query an ungranted table → denied.

Design + plan: `docs/superpowers/specs/2026-07-16-qod-demo-self-contained-design.md` / `docs/superpowers/plans/2026-07-16-qod-demo-self-contained.md` (kept off-repo per the `/docs/` gitignore).

## How it's built (12 commits, TDD)

- `bootManager` extracted from `normalManagerRun` (behavior-preserving) so the demo can boot with an overlaid config.
- `DemoPostgres` (embedded PG), `DemoHome` (ephemeral dir), `DemoConfig.overlay` (demo posture), `DemoSeed` (dbgen loader), `DemoRunner` (orchestration + teardown), `DemoBanner`.
- `LocalQuackBackend` resolves a bundled `duckdb` via `QOD_APP_HOME` (additive, no-op in dev).

## Guardrails
- **G1 — insecure demo posture cannot leak to a normal boot.** TLS-off / REST-open / cls-rls-on / auth-override are produced only on the `demo` code path (`DemoRunner`/`DemoConfig`); `normalManagerRun` is unchanged. Demo-mutated JVM sysprops are snapshotted and restored on teardown.
- **G2 — native extraction.** The DuckDB JDBC driver self-cleans its extracted native via `deleteOnExit` (an earlier "pin the temp dir" claim was found ineffective in final review and corrected to this).

## Notable production-adjacent change
- **`fix(cls)` (1763fe0):** CLS masking of a bare `SELECT c_phone` was renaming the result column (client asking for `c_phone` got a differently-named column). Now preserves the name via an alias for the bare-column case; explicit aliases and nested/aggregate masks untouched. Same root cause as the pre-existing `@Ignore`d KNOWN-GAP (aggregate) test, which stays open. All 46 existing CLS specs pass. Surfaced by the demo's live differentiator.
- `nativeClient=false` in the demo overlay (documented GLIBC/native-ABI portability fallback).

## Testing
- `demo.*` 8/8 green including a **live** `DemoDifferentiatorSpec` (real FlightSQL wire, real DuckDB node, real embedded PG; cancels rather than false-passes when `duckdb` is unavailable).
- `cls.*` + `rls.*` 77 green (1 pre-existing KNOWN-GAP ignored).
- Reviewed via multi-stage subagent review per task + a final whole-branch review (both flagged Important items fixed in `fc51304`).

Known follow-up Minors (non-blocking): UI `/api` config viewer shows non-demo posture (cosmetic); CLS alias not re-quoted for reserved/mixed-case names; differentiator uses fixed ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
