### PR TITLE
chore: bump DuckDB consumer pins to 1.5.5 (JDBC, launchers, CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.5.3
+
+- **DuckDB upgraded 1.5.4 -> 1.5.5** across every pinned layer: libquackwire
+  rebuilt against libduckdb 1.5.5 (`1.5.5-7e80f7ffcc98-1`, duckdb-quack
+  submodule at the v1.5-variegata head - brings fetch-batch pushdown fixes,
+  catalog fetch truncation fix, INSERT RETURNING rejection, and secret-sourced
+  quack_serve tokens), the DuckDB JDBC driver (`1.5.5.0`), and the runtime
+  libduckdb / DuckDB CLI fetched by `run-jar.sh` / `run-jar.ps1` and the
+  `qod` Python CLI.
+- **quackwire macOS CI now links the official libduckdb release zip** instead
+  of Homebrew (whose bottle lags DuckDB releases).
+- **`QOD_VERSION=BUILD` links the local libquackwire rebuild against the
+  pinned libduckdb** from the `.duckdb/<version>` cache (staging the internal
+  header tree once per version) instead of the operator's system install.
+
 ## 0.5.1
 
 ### Module SPI: mutation gates

--- a/cli/src/qod_cli/launcher.py
+++ b/cli/src/qod_cli/launcher.py
@@ -284,7 +284,7 @@ def ensure_jre(
 # DuckDB CLI provisioning. The spawn script runs the `duckdb` CLI; the demo
 # pins it to the libquackwire ABI version (Versions.scala first 3 segments,
 # see docs/duckdb-pin-bump-checklist.md) instead of trusting a system install.
-DUCKDB_CLI_VERSION = "1.5.4"
+DUCKDB_CLI_VERSION = "1.5.5"
 
 _DUCKDB_PLAT = {
     ("darwin", "arm64"): "osx-universal",

--- a/cli/src/qod_cli/scripts/spawn-quack-node.ps1
+++ b/cli/src/qod_cli/scripts/spawn-quack-node.ps1
@@ -18,6 +18,10 @@
     dataPath                           (DuckLake data files directory)
     kind                               (ducklake | duckdb-file | memory)
     dbInitSql extraSetupSql            (optional per-db / per-pool init SQL)
+    lockdownSql                        (optional engine lockdown SQL, NodeLockdown.scala; runs
+                                        before quack_serve)
+    objectStoreSql                     (optional per-db object-store CREATE SECRET SQL,
+                                        ObjectStoreSecret.scala; runs before the DuckLake ATTACH)
 
   Unlike the bash version there is no FIFO: DuckDB is fed its init SQL over a
   redirected stdin that this script leaves OPEN, so the background quack
@@ -147,6 +151,8 @@ if (-not [string]::IsNullOrEmpty($proxyUrl)) {
 
 $dbInitSql    = [Environment]::GetEnvironmentVariable('dbInitSql')
 $extraSetupSql = [Environment]::GetEnvironmentVariable('extraSetupSql')
+$lockdownSql  = [Environment]::GetEnvironmentVariable('lockdownSql')
+$objectStoreSql = [Environment]::GetEnvironmentVariable('objectStoreSql')
 
 # Build init SQL piecemeal based on $kind so memory / duckdb-file skip the
 # DuckLake-specific setup entirely. Mirrors spawn-quack-node.sh.
@@ -160,6 +166,10 @@ switch ($kind) {
     [void]$sb.AppendLine("INSTALL ducklake; LOAD ducklake;")
     [void]$sb.AppendLine("INSTALL postgres; LOAD postgres;")
     if (-not [string]::IsNullOrEmpty($storageSql)) { [void]$sb.AppendLine($storageSql) }
+    # Per-database object-store secret (objectStoreSql env, authored by ObjectStoreSecret.scala).
+    # A scoped CREATE SECRET for this database's own bucket/credentials. Runs alongside the global
+    # storageSql above (DuckDB picks the longest matching scope), before the catalog ATTACH.
+    if (-not [string]::IsNullOrEmpty($objectStoreSql)) { [void]$sb.AppendLine($objectStoreSql) }
     [void]$sb.AppendLine("ATTACH 'host=$pgHost port=$pgPort dbname=$dbName user=$pgUser password=$pgPassword' AS qod_init_pg (TYPE postgres);")
     [void]$sb.AppendLine("SELECT * FROM postgres_query('qod_init_pg', 'SELECT pg_advisory_lock(hashtext(''qod-ducklake-init:$dbName''))');")
     [void]$sb.AppendLine("ATTACH 'ducklake:postgres:host=$pgHost port=$pgPort dbname=$dbName user=$pgUser password=$pgPassword' AS ""$dbName""")
@@ -182,6 +192,11 @@ switch ($kind) {
 }
 
 if (-not [string]::IsNullOrEmpty($extraSetupSql)) { [void]$sb.AppendLine($extraSetupSql) }
+
+# Deployment lockdown (lockdownSql env var, authored by NodeLockdown.scala).
+# MUST run before quack_serve so the restrictions are in effect before the
+# node serves any tenant statement.
+if (-not [string]::IsNullOrEmpty($lockdownSql)) { [void]$sb.AppendLine($lockdownSql) }
 
 [void]$sb.AppendLine("CALL quack_serve('quack:0.0.0.0:$Port', token := '$Token', allow_other_hostname := true);")
 

--- a/cli/src/qod_cli/scripts/spawn-quack-node.sh
+++ b/cli/src/qod_cli/scripts/spawn-quack-node.sh
@@ -189,6 +189,12 @@ case "$kind" in
     INIT_SQL+=$'INSTALL ducklake; LOAD ducklake;\n'
     INIT_SQL+=$'INSTALL postgres; LOAD postgres;\n'
     INIT_SQL+="$STORAGE_SQL"$'\n'
+    # Per-database object-store secret (objectStoreSql env, authored by ObjectStoreSecret.scala).
+    # A scoped CREATE SECRET for this database's own bucket/credentials. Runs alongside the global
+    # STORAGE_SQL above (DuckDB picks the longest matching scope), before the catalog ATTACH.
+    if [[ -n "${objectStoreSql:-}" ]]; then
+      INIT_SQL+="$objectStoreSql"$'\n'
+    fi
     INIT_SQL+="ATTACH 'host=$pgHost port=$pgPort dbname=$dbName user=$pgUser password=$pgPassword' AS qod_init_pg (TYPE postgres);"$'\n'
     INIT_SQL+="SELECT * FROM postgres_query('qod_init_pg', 'SELECT pg_advisory_lock(hashtext(''qod-ducklake-init:$dbName''))');"$'\n'
     INIT_SQL+="ATTACH 'ducklake:postgres:host=$pgHost port=$pgPort dbname=$dbName user=$pgUser password=$pgPassword' AS \"$dbName\""$'\n'
@@ -212,6 +218,13 @@ esac
 
 if [[ -n "${extraSetupSql:-}" ]]; then
   INIT_SQL+="$extraSetupSql"$'\n'
+fi
+
+# Deployment lockdown (lockdownSql env var, authored by NodeLockdown.scala).
+# MUST run before quack_serve so the restrictions are in effect before the
+# node serves any tenant statement.
+if [[ -n "${lockdownSql:-}" ]]; then
+  INIT_SQL+="$lockdownSql"$'\n'
 fi
 
 INIT_SQL+="CALL quack_serve('quack:0.0.0.0:$PORT', token := '$TOKEN', allow_other_hostname := true);"$'\n'

--- a/cli/tests/test_demo.py
+++ b/cli/tests/test_demo.py
@@ -429,7 +429,7 @@ def test_demo_refuses_when_latest_release_predates_the_demo(runner, monkeypatch)
 
 
 def test_duckdb_cli_url_platform_mapping():
-    base = "https://github.com/duckdb/duckdb/releases/download/v1.5.4"
+    base = "https://github.com/duckdb/duckdb/releases/download/v1.5.5"
     assert launcher.duckdb_cli_url("darwin", "arm64") == f"{base}/duckdb_cli-osx-universal.zip"
     assert launcher.duckdb_cli_url("linux", "x86_64") == f"{base}/duckdb_cli-linux-amd64.zip"
     assert launcher.duckdb_cli_url("linux", "aarch64") == f"{base}/duckdb_cli-linux-arm64.zip"
@@ -588,7 +588,7 @@ def test_demo_rejects_non_release_version_with_hint(runner, monkeypatch):
 
 
 def test_libduckdb_url_platform_mapping():
-    base = "https://github.com/duckdb/duckdb/releases/download/v1.5.4"
+    base = "https://github.com/duckdb/duckdb/releases/download/v1.5.5"
     assert launcher.libduckdb_url("darwin", "arm64") == f"{base}/libduckdb-osx-universal.zip"
     assert launcher.libduckdb_url("linux", "x86_64") == f"{base}/libduckdb-linux-amd64.zip"
     assert launcher.libduckdb_url("win32", "ARM64") == f"{base}/libduckdb-windows-arm64.zip"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,7 +25,7 @@ object Versions {
   val wireMock       = "3.9.2"
   val blobstore      = "0.10.1"
   val starlakeJdbc   = "0.7"
-  val duckdb         = "1.5.4.0" // before bumping: docs/duckdb-pin-bump-checklist.md
+  val duckdb         = "1.5.5.0" // before bumping: docs/duckdb-pin-bump-checklist.md
   val micrometer     = "1.13.6"
   val liquibase      = "4.29.2"
   val caffeine       = "3.1.8"

--- a/scripts/run-jar.ps1
+++ b/scripts/run-jar.ps1
@@ -100,7 +100,7 @@ function Resolve-DuckDbVersion {
     $line = Select-String -Path $buildSbt -Pattern '^val libquackwireVersion' | Select-Object -First 1
     if ($line -and $line.Line -match '"([0-9]+\.[0-9]+\.[0-9]+)') { return $Matches[1] }
   }
-  return '1.5.4'
+  return '1.5.5'
 }
 
 function Install-DuckDb {

--- a/scripts/run-jar.sh
+++ b/scripts/run-jar.sh
@@ -66,7 +66,7 @@
 #                                 Mirrors run-docker-compose.sh's NUKE flag for
 #                                 the native-jar path.                  (default 0)
 #
-#   DUCKDB_VERSION                pin a specific DuckDB release (e.g. 1.5.4).
+#   DUCKDB_VERSION                pin a specific DuckDB release (e.g. 1.5.5).
 #                                 Default = derived from build.sbt's
 #                                 libquackwireVersion so the CLI and libquackwire
 #                                 stay ABI-compatible. The script always installs
@@ -146,7 +146,7 @@ ensure_duckdb() {
     version="$(grep -E '^val libquackwireVersion' "$REPO_DIR/build.sbt" \
       | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
   fi
-  version="${version:-1.5.4}"
+  version="${version:-1.5.5}"
 
   local cache="$DUCKDB_CACHE_DIR/$version"
   local bin_dir="$cache/bin"

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -127,7 +127,7 @@ qod start
 
 On **Windows on ARM** (e.g. Parallels on Apple Silicon), DuckDB is provisioned as native `windows-arm64`, but the bundled `quackwire.dll` is x86_64-only and cannot load in the arm64 JVM. The manager detects this at boot and falls back to the embedded client automatically (a `WARN` is logged); no configuration needed.
 
-**Building the Windows native (`quackwire.dll`), optional.** Requires MSVC (Visual Studio Build Tools) + CMake + `sbt`. Assemble a `DUCKDB_HOME` with `duckdb.lib` plus the full `duckdb/` include tree (see `.github/workflows/quackwire.yml`, step "Install libduckdb v1.5.4 (Windows)"), then:
+**Building the Windows native (`quackwire.dll`), optional.** Requires MSVC (Visual Studio Build Tools) + CMake + `sbt`. Assemble a `DUCKDB_HOME` with `duckdb.lib` plus the full `duckdb/` include tree (see `.github/workflows/quackwire.yml`, step "Install libduckdb v1.5.5 (Windows)"), then:
 
 ```powershell
 $env:DUCKDB_HOME = 'C:\path\to\duckdb-home'


### PR DESCRIPTION
## Summary

Phase B of the DuckDB 1.5.5 bump (libquackwire side landed in #61):

- duckdb_jdbc 1.5.5.0 (hit Maven Central 2026-07-25)
- run-jar.sh / run-jar.ps1 fallback pins to 1.5.5 (primary path already derives from libquackwireVersion)
- qod CLI DUCKDB_CLI_VERSION 1.5.5 + fixture URLs, CHANGELOG 0.5.3 section, doc mentions
- Separate commit: re-sync the CLI-bundled spawn scripts with the canonical ones (they were missing the objectStoreSql and lockdownSql blocks; the parity test was failing on main)

## Verification

- Full Scala suite: 1937 passed, 0 failed
- CLI pytest: 241 passed, 1 skipped (parity test green after the re-sync)
- Live pin-bump checklist (docs/duckdb-pin-bump-checklist.md) runs as the follow-up phase before the 'verified on 1.5.4' comments get updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)