### PR TITLE
chore(quackwire): bump to DuckDB 1.5.5, duckdb-quack upstream head, release-zip macOS CI

### DIFF
--- a/.github/workflows/quackwire.yml
+++ b/.github/workflows/quackwire.yml
@@ -8,11 +8,12 @@ name: quackwire native build
 # need a local C/C++ toolchain.
 #
 # Co-pinned versions (single source of truth: design doc §9.9):
-#   - duckdb-quack : 40de7badae4193c29d9c0834473fb76acc6c51e6
-#                    (branch v1.5-variegata, short 40de7badae41)
-#   - libduckdb    : v1.5.4 (matches Homebrew stable; matches the
-#                    libduckdb-{linux-amd64,linux-arm64,osx-universal}.zip
-#                    release artifacts)
+#   - duckdb-quack : 7e80f7ffcc98d0b3e81d0e1df8cc1c2da240a64b
+#                    (branch v1.5-variegata, short 7e80f7ffcc98)
+#   - libduckdb    : v1.5.5 official release zips on every platform:
+#                    libduckdb-{linux-amd64,linux-arm64,osx-universal,
+#                    windows-amd64}.zip. Homebrew is NOT used (its bottle
+#                    lags releases; it was still 1.5.4 on 2026-07-22).
 #
 # Runner labels (verified 2026-06-01):
 #   - ubuntu-22.04        : standard linux/x86_64, free on public repos
@@ -72,12 +73,12 @@ jobs:
             platform: osx-x86_64
             libname: libquackwire.dylib
             os: macos
-            duckdb_zip: ''
+            duckdb_zip: libduckdb-osx-universal.zip
           - runner: macos-14
             platform: osx-aarch64
             libname: libquackwire.dylib
             os: macos
-            duckdb_zip: ''
+            duckdb_zip: libduckdb-osx-universal.zip
     steps:
       - name: Checkout (with duckdb-quack submodule)
         uses: actions/checkout@v4
@@ -90,34 +91,44 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      # --- libduckdb v1.5.4 install ---------------------------------------
-      # macOS: Homebrew currently ships duckdb 1.5.4 as the stable bottle
-      # (verified 2026-06-24: `brew info --json=v2 duckdb` -> stable 1.5.4
-      # with bottle tags arm64_sequoia / sonoma / arm64_linux / x86_64_linux).
-      # The find_path / find_library in native/quackwire/CMakeLists.txt
-      # already probes /opt/homebrew/{include,lib} (Apple Silicon) and
-      # /usr/local/{include,lib} (Intel) so no extra hint is needed.
-      - name: Install libduckdb v1.5.4 (macOS)
+      # --- libduckdb v1.5.5 install ---------------------------------------
+      # macOS: assemble DUCKDB_HOME from the official release zip, same
+      # pattern as Windows. We deliberately do NOT use Homebrew: its bottle
+      # lags DuckDB releases (still 1.5.4 the day 1.5.5 shipped) and the
+      # macOS leg must link the exact pinned ABI. CMakeLists probes
+      # $ENV{DUCKDB_HOME}{,/include,/lib} FIRST, so this wins over any
+      # /opt/homebrew leftovers on the runner.
+      - name: Install libduckdb v1.5.5 (macOS)
         if: matrix.os == 'macos'
+        env:
+          DUCKDB_ZIP: ${{ matrix.duckdb_zip }}
         run: |
           set -euo pipefail
-          brew update
-          brew install duckdb
-          INSTALLED=$(brew list --versions duckdb | awk '{print $2}')
-          echo "libduckdb installed: $INSTALLED"
-          if [[ "$INSTALLED" != 1.5.4* ]]; then
-            echo "::error::Homebrew duckdb is not 1.5.4 (got: $INSTALLED). The duckdb-quack pin requires the v1.5.4 ABI." >&2
-            exit 1
-          fi
+          home="$RUNNER_TEMP/duckdb-home"
+          mkdir -p "$home/include" "$home/lib"
+          tmp=$(mktemp -d)
+          curl -fsSL -o "$tmp/$DUCKDB_ZIP" \
+            "https://github.com/duckdb/duckdb/releases/download/v1.5.5/$DUCKDB_ZIP"
+          unzip -o "$tmp/$DUCKDB_ZIP" -d "$tmp/extracted"
+          cp "$tmp/extracted/duckdb.h"   "$home/include/duckdb.h"
+          cp "$tmp/extracted/duckdb.hpp" "$home/include/duckdb.hpp"
+          cp "$tmp/extracted/libduckdb.dylib" "$home/lib/libduckdb.dylib"
+          # Nested INTERNAL headers (duckdb/common/serializer/*.hpp etc.),
+          # same reason as the Linux step below.
+          git clone --depth 1 --branch v1.5.5 https://github.com/duckdb/duckdb "$tmp/duckdb-src"
+          cp -r "$tmp/duckdb-src/src/include/duckdb" "$home/include/"
+          echo "DUCKDB_HOME=$home" >> "$GITHUB_ENV"
+          ls -l "$home/lib/libduckdb.dylib" "$home/include/duckdb.hpp"
+          ls "$home/include/duckdb/common/serializer/binary_serializer.hpp"
 
       # Linux: download the official libduckdb release zip and stage into
       # /usr/local. The CMake `find_path / find_library` hints in
       # native/quackwire/CMakeLists.txt cover /usr/local/{include,lib}.
-      # Verified asset names on the v1.5.4 release page:
+      # Verified asset names on the v1.5.5 release page:
       #   libduckdb-linux-amd64.zip   (x86_64)
       #   libduckdb-linux-arm64.zip   (aarch64)
-      # (gh api repos/duckdb/duckdb/releases/tags/v1.5.4 .assets[].name)
-      - name: Install libduckdb v1.5.4 (Linux)
+      # (gh api repos/duckdb/duckdb/releases/tags/v1.5.5 .assets[].name)
+      - name: Install libduckdb v1.5.5 (Linux)
         if: matrix.os == 'linux'
         env:
           DUCKDB_ZIP: ${{ matrix.duckdb_zip }}
@@ -128,7 +139,7 @@ jobs:
           tmp=$(mktemp -d)
           # 1. Binary + amalgamated public headers from the official release.
           curl -fsSL -o "$tmp/$DUCKDB_ZIP" \
-            "https://github.com/duckdb/duckdb/releases/download/v1.5.4/$DUCKDB_ZIP"
+            "https://github.com/duckdb/duckdb/releases/download/v1.5.5/$DUCKDB_ZIP"
           unzip -o "$tmp/$DUCKDB_ZIP" -d "$tmp/extracted"
           sudo install -m 0644 "$tmp/extracted/duckdb.h"   /usr/local/include/duckdb.h
           sudo install -m 0644 "$tmp/extracted/duckdb.hpp" /usr/local/include/duckdb.hpp
@@ -136,10 +147,9 @@ jobs:
           # 2. Nested INTERNAL headers (duckdb/common/serializer/*.hpp etc.).
           # The release zip ships only the amalgamated duckdb.{h,hpp}; the
           # duckdb-quack message layer pulls `duckdb/common/serializer/
-          # binary_serializer.hpp` directly. Homebrew's duckdb formula
-          # installs them under /opt/homebrew/include/duckdb/ on macOS;
-          # on Linux we grab them from a shallow clone at the same tag.
-          git clone --depth 1 --branch v1.5.4 https://github.com/duckdb/duckdb "$tmp/duckdb-src"
+          # binary_serializer.hpp` directly; we grab them from a shallow
+          # clone at the same tag.
+          git clone --depth 1 --branch v1.5.5 https://github.com/duckdb/duckdb "$tmp/duckdb-src"
           sudo cp -r "$tmp/duckdb-src/src/include/duckdb" /usr/local/include/
           sudo ldconfig
           ls -l /usr/local/lib/libduckdb.so /usr/local/include/duckdb.hpp
@@ -202,9 +212,9 @@ jobs:
       # FULL duckdb/ include tree. The release zip ships only the amalgamated
       # duckdb.{h,hpp}; the duckdb-quack message layer also pulls internal
       # headers (duckdb/common/serializer/binary_serializer.hpp), grabbed from a
-      # shallow clone at the same v1.5.4 tag. Runs in git-bash for parity with
+      # shallow clone at the same v1.5.5 tag. Runs in git-bash for parity with
       # the Linux step.
-      - name: Install libduckdb v1.5.4 (Windows)
+      - name: Install libduckdb v1.5.5 (Windows)
         shell: bash
         run: |
           set -euo pipefail
@@ -212,13 +222,13 @@ jobs:
           mkdir -p "$home/include" "$home/lib"
           tmp="$(mktemp -d)"
           curl -fsSL -o "$tmp/libduckdb.zip" \
-            "https://github.com/duckdb/duckdb/releases/download/v1.5.4/libduckdb-windows-amd64.zip"
+            "https://github.com/duckdb/duckdb/releases/download/v1.5.5/libduckdb-windows-amd64.zip"
           unzip -o "$tmp/libduckdb.zip" -d "$tmp/dl"
           cp "$tmp/dl/duckdb.h"   "$home/include/duckdb.h"
           cp "$tmp/dl/duckdb.hpp" "$home/include/duckdb.hpp"
           cp "$tmp/dl/duckdb.lib" "$home/lib/duckdb.lib"
           cp "$tmp/dl/duckdb.dll" "$home/lib/duckdb.dll"
-          git clone --depth 1 --branch v1.5.4 https://github.com/duckdb/duckdb "$tmp/duckdb-src"
+          git clone --depth 1 --branch v1.5.5 https://github.com/duckdb/duckdb "$tmp/duckdb-src"
           cp -r "$tmp/duckdb-src/src/include/duckdb" "$home/include/"
           ls "$home/lib/duckdb.lib" "$home/include/duckdb.hpp"
           ls "$home/include/duckdb/common/serializer/binary_serializer.hpp"

--- a/build.sbt
+++ b/build.sbt
@@ -57,10 +57,10 @@ lazy val genConfigDocs = taskKey[Unit]("Generate website/docs/reference/configur
 // JNI shim native binaries published as classifier-per-platform jars.
 //
 // Version format:  <duckdb-abi>-<duckdb-quack-short-sha>-<rev>[-SNAPSHOT]
-// Example:         1.5.4-40de7badae41-1-SNAPSHOT
+// Example:         1.5.5-7e80f7ffcc98-1-SNAPSHOT
 //
 //   duckdb-abi              the DuckDB libduckdb release the C++ shim
-//                           links against (1.5.4)
+//                           links against (1.5.5)
 //   duckdb-quack-short-sha  the pinned `native/quackwire/thirdparty/
 //                           duckdb-quack` commit
 //   rev                     monotonic patch number; bumps each time we
@@ -81,7 +81,7 @@ lazy val genConfigDocs = taskKey[Unit]("Generate website/docs/reference/configur
 // etc.) copied from the pinned DuckDB source. A DuckDB bump can change those
 // values or introduce new unresolved symbols on the Windows link. See that
 // file's header for how to re-derive them.
-val libquackwireVersion = "1.5.4-40de7badae41-7"
+val libquackwireVersion = "1.5.5-7e80f7ffcc98-1-SNAPSHOT"
 
 // Opt-in Windows native classifier. Default OFF so existing Linux/macOS/CI
 // `sbt assembly` / `sbt test` never try to resolve a windows-x86_64 classifier

--- a/libquackwire/README.md
+++ b/libquackwire/README.md
@@ -22,12 +22,12 @@ it to a temp file and `System.load`s it.
 
 `<duckdb-abi-version>-<duckdb-quack-short-sha>`
 
-For example, `1.5.4-40de7badae41` says:
+For example, `1.5.5-7e80f7ffcc98` says:
 
-- Built against DuckDB v1.5.4's C++ ABI (link-compatible with
+- Built against DuckDB v1.5.5's C++ ABI (link-compatible with
   `libduckdb.so` / `libduckdb.dylib` from
-  https://github.com/duckdb/duckdb/releases/tag/v1.5.4).
-- Pinned at `duckdb/duckdb-quack` commit `40de7badae41`.
+  https://github.com/duckdb/duckdb/releases/tag/v1.5.5).
+- Pinned at `duckdb/duckdb-quack` commit `7e80f7ffcc98`.
 
 Bumping either pin bumps the version. There is no truncation - the
 short SHA is the integrity check.

--- a/native/quackwire/CMakeLists.txt
+++ b/native/quackwire/CMakeLists.txt
@@ -38,21 +38,22 @@ target_include_directories(quackwire PRIVATE
   ${DUCKDB_QUACK_DIR}/src/include
 )
 
-# libduckdb v1.5.4 link target.
+# libduckdb v1.5.5 link target (duckdb-quack pin: 7e80f7ffcc98, branch
+# v1.5-variegata).
 #
-# Path 1 (chosen): system install via Homebrew on macOS / apt on Linux.
-# On this developer machine `brew info duckdb` reports stable 1.5.4 - an
-# exact match for the version duckdb-quack at 40de7badae41 was built against.
-# Task 8 (CI matrix) will likely switch CI to FetchContent on the v1.5.4
-# release artifact for reproducibility, but for local dev the system
-# package is the fastest path to a working link.
+# CI assembles DUCKDB_HOME from the official v1.5.5 release zips on ALL
+# platforms (see .github/workflows/quackwire.yml). The system-package hints
+# below remain for local dev, but verify the installed version first: a
+# libduckdb ABI mismatch (e.g. Homebrew still shipping 1.5.4) can link
+# cleanly and fail at runtime. Prefer pointing DUCKDB_HOME at an unpacked
+# v1.5.5 release zip plus the internal-header tree.
 # DUCKDB_HOME (env var or -DDUCKDB_HOME=) points at an unpacked libduckdb dir.
 # It is required on Windows (there is no system package): unzip
 # libduckdb-windows-amd64.zip and populate it with duckdb.lib + the FULL duckdb/
 # include tree. The release zip ships only the amalgamated duckdb.{h,hpp}; the
 # duckdb-quack message layer also pulls internal headers such as
 # duckdb/common/serializer/binary_serializer.hpp, so a shallow `git clone
-# --branch v1.5.4` of duckdb/src/include/duckdb must be copied alongside them
+# --branch v1.5.5` of duckdb/src/include/duckdb must be copied alongside them
 # (see .github/workflows/quackwire.yml for the exact staging). On macOS/Linux the
 # system package hints below still apply, so DUCKDB_HOME is optional there.
 find_path(DUCKDB_INCLUDE_DIR duckdb.hpp

--- a/native/quackwire/src/win_duckdb_compat.cpp
+++ b/native/quackwire/src/win_duckdb_compat.cpp
@@ -3,8 +3,10 @@
 // ============================================================================
 //  !! VERSION-PINNED FILE - REVISIT ON EVERY DUCKDB / duckdb-quack BUMP !!
 //
-//  Pinned to: duckdb @ 14eca11bd9  (libduckdb v1.5.4, build.sbt
-//             libquackwireVersion "1.5.4-40de7badae41-*").
+//  Pinned to: duckdb @ d8cdaa33fd  (libduckdb v1.5.5, build.sbt
+//             libquackwireVersion "1.5.5-7e80f7ffcc98-*").
+//  Re-verified 2026-07-22 at v1.5.5: Default() still FromString("v0.10.2"),
+//  storage_info.cpp still maps {"v0.10.2", 64}; no constant changes needed.
 //
 //  The values below are COPIED from that exact DuckDB source. When you bump the
 //  duckdb-quack submodule / libduckdb ABI in build.sbt, re-derive them or the

--- a/scripts/run-jar.sh
+++ b/scripts/run-jar.sh
@@ -134,8 +134,10 @@ JAR_CACHE_DIR="${JAR_CACHE_DIR:-$HOME/.cache/quack-on-demand}"
 #
 # Air-gapped / CI: pre-populate $DUCKDB_CACHE_DIR/$DUCKDB_VERSION/{bin,lib}
 # with the right binaries; the fast-path check will see them and skip the
-# network fetch. Override the pinned version with DUCKDB_VERSION (defaults
-# to libquackwireVersion's first 3 segments).
+# network fetch. The QOD_VERSION=BUILD path additionally needs
+# $DUCKDB_CACHE_DIR/$DUCKDB_VERSION/include (see ensure_duckdb_headers
+# below). Override the pinned version with DUCKDB_VERSION (defaults to
+# libquackwireVersion's first 3 segments).
 DUCKDB_CACHE_DIR="${DUCKDB_CACHE_DIR:-$REPO_DIR/.duckdb}"
 
 ensure_duckdb() {
@@ -228,6 +230,51 @@ ensure_duckdb() {
   echo "duckdb: ready -> $bin_dir/duckdb (v$version)"
 }
 ensure_duckdb
+
+# Stage the pinned DuckDB headers at $2/include for the local libquackwire
+# cmake rebuild (BUILD path only, lazy): duckdb.{h,hpp} come from the
+# libduckdb zip ensure_duckdb already unpacked into lib/, and the FULL
+# internal duckdb/ header tree comes from the v$1 source tarball - the
+# duckdb-quack message layer includes internals such as
+# duckdb/common/serializer/binary_serializer.hpp that the release zip does
+# not ship. One-time per version; the presence check makes reruns free.
+# Air-gapped: pre-populate $2/include with duckdb.{h,hpp} plus the
+# src/include/duckdb tree (same staging CI does in quackwire.yml) and this
+# becomes a no-op.
+ensure_duckdb_headers() {
+  local version="$1" home="$2"
+  local inc="$home/include"
+  if [[ -f "$inc/duckdb.hpp" && -f "$inc/duckdb/common/serializer/binary_serializer.hpp" ]]; then
+    return 0
+  fi
+  mkdir -p "$inc"
+  if [[ ! -f "$inc/duckdb.hpp" ]]; then
+    if [[ -f "$home/lib/duckdb.hpp" ]]; then
+      cp "$home/lib/duckdb.h" "$home/lib/duckdb.hpp" "$inc/"
+    else
+      echo "ERROR: duckdb.hpp not found in $home/lib (expected from the libduckdb zip)." >&2
+      echo "       Delete $home and re-run so ensure_duckdb refetches libduckdb v$version." >&2
+      exit 1
+    fi
+  fi
+  echo "duckdb: staging v$version internal headers into $inc (one-time per version)"
+  local tmp
+  tmp="$(mktemp -d -t qod-duckdb-src.XXXXXX)"
+  if ! curl -fsSL -o "$tmp/src.tar.gz" \
+      "https://github.com/duckdb/duckdb/archive/refs/tags/v$version.tar.gz"; then
+    rm -rf "$tmp"
+    echo "ERROR: failed to download the duckdb v$version source tarball (internal headers)." >&2
+    echo "       Air-gapped? Pre-populate $inc/duckdb with duckdb-src/src/include/duckdb." >&2
+    exit 1
+  fi
+  tar -xzf "$tmp/src.tar.gz" -C "$tmp" "duckdb-$version/src/include/duckdb"
+  rm -rf "$inc/duckdb"
+  mv "$tmp/duckdb-$version/src/include/duckdb" "$inc/duckdb"
+  rm -rf "$tmp"
+  [[ -f "$inc/duckdb/common/serializer/binary_serializer.hpp" ]] || {
+    echo "ERROR: header staging incomplete: binary_serializer.hpp missing under $inc/duckdb." >&2
+    exit 1; }
+}
 
 # Demo seed controls. LOAD_TPC=N is the legacy shortcut that seeds ALL
 # benchmarks at the same scale factor; LOAD_TPCH / LOAD_TPCDS / LOAD_SSB
@@ -356,10 +403,24 @@ rebuild_libquackwire_locally() {
   [[ -n "$libq_version" ]] || {
     echo "ERROR: could not parse libquackwireVersion from build.sbt" >&2; exit 1; }
 
-  # 3. CMake build for the host platform.
-  echo "rebuilding libquackwire for $host_platform via cmake..."
+  # 3. CMake build for the host platform, linked against the PINNED
+  # libduckdb from the .duckdb cache (populated by ensure_duckdb above),
+  # never the operator's system install: a Homebrew/apt libduckdb at
+  # another version links cleanly and mismatches at runtime. The build dir
+  # is wiped first because CMake caches the resolved find_path/find_library
+  # results - a stale cache would keep pointing at whatever a previous
+  # configure found, DUCKDB_HOME notwithstanding. The build is 5 files;
+  # losing incrementality costs seconds.
+  local duckdb_version duckdb_home
+  duckdb_version="${DUCKDB_VERSION:-${libq_version%%-*}}"
+  duckdb_home="$DUCKDB_CACHE_DIR/$duckdb_version"
+  ensure_duckdb_headers "$duckdb_version" "$duckdb_home"
+  # The cache lays libduckdb in lib/ and headers in include/ - exactly the
+  # DUCKDB_HOME layout CMakeLists probes first.
+  echo "rebuilding libquackwire for $host_platform via cmake (DUCKDB_HOME=$duckdb_home)..."
   ( cd "$REPO_DIR/native/quackwire" \
-    && cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    && rm -rf build \
+    && DUCKDB_HOME="$duckdb_home" cmake -B build -DCMAKE_BUILD_TYPE=Release \
     && cmake --build build --config Release )
   local host_built="$REPO_DIR/native/quackwire/build/libquackwire.$host_ext"
   [[ -f "$host_built" ]] || {


### PR DESCRIPTION
## Summary

- duckdb-quack submodule 40de7ba -> 7e80f7f (v1.5-variegata head, 30 commits: fetch-batch pushdown fix, catalog fetch truncation fix, INSERT RETURNING rejection, secret-sourced quack_serve tokens, extra HTTP headers)
- libquackwireVersion = 1.5.5-7e80f7ffcc98-1-SNAPSHOT (rev reset on sha change; SNAPSHOT required by the publish-central guard)
- quackwire.yml: macOS legs now assemble DUCKDB_HOME from the official libduckdb-osx-universal.zip like the Windows leg, instead of Homebrew (its bottle lags releases: still 1.5.4 the day 1.5.5 shipped)
- win_duckdb_compat.cpp: pin comment updated; constants verified unchanged at v1.5.5 (Default() still v0.10.2 -> serialization_version 64; config.cpp identical between the nested duckdb pin 08e34c447bae and v1.5.5)

## Verification

- The three compiled duckdb-quack sources are byte-identical between the old and new pin (headers only changed)
- Local osx-aarch64 build against the v1.5.5 release zip: CMake picks the 1.5.5 headers/dylib, smokeAnswer JNI symbol exported, links libduckdb
- Merging to main publishes the snapshot to Central; the QoD-side pin bump (Versions.duckdb) is a follow-up gated on org.duckdb:duckdb_jdbc 1.5.5.0 reaching Maven Central

🤖 Generated with [Claude Code](https://claude.com/claude-code)