### PR TITLE
Demand scale-out between owner-declared pool bands (+ kind-aware node metastore fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,24 @@ reason `rest | query | module`; idle-detection policy lives in the hosted
 module, never in core. See
 docs/superpowers/specs/2026-07-18-pool-suspend-resume-design.md.
 
+### Demand scale-out (owner-declared band)
+
+Pools with `minNodes`/`maxNodes` set (create-time or `POST /api/pool/setAutoscale`)
+gain readers under sustained load and shed them when quiet, never leaving the
+band; writers are never touched and scale-in stops at `minNodes` (zero stays
+hibernation's job). Load signal: StatementExecuted -> per-pool 1-minute buckets
+(`PoolLoadStats`) flushed upsert-add by every replica to `qodstate_pool_load`;
+the HA leader decides (`Autoscale.decide`, pure) and acts through
+`PoolSupervisor.scale(reason = "autoscale")`, so quota gating applies. Config
+under `quack-on-demand.autoscale` (env `QOD_AUTOSCALE_*`); `enabled` (default
+true, env `QOD_AUTOSCALE_ENABLED`) is the manager-wide kill switch and the sweep
+is inert without a band anyway. `minNodes == maxNodes` is a legal band that holds
+the pool at exactly that size (the per-pool way to opt out). With the switch off
+Main does not wire `PoolLoadStats` into the router's event sink at all, since the
+sweep is that sink's sole drainer. Manual scale outside the band is refused
+(`outside_band`).
+See docs/superpowers/specs/2026-08-11-demand-scale-out-policy-design.md.
+
 ### HA mode (opt-in, Kubernetes only)
 
 `QOD_HA_ENABLED=true` (helm: `replicaCount > 1`) runs N active-active managers.

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,12 @@ import xerial.sbt.Sonatype.sonatypeCentralHost
 ThisBuild / scalaVersion := "3.7.4"
 ThisBuild / organization := "ai.starlake"
 
+// pureconfig's Mirror-based deriveReader macro recurses once per ManagerConfig
+// field; the scala3 compiler default (-Xmax-inlines:32) is exceeded once
+// ManagerConfig grows past ~28 fields (hit adding AutoscaleConfig). Bump with
+// headroom rather than re-tuning on every future config block.
+ThisBuild / scalacOptions += "-Xmax-inlines:64"
+
 // ----- Sonatype Central Portal publishing (snapshot + release-ready) -----
 // The published artifact is the assembly uber-jar - quack-on-demand is an
 // app, not an embed-style library, so consumers run `java -jar` rather

--- a/cli/src/qod_cli/commands/pool.py
+++ b/cli/src/qod_cli/commands/pool.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import typer
 
 from ..registry import covers
@@ -42,6 +44,8 @@ def list_(ctx: typer.Context):
         "startSuspended": "--start-suspended",
         "cohorts": "--cohort",
         "lockdown": "--lockdown",
+        "minNodes": "--min-nodes",
+        "maxNodes": "--max-nodes",
     },
 )
 def create(
@@ -73,6 +77,8 @@ def create(
         "--lockdown",
         help="inherit|on|off - per-pool node-lockdown override; inherit follows the global QOD_NODE_LOCKDOWN flag.",
     ),
+    min_nodes: Optional[int] = typer.Option(None, "--min-nodes", help="Autoscale floor (set with --max-nodes)"),
+    max_nodes: Optional[int] = typer.Option(None, "--max-nodes", help="Autoscale ceiling (set with --min-nodes)"),
 ):
     body = {
         **_key(tenant, db, pool),
@@ -106,6 +112,10 @@ def create(
                 }
             )
         body["cohorts"] = cohorts
+    if min_nodes is not None:
+        body["minNodes"] = min_nodes
+    if max_nodes is not None:
+        body["maxNodes"] = max_nodes
     call(ctx, "POST", "/api/pool/create", body=body)
 
 
@@ -176,6 +186,39 @@ def set_disabled(ctx: typer.Context, tenant: str = TENANT, db: str = DB, pool: s
 )
 def set_resources(ctx: typer.Context, tenant: str = TENANT, db: str = DB, pool: str = POOL, cpu: str = typer.Option(..., "--cpu"), memory: str = typer.Option(..., "--memory")):
     call(ctx, "POST", "/api/pool/setResources", body={**_key(tenant, db, pool), "cpu": cpu, "memory": memory})
+
+
+@app.command("set-autoscale")
+@covers(
+    "POST",
+    "/api/pool/setAutoscale",
+    {
+        "tenant": "--tenant",
+        "tenantDb": "--db",
+        "pool": "--pool",
+        "minNodes": "--min-nodes",
+        "maxNodes": "--max-nodes",
+    },
+)
+def set_autoscale(
+    ctx: typer.Context,
+    tenant: str = TENANT,
+    db: str = DB,
+    pool: str = POOL,
+    min_nodes: Optional[int] = typer.Option(
+        None, "--min-nodes", help="Set both or neither; omit both to clear the band."
+    ),
+    max_nodes: Optional[int] = typer.Option(
+        None, "--max-nodes", help="Set both or neither; omit both to clear the band."
+    ),
+):
+    """Set or clear a pool's autoscale band (omit both bounds to clear)."""
+    body = _key(tenant, db, pool)
+    if min_nodes is not None:
+        body["minNodes"] = min_nodes
+    if max_nodes is not None:
+        body["maxNodes"] = max_nodes
+    call(ctx, "POST", "/api/pool/setAutoscale", body=body)
 
 
 @app.command("set-lockdown")

--- a/cli/src/qod_cli/scripts/spawn-quack-node.ps1
+++ b/cli/src/qod_cli/scripts/spawn-quack-node.ps1
@@ -121,8 +121,29 @@ CREATE OR REPLACE SECRET quack_azure (
   }
 }
 
-if ($kind -ne 'memory' -and -not $isRemote) {
-  New-Item -ItemType Directory -Force -Path $dataPath | Out-Null
+# New-Item behaviour differs by kind: for `ducklake`, dataPath is a parquet
+# DIRECTORY, so creating the path itself is correct. For `duckdb-file`,
+# dataPath is a .duckdb FILE path - creating a directory at that exact path
+# would make the later `ATTACH '$dataPath'` fail ("Is a directory" / file
+# already exists as a directory); only the parent directory needs to exist.
+# For `memory`, there is no on-disk path at all. Mirrors spawn-quack-node.sh.
+if (-not $isRemote) {
+  switch ($kind) {
+    'ducklake' {
+      New-Item -ItemType Directory -Force -Path $dataPath | Out-Null
+    }
+    'duckdb-file' {
+      if (-not [string]::IsNullOrEmpty($dataPath)) {
+        $parent = Split-Path -Path $dataPath -Parent
+        if (-not [string]::IsNullOrEmpty($parent)) {
+          New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+      }
+    }
+    'memory' {
+      # no on-disk dataPath to create
+    }
+  }
 }
 
 # Resolve the DuckDB CLI. $env:DUCKDB_BIN wins; otherwise the first `duckdb`

--- a/cli/src/qod_cli/scripts/spawn-quack-node.sh
+++ b/cli/src/qod_cli/scripts/spawn-quack-node.sh
@@ -90,8 +90,26 @@ CREATE OR REPLACE SECRET quack_azure (
     ;;
 esac
 
-if [[ "$kind" != "memory" && "$IS_REMOTE" == "0" ]]; then
-  mkdir -p "$dataPath"
+# mkdir behaviour differs by kind: for `ducklake`, dataPath is a parquet
+# DIRECTORY, so mkdir -p on the path itself is correct. For `duckdb-file`,
+# dataPath is a .duckdb FILE path - mkdir -p on the path itself would create
+# a directory there and the later `ATTACH '$dataPath'` fails with "Is a
+# directory"; only the parent directory needs to exist. For `memory`, there
+# is no on-disk path at all.
+if [[ "$IS_REMOTE" == "0" ]]; then
+  case "$kind" in
+    ducklake)
+      mkdir -p "$dataPath"
+      ;;
+    duckdb-file)
+      if [[ -n "$dataPath" ]]; then
+        mkdir -p "$(dirname "$dataPath")"
+      fi
+      ;;
+    memory)
+      : # no on-disk dataPath to create
+      ;;
+  esac
 fi
 
 # Resolve the duckdb CLI. $DUCKDB_BIN wins (an absolute path the launcher sets to
@@ -159,6 +177,63 @@ if [[ -n "$PROXY_URL" ]]; then
   PROXY_SQL="SET http_proxy = '$HOSTPORT';"
 fi
 
+# Cgroup-aware memory_limit / threads, K8s pods only (no-op elsewhere).
+#
+# DuckDB's own defaults read the HOST, not the container: memory_limit
+# defaults to ~80% of host RAM (ignores the cgroup limit a K8s
+# `resources.limits.memory` actually sets), and threads defaults to the
+# CPU count visible via affinity, which K8s's CFS-quota-based
+# `resources.limits.cpu` does not reduce (that throttles time slices, it
+# doesn't shrink the visible core count without the rarely-used "static"
+# CPU manager policy). Left alone, a pod sized smaller than the node
+# either gets OOM-killed by the kernel once it exceeds its real cgroup
+# limit (DuckDB never thought it was close, so it never spilled), or
+# oversubscribes worker threads onto a fraction of a CPU's worth of
+# actual CFS-granted time. Reading the cgroup files directly - rather
+# than threading a new cpu/memory env var through both backends - stays
+# correct for any pool size (fixed tier or custom) with no new plumbing.
+# Same pattern as the SF>=10 fix in _load-common.sh's
+# cgroup_memory_bytes/default_memory_limit, but tuned differently: that
+# script shares its cgroup with the manager JVM during a local demo load
+# (hence a conservative 40%), whereas a node pod runs nothing but DuckDB,
+# so 85% (in line with general DuckDB memory-tuning guidance) is safe.
+# `/duckdb-tmp` is the emptyDir KubernetesQuackBackend already mounts on
+# every pod for `readOnlyRootFilesystem` compatibility; only point
+# temp_directory at it when it actually exists so LocalQuackBackend (no
+# such mount, no meaningful cgroup either) is unaffected.
+RESOURCE_SQL=""
+if [[ -r /sys/fs/cgroup/memory.max ]]; then
+  MEM_BYTES="$(cat /sys/fs/cgroup/memory.max 2>/dev/null)"        # cgroup v2
+elif [[ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+  MEM_BYTES="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)"  # cgroup v1
+else
+  MEM_BYTES=""
+fi
+if [[ "$MEM_BYTES" =~ ^[0-9]+$ ]] && (( MEM_BYTES > 0 && MEM_BYTES < 9000000000000000000 )); then
+  MEM_MIB=$(( MEM_BYTES / 1024 / 1024 * 85 / 100 ))
+  (( MEM_MIB < 256 )) && MEM_MIB=256
+  RESOURCE_SQL+="SET memory_limit = '${MEM_MIB}MiB';"$'\n'
+fi
+if [[ -d /duckdb-tmp && -w /duckdb-tmp ]]; then
+  RESOURCE_SQL+="SET temp_directory = '/duckdb-tmp';"$'\n'
+fi
+if [[ -r /sys/fs/cgroup/cpu.max ]]; then
+  read -r CPU_QUOTA CPU_PERIOD < /sys/fs/cgroup/cpu.max              # cgroup v2: "<quota> <period>"
+  if [[ "$CPU_QUOTA" =~ ^[0-9]+$ && "$CPU_PERIOD" =~ ^[0-9]+$ && "$CPU_PERIOD" -gt 0 ]]; then
+    CPU_THREADS=$(( (CPU_QUOTA + CPU_PERIOD - 1) / CPU_PERIOD ))     # ceil(quota / period)
+    (( CPU_THREADS < 1 )) && CPU_THREADS=1
+    RESOURCE_SQL+="SET threads = ${CPU_THREADS};"$'\n'
+  fi
+elif [[ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us && -r /sys/fs/cgroup/cpu/cpu.cfs_period_us ]]; then
+  CPU_QUOTA="$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null)"   # cgroup v1
+  CPU_PERIOD="$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null)"
+  if [[ "$CPU_QUOTA" =~ ^[0-9]+$ && "$CPU_PERIOD" =~ ^[0-9]+$ && "$CPU_PERIOD" -gt 0 ]]; then
+    CPU_THREADS=$(( (CPU_QUOTA + CPU_PERIOD - 1) / CPU_PERIOD ))
+    (( CPU_THREADS < 1 )) && CPU_THREADS=1
+    RESOURCE_SQL+="SET threads = ${CPU_THREADS};"$'\n'
+  fi
+fi
+
 # Feed init SQL. Per-kind branching below:
 #   ducklake    - INSTALL/ATTACH the DuckLake catalog via a per-dbname
 #                 pg_advisory_lock to serialize first-time
@@ -174,6 +249,12 @@ fi
 # kind=duckdb-file skip DuckLake-specific setup entirely.
 INIT_SQL=""
 INIT_SQL+="$PROXY_SQL"$'\n'
+# Cgroup-derived memory_limit / temp_directory / threads (see above) run
+# right after the proxy settings and before dbInitSql, so an operator's
+# own "SET memory_limit=..." / "SET threads=..." in dbInitSql or
+# extraSetupSql still wins - DuckDB's SET is a plain reassignment, so the
+# later statement is the one that sticks.
+INIT_SQL+="$RESOURCE_SQL"
 # Per-database init SQL (tenant-db initSql, `dbInitSql` env var). Runs BEFORE
 # the quack extension is installed/loaded and before the catalog ATTACH, right
 # after the proxy settings, so engine-level defaults (SET memory_limit,

--- a/cli/tests/resources/openapi.yaml
+++ b/cli/tests/resources/openapi.yaml
@@ -3588,6 +3588,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/pool/setAutoscale:
+    post:
+      operationId: postApiPoolSetautoscale
+      parameters:
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          type: string
+      - name: qod_session
+        in: cookie
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetPoolAutoscaleRequest'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PoolResponse'
+        '400':
+          description: 'Invalid value for: body, Invalid value for: header X-API-Key,
+            Invalid value for: cookie qod_session'
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/pool/setDisabled:
     post:
       operationId: postApiPoolSetdisabled
@@ -5029,6 +5069,12 @@ components:
           type: string
         lockdown:
           type: string
+        minNodes:
+          type: integer
+          format: int32
+        maxNodes:
+          type: integer
+          format: int32
     CreateRowPolicyRequest:
       title: CreateRowPolicyRequest
       type: object
@@ -5912,6 +5958,12 @@ components:
           type: string
         lockdownEffective:
           type: boolean
+        minNodes:
+          type: integer
+          format: int32
+        maxNodes:
+          type: integer
+          format: int32
     PreviewColumn:
       title: PreviewColumn
       type: object
@@ -6299,6 +6351,26 @@ components:
         nodeId:
           type: string
         max:
+          type: integer
+          format: int32
+    SetPoolAutoscaleRequest:
+      title: SetPoolAutoscaleRequest
+      type: object
+      required:
+      - tenant
+      - tenantDb
+      - pool
+      properties:
+        tenant:
+          type: string
+        tenantDb:
+          type: string
+        pool:
+          type: string
+        minNodes:
+          type: integer
+          format: int32
+        maxNodes:
           type: integer
           format: int32
     SetPoolDisabledRequest:

--- a/cli/tests/test_commands_table.py
+++ b/cli/tests/test_commands_table.py
@@ -122,6 +122,22 @@ CASES = [
         },
     ),
     (
+        [
+            "pool", "create", "--tenant", "acme", "--db", "tpch1", "--pool", "bi",
+            "--size", "2", "--min-nodes", "1", "--max-nodes", "4",
+        ],
+        "POST",
+        "/api/pool/create",
+        {},
+        {
+            "tenant": "acme", "tenantDb": "tpch1", "pool": "bi", "size": 2,
+            "roleDistribution": {"writeonly": 0, "readonly": 0, "dual": 0},
+            "idleTimeoutSec": -1, "maxConcurrentPerNode": 0, "disabled": False,
+            "cpu": "", "memory": "", "podTemplateYaml": "", "startSuspended": False,
+            "lockdown": "inherit", "minNodes": 1, "maxNodes": 4,
+        },
+    ),
+    (
         ["pool", "suspend", "--tenant", "acme", "--db", "tpch1", "--pool", "bi"],
         "POST", "/api/pool/suspend", {},
         {"tenant": "acme", "tenantDb": "tpch1", "pool": "bi"},
@@ -169,6 +185,21 @@ CASES = [
         ["pool", "set-lockdown", "--tenant", "acme", "--db", "tpch1", "--pool", "bi", "--lockdown", "on"],
         "POST", "/api/pool/setLockdown", {},
         {"tenant": "acme", "tenantDb": "tpch1", "pool": "bi", "lockdown": "on"},
+    ),
+    (
+        ["pool", "set-autoscale", "--tenant", "acme", "--db", "tpch1", "--pool", "bi", "--min-nodes", "1", "--max-nodes", "4"],
+        "POST", "/api/pool/setAutoscale", {},
+        {"tenant": "acme", "tenantDb": "tpch1", "pool": "bi", "minNodes": 1, "maxNodes": 4},
+    ),
+    (
+        ["pool", "set-autoscale", "--tenant", "acme", "--db", "tpch1", "--pool", "bi"],
+        "POST", "/api/pool/setAutoscale", {},
+        {"tenant": "acme", "tenantDb": "tpch1", "pool": "bi"},
+    ),
+    (
+        ["pool", "set-autoscale", "--tenant", "acme", "--db", "tpch1", "--pool", "bi", "--min-nodes", "0", "--max-nodes", "4"],
+        "POST", "/api/pool/setAutoscale", {},
+        {"tenant": "acme", "tenantDb": "tpch1", "pool": "bi", "minNodes": 0, "maxNodes": 4},
     ),
     (
         ["pool", "permission", "list", "--tenant", "acme"],

--- a/scripts/spawn-quack-node.ps1
+++ b/scripts/spawn-quack-node.ps1
@@ -121,8 +121,29 @@ CREATE OR REPLACE SECRET quack_azure (
   }
 }
 
-if ($kind -ne 'memory' -and -not $isRemote) {
-  New-Item -ItemType Directory -Force -Path $dataPath | Out-Null
+# New-Item behaviour differs by kind: for `ducklake`, dataPath is a parquet
+# DIRECTORY, so creating the path itself is correct. For `duckdb-file`,
+# dataPath is a .duckdb FILE path - creating a directory at that exact path
+# would make the later `ATTACH '$dataPath'` fail ("Is a directory" / file
+# already exists as a directory); only the parent directory needs to exist.
+# For `memory`, there is no on-disk path at all. Mirrors spawn-quack-node.sh.
+if (-not $isRemote) {
+  switch ($kind) {
+    'ducklake' {
+      New-Item -ItemType Directory -Force -Path $dataPath | Out-Null
+    }
+    'duckdb-file' {
+      if (-not [string]::IsNullOrEmpty($dataPath)) {
+        $parent = Split-Path -Path $dataPath -Parent
+        if (-not [string]::IsNullOrEmpty($parent)) {
+          New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+      }
+    }
+    'memory' {
+      # no on-disk dataPath to create
+    }
+  }
 }
 
 # Resolve the DuckDB CLI. $env:DUCKDB_BIN wins; otherwise the first `duckdb`

--- a/scripts/spawn-quack-node.sh
+++ b/scripts/spawn-quack-node.sh
@@ -159,6 +159,63 @@ if [[ -n "$PROXY_URL" ]]; then
   PROXY_SQL="SET http_proxy = '$HOSTPORT';"
 fi
 
+# Cgroup-aware memory_limit / threads, K8s pods only (no-op elsewhere).
+#
+# DuckDB's own defaults read the HOST, not the container: memory_limit
+# defaults to ~80% of host RAM (ignores the cgroup limit a K8s
+# `resources.limits.memory` actually sets), and threads defaults to the
+# CPU count visible via affinity, which K8s's CFS-quota-based
+# `resources.limits.cpu` does not reduce (that throttles time slices, it
+# doesn't shrink the visible core count without the rarely-used "static"
+# CPU manager policy). Left alone, a pod sized smaller than the node
+# either gets OOM-killed by the kernel once it exceeds its real cgroup
+# limit (DuckDB never thought it was close, so it never spilled), or
+# oversubscribes worker threads onto a fraction of a CPU's worth of
+# actual CFS-granted time. Reading the cgroup files directly - rather
+# than threading a new cpu/memory env var through both backends - stays
+# correct for any pool size (fixed tier or custom) with no new plumbing.
+# Same pattern as the SF>=10 fix in _load-common.sh's
+# cgroup_memory_bytes/default_memory_limit, but tuned differently: that
+# script shares its cgroup with the manager JVM during a local demo load
+# (hence a conservative 40%), whereas a node pod runs nothing but DuckDB,
+# so 85% (in line with general DuckDB memory-tuning guidance) is safe.
+# `/duckdb-tmp` is the emptyDir KubernetesQuackBackend already mounts on
+# every pod for `readOnlyRootFilesystem` compatibility; only point
+# temp_directory at it when it actually exists so LocalQuackBackend (no
+# such mount, no meaningful cgroup either) is unaffected.
+RESOURCE_SQL=""
+if [[ -r /sys/fs/cgroup/memory.max ]]; then
+  MEM_BYTES="$(cat /sys/fs/cgroup/memory.max 2>/dev/null)"        # cgroup v2
+elif [[ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]]; then
+  MEM_BYTES="$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null)"  # cgroup v1
+else
+  MEM_BYTES=""
+fi
+if [[ "$MEM_BYTES" =~ ^[0-9]+$ ]] && (( MEM_BYTES > 0 && MEM_BYTES < 9000000000000000000 )); then
+  MEM_MIB=$(( MEM_BYTES / 1024 / 1024 * 85 / 100 ))
+  (( MEM_MIB < 256 )) && MEM_MIB=256
+  RESOURCE_SQL+="SET memory_limit = '${MEM_MIB}MiB';"$'\n'
+fi
+if [[ -d /duckdb-tmp && -w /duckdb-tmp ]]; then
+  RESOURCE_SQL+="SET temp_directory = '/duckdb-tmp';"$'\n'
+fi
+if [[ -r /sys/fs/cgroup/cpu.max ]]; then
+  read -r CPU_QUOTA CPU_PERIOD < /sys/fs/cgroup/cpu.max              # cgroup v2: "<quota> <period>"
+  if [[ "$CPU_QUOTA" =~ ^[0-9]+$ && "$CPU_PERIOD" =~ ^[0-9]+$ && "$CPU_PERIOD" -gt 0 ]]; then
+    CPU_THREADS=$(( (CPU_QUOTA + CPU_PERIOD - 1) / CPU_PERIOD ))     # ceil(quota / period)
+    (( CPU_THREADS < 1 )) && CPU_THREADS=1
+    RESOURCE_SQL+="SET threads = ${CPU_THREADS};"$'\n'
+  fi
+elif [[ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us && -r /sys/fs/cgroup/cpu/cpu.cfs_period_us ]]; then
+  CPU_QUOTA="$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null)"   # cgroup v1
+  CPU_PERIOD="$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null)"
+  if [[ "$CPU_QUOTA" =~ ^[0-9]+$ && "$CPU_PERIOD" =~ ^[0-9]+$ && "$CPU_PERIOD" -gt 0 ]]; then
+    CPU_THREADS=$(( (CPU_QUOTA + CPU_PERIOD - 1) / CPU_PERIOD ))
+    (( CPU_THREADS < 1 )) && CPU_THREADS=1
+    RESOURCE_SQL+="SET threads = ${CPU_THREADS};"$'\n'
+  fi
+fi
+
 # Feed init SQL. Per-kind branching below:
 #   ducklake    - INSTALL/ATTACH the DuckLake catalog via a per-dbname
 #                 pg_advisory_lock to serialize first-time
@@ -174,6 +231,12 @@ fi
 # kind=duckdb-file skip DuckLake-specific setup entirely.
 INIT_SQL=""
 INIT_SQL+="$PROXY_SQL"$'\n'
+# Cgroup-derived memory_limit / temp_directory / threads (see above) run
+# right after the proxy settings and before dbInitSql, so an operator's
+# own "SET memory_limit=..." / "SET threads=..." in dbInitSql or
+# extraSetupSql still wins - DuckDB's SET is a plain reassignment, so the
+# later statement is the one that sticks.
+INIT_SQL+="$RESOURCE_SQL"
 # Per-database init SQL (tenant-db initSql, `dbInitSql` env var). Runs BEFORE
 # the quack extension is installed/loaded and before the catalog ATTACH, right
 # after the proxy settings, so engine-level defaults (SET memory_limit,

--- a/scripts/spawn-quack-node.sh
+++ b/scripts/spawn-quack-node.sh
@@ -90,8 +90,26 @@ CREATE OR REPLACE SECRET quack_azure (
     ;;
 esac
 
-if [[ "$kind" != "memory" && "$IS_REMOTE" == "0" ]]; then
-  mkdir -p "$dataPath"
+# mkdir behaviour differs by kind: for `ducklake`, dataPath is a parquet
+# DIRECTORY, so mkdir -p on the path itself is correct. For `duckdb-file`,
+# dataPath is a .duckdb FILE path - mkdir -p on the path itself would create
+# a directory there and the later `ATTACH '$dataPath'` fails with "Is a
+# directory"; only the parent directory needs to exist. For `memory`, there
+# is no on-disk path at all.
+if [[ "$IS_REMOTE" == "0" ]]; then
+  case "$kind" in
+    ducklake)
+      mkdir -p "$dataPath"
+      ;;
+    duckdb-file)
+      if [[ -n "$dataPath" ]]; then
+        mkdir -p "$(dirname "$dataPath")"
+      fi
+      ;;
+    memory)
+      : # no on-disk dataPath to create
+      ;;
+  esac
 fi
 
 # Resolve the duckdb CLI. $DUCKDB_BIN wins (an absolute path the launcher sets to

--- a/skills/quack-on-demand/SKILL.md
+++ b/skills/quack-on-demand/SKILL.md
@@ -135,6 +135,45 @@ curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/resume \
 # (bounded by PROXY_RESUME_HOLD_TIMEOUT_SEC, default 60s). A stopped pool
 # (pool/stop) stays down; a disabled pool is never auto-woken.
 
+# Autoscale band: declare minNodes/maxNodes and the manager adds/removes READONLY
+# nodes with demand, never leaving the band. Both bounds together or neither.
+# Rules: 1 <= min <= max <= QOD_AUTOSCALE_HARD_CAP (16); min must cover the
+# write-capable nodes (writeonly + dual); the CURRENT size must sit inside the
+# band (so a stopped pool, size 0, cannot take one - scale it up first); a pool
+# with authored cohorts cannot be elastic. Violations return 400 invalid_band.
+# Create a pool with a band:
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/create \
+  -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","tenantDb":"acme_tpch","pool":"bi","size":2,
+       "roleDistribution":{"writeonly":1,"readonly":1,"dual":0},
+       "minNodes":2,"maxNodes":6}'
+
+# Set (or change) the band on an existing pool
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/setAutoscale \
+  -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","tenantDb":"acme_tpch","pool":"bi","minNodes":2,"maxNodes":6}'
+
+# Clear the band (omit BOTH bounds) - the pool goes back to a fixed size
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/setAutoscale \
+  -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","tenantDb":"acme_tpch","pool":"bi"}'
+
+# CLI equivalents
+qod pool create --tenant acme --db acme_tpch --pool bi --size 2 \
+  --writeonly 1 --readonly 1 --min-nodes 2 --max-nodes 6
+qod pool set-autoscale --tenant acme --db acme_tpch --pool bi --min-nodes 2 --max-nodes 6
+qod pool set-autoscale --tenant acme --db acme_tpch --pool bi   # clears it
+
+# pool/scale on a banded pool refuses a targetSize outside [min, max] with
+# 400 outside_band ("adjust the band first via pool/setAutoscale") - the next
+# sweep would just undo it. Widen or clear the band, then scale.
+# To pin a pool: set minNodes == maxNodes. That is a legal band meaning "hold
+# exactly this size, never scale", and it keeps manual scaling constrained to
+# that size. To stop the sweep manager-wide: QOD_AUTOSCALE_ENABLED=false (bands
+# stay recorded and are simply not acted on). Actions land in the audit log with
+# actor "autoscale" and in the manager log as
+# "autoscale: acme/acme_tpch/bi out 2 -> 3 util=0.91".
+
 # Delete a pool: stops nodes AND removes the pool from the registry
 curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/pool/delete \
   -H 'Content-Type: application/json' \

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -403,6 +403,37 @@ quack-on-demand {
     directoryMaxTables = 4096
     directoryMaxTables = ${?QOD_ROUTING_DIRECTORY_MAX_TABLES}
   }
+
+  # Demand scale-out between a pool's owner-declared minNodes/maxNodes band.
+  # Inert unless a pool declares a band. `enabled = false` stops the sweep
+  # manager-wide; a single pool opts out by declaring minNodes == maxNodes,
+  # which holds it at exactly that size. See the scale-out design spec.
+  autoscale {
+    enabled = true
+    enabled = ${?QOD_AUTOSCALE_ENABLED}
+    sweepSeconds = 60
+    sweepSeconds = ${?QOD_AUTOSCALE_SWEEP_SEC}
+    windowMinutes = 5
+    windowMinutes = ${?QOD_AUTOSCALE_WINDOW_MINUTES}
+    highWatermark = 0.8
+    highWatermark = ${?QOD_AUTOSCALE_HIGH_WATERMARK}
+    lowWatermark = 0.3
+    lowWatermark = ${?QOD_AUTOSCALE_LOW_WATERMARK}
+    outStreak = 2
+    outStreak = ${?QOD_AUTOSCALE_OUT_STREAK}
+    inStreak = 10
+    inStreak = ${?QOD_AUTOSCALE_IN_STREAK}
+    scaleOutCooldownSec = 180
+    scaleOutCooldownSec = ${?QOD_AUTOSCALE_OUT_COOLDOWN_SEC}
+    scaleInCooldownSec = 600
+    scaleInCooldownSec = ${?QOD_AUTOSCALE_IN_COOLDOWN_SEC}
+    assumedConcurrencyPerNode = 4
+    assumedConcurrencyPerNode = ${?QOD_AUTOSCALE_ASSUMED_CONCURRENCY}
+    hardCap = 16
+    hardCap = ${?QOD_AUTOSCALE_HARD_CAP}
+    failureBackoffSweeps = 5
+    failureBackoffSweeps = ${?QOD_AUTOSCALE_FAILURE_BACKOFF_SWEEPS}
+  }
 }
 
 quack-flightsql {

--- a/src/main/resources/db/changelog/0025-pool-autoscale-band.yaml
+++ b/src/main/resources/db/changelog/0025-pool-autoscale-band.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0025-qodstate-pool-autoscale-band
+      author: quack-on-demand
+      changes:
+        # Owner-declared demand scale-out band. Both NULL = fixed-size pool
+        # (exact pre-0025 behavior). Set together or not at all; REST validates.
+        - addColumn:
+            tableName: qodstate_pool
+            columns:
+              - column:
+                  name: min_nodes
+                  type: INT
+              - column:
+                  name: max_nodes
+                  type: INT

--- a/src/main/resources/db/changelog/0026-pool-load.yaml
+++ b/src/main/resources/db/changelog/0026-pool-load.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0026-qodstate-pool-load
+      author: quack-on-demand
+      changes:
+        # Per-pool 1-minute demand buckets for the autoscale sweep. Written
+        # upsert-add by every replica; read summed by the HA leader; purged
+        # after an hour. No FK to qodstate_pool: rows of a deleted pool age
+        # out on their own within the retention window.
+        - createTable:
+            tableName: qodstate_pool_load
+            columns:
+              - column:
+                  name: pool_id
+                  type: TEXT
+                  constraints: { nullable: false }
+              - column:
+                  name: bucket_start
+                  type: TIMESTAMPTZ
+                  constraints: { nullable: false }
+              - column:
+                  name: statements
+                  type: BIGINT
+                  constraints: { nullable: false }
+              - column:
+                  name: total_duration_ms
+                  type: BIGINT
+                  constraints: { nullable: false }
+        - addPrimaryKey:
+            tableName: qodstate_pool_load
+            columnNames: pool_id, bucket_start
+            constraintName: pk_qodstate_pool_load

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -53,3 +53,7 @@ databaseChangeLog:
       file: db/changelog/0023-pool-suspended.yaml
   - include:
       file: db/changelog/0024-pool-lockdown.yaml
+  - include:
+      file: db/changelog/0025-pool-autoscale-band.yaml
+  - include:
+      file: db/changelog/0026-pool-load.yaml

--- a/src/main/scala/ai/starlake/quack/Config.scala
+++ b/src/main/scala/ai/starlake/quack/Config.scala
@@ -469,6 +469,7 @@ final case class ManagerConfig(
     maintenance: MaintenanceConfig = MaintenanceConfig(),
     catalog: CatalogConfig = CatalogConfig(),
     routing: RoutingConfig = RoutingConfig(),
+    autoscale: AutoscaleConfig = AutoscaleConfig(),
     @field @ConfigField(
       envVar = "QOD_SESSION_IDLE_TTL_SEC",
       description =
@@ -504,6 +505,86 @@ final case class RoutingConfig(
     )
     directoryMaxTables: Int = 4096
 )
+
+/** Demand scale-out between a pool's owner-declared min/max band. Policy lives in core; per-pool
+  * participation requires an explicit band, so the sweep is inert on fresh installs. Two levels of
+  * opt-out: `enabled = false` stops the sweep manager-wide, and a pool opts out on its own by
+  * declaring `minNodes == maxNodes` (hold that size, never scale) or by carrying no band at all.
+  * See docs/superpowers/specs/2026-08-11-demand-scale-out-policy-design.md.
+  */
+final case class AutoscaleConfig(
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_ENABLED",
+      description = "Global kill switch for the demand scale-out sweep."
+    )
+    enabled: Boolean = true,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_SWEEP_SEC",
+      description = "Sweep interval in seconds; clamped to a 30s floor."
+    )
+    sweepSeconds: Int = 60,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_WINDOW_MINUTES",
+      description = "Load window W for the Little's-law concurrency estimate."
+    )
+    windowMinutes: Int = 5,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_HIGH_WATERMARK",
+      description = "Scale-out utilization threshold."
+    )
+    highWatermark: Double = 0.8,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_LOW_WATERMARK",
+      description = "Scale-in utilization threshold; must be < highWatermark."
+    )
+    lowWatermark: Double = 0.3,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_OUT_STREAK",
+      description = "Consecutive sweeps above highWatermark before adding a reader."
+    )
+    outStreak: Int = 2,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_IN_STREAK",
+      description = "Consecutive sweeps below lowWatermark before removing a reader."
+    )
+    inStreak: Int = 10,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_OUT_COOLDOWN_SEC",
+      description = "Per-pool cooldown after any scale action or resume before scaling out."
+    )
+    scaleOutCooldownSec: Int = 180,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_IN_COOLDOWN_SEC",
+      description = "Per-pool cooldown after any scale action before scaling in."
+    )
+    scaleInCooldownSec: Int = 600,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_ASSUMED_CONCURRENCY",
+      description = "Capacity contribution of a node with maxConcurrent = 0 (unlimited)."
+    )
+    assumedConcurrencyPerNode: Int = 4,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_HARD_CAP",
+      description = "Upper bound on maxNodes at validation time; a typo guard, not a quota."
+    )
+    hardCap: Int = 16,
+    @field @ConfigField(
+      envVar = "QOD_AUTOSCALE_FAILURE_BACKOFF_SWEEPS",
+      description = "Sweeps to skip a pool after 3 consecutive scale failures."
+    )
+    failureBackoffSweeps: Int = 5
+):
+  require(lowWatermark < highWatermark, "autoscale: lowWatermark must be < highWatermark")
+  require(outStreak >= 1, "autoscale: outStreak must be >= 1")
+  require(inStreak >= 1, "autoscale: inStreak must be >= 1")
+  require(windowMinutes >= 1, "autoscale: windowMinutes must be >= 1")
+  require(scaleOutCooldownSec >= 0, "autoscale: scaleOutCooldownSec must be >= 0")
+  require(scaleInCooldownSec >= 0, "autoscale: scaleInCooldownSec must be >= 0")
+  require(failureBackoffSweeps >= 1, "autoscale: failureBackoffSweeps must be >= 1")
+  require(assumedConcurrencyPerNode >= 0, "autoscale: assumedConcurrencyPerNode must be >= 0")
+  require(hardCap >= 1, "autoscale: hardCap must be >= 1")
+  def sweepInterval: scala.concurrent.duration.FiniteDuration =
+    scala.concurrent.duration.DurationInt(math.max(30, sweepSeconds)).seconds
 
 final case class FlightConfig(
     @field @ConfigField(envVar = "PROXY_HOST", description = "FlightSQL edge bind address.")

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -88,6 +88,7 @@ object Main extends IOApp with LazyLogging:
   given ProductHint[MaintenanceConfig]         = ProductHint[MaintenanceConfig](camelMapping)
   given ProductHint[CatalogConfig]             = ProductHint[CatalogConfig](camelMapping)
   given ProductHint[RoutingConfig]             = ProductHint[RoutingConfig](camelMapping)
+  given ProductHint[AutoscaleConfig]           = ProductHint[AutoscaleConfig](camelMapping)
   given ProductHint[ManagerConfig]             = ProductHint[ManagerConfig](camelMapping)
   given ProductHint[FlightConfig]              = ProductHint[FlightConfig](camelMapping)
   given ProductHint[DatabaseAuthConfig]        = ProductHint[DatabaseAuthConfig](camelMapping)
@@ -110,6 +111,7 @@ object Main extends IOApp with LazyLogging:
   given ConfigReader[MaintenanceConfig]      = deriveReader[MaintenanceConfig]
   given ConfigReader[CatalogConfig]          = deriveReader[CatalogConfig]
   given ConfigReader[RoutingConfig]          = deriveReader[RoutingConfig]
+  given ConfigReader[AutoscaleConfig]        = deriveReader[AutoscaleConfig]
   given ConfigReader[ManagerConfig]          = deriveReader[ManagerConfig]
   given ConfigReader[FlightConfig]           = deriveReader[FlightConfig]
   given ConfigReader[DatabaseAuthConfig]     = deriveReader[DatabaseAuthConfig]
@@ -279,7 +281,11 @@ object Main extends IOApp with LazyLogging:
     val placementDirectory =
       new ai.starlake.quack.route.PlacementDirectory(mgrCfg.routing.directoryMaxTables)
     val localityTracker = new ai.starlake.quack.route.LocalityTracker()
-    val sup             = new PoolSupervisor(
+    // In-process demand buckets for the autoscale sweep. Fed from the router's
+    // StatementExecuted events; drained (and flushed to Postgres) by AutoscaleWiring
+    // on every replica, since each edge only sees the statements it served.
+    val poolLoadStats = new ai.starlake.quack.route.PoolLoadStats()
+    val sup           = new PoolSupervisor(
       backend,
       tracker,
       store,
@@ -371,6 +377,7 @@ object Main extends IOApp with LazyLogging:
       tracker,
       engineStatsTracker,
       mgrCfg.k8s.podTemplateEnabled,
+      autoscaleHardCap = mgrCfg.autoscale.hardCap,
       audit = auditRecorder
     )
     val nodes   = new NodeHandlers(sup, tracker, store, publisher, audit = auditRecorder)
@@ -629,7 +636,15 @@ object Main extends IOApp with LazyLogging:
         eventJournal,
         stampWrites = mgrCfg.stampWrites,
         attachedCatalogsOf = attachedCatalogsOf,
-        events = moduleEventBus.sink,
+        // The load-stats sink goes FIRST: fanout has no error isolation, so a module
+        // sink that throws must not be able to starve the autoscale demand signal.
+        // Invariant: poolLoadStats.sink is ONLY wired when the autoscale sweep runs,
+        // because that sweep is its sole drainer -- feeding it with autoscale disabled
+        // would grow the per-(pool, minute) bucket map without bound.
+        events =
+          if mgrCfg.autoscale.enabled then
+            ai.starlake.quack.spi.ManagerEventSink.fanout(poolLoadStats.sink, moduleEventBus.sink)
+          else moduleEventBus.sink,
         resumeHoldTimeout =
           scala.concurrent.duration.DurationLong(edgeCfg.resumeHoldTimeoutSec).seconds,
         lockdownFor = sup.effectiveLockdown,
@@ -1004,6 +1019,47 @@ object Main extends IOApp with LazyLogging:
                 val maintenanceSchedulerFiber = maintenanceWiring.schedulerFiber
                 val maintenanceDrainFiber     = maintenanceWiring.drainFiber
 
+                val autoscaleWiring = new ai.starlake.quack.boot.AutoscaleWiring(
+                  cfg = mgrCfg.autoscale,
+                  views = () =>
+                    ai.starlake.quack.boot.AutoscaleWiringSupport
+                      .views(sup, store, mgrCfg.autoscale),
+                  flushLocal = () =>
+                    poolLoadStats.drainClosed().foreach { case ((key, bucketMs), s) =>
+                      sup
+                        .poolId(key)
+                        .foreach(id =>
+                          store.addPoolLoad(
+                            id,
+                            java.time.Instant.ofEpochMilli(bucketMs),
+                            s.statements,
+                            s.totalDurationMs
+                          )
+                        )
+                    },
+                  purge =
+                    () => store.purgePoolLoad(java.time.Instant.now().minusSeconds(3600)): Unit,
+                  // Both directions are the same supervisor call: scale() takes the
+                  // target size and the new distribution the decision core computed.
+                  // force = false keeps the quota gate and the pool lock in play, so a
+                  // rejected scale surfaces as a Left the wiring counts as a failure.
+                  scale = { a =>
+                    val (k, t, d) = a match
+                      case ai.starlake.quack.ondemand.autoscale.AutoscaleAction
+                            .ScaleOut(k, t, d) =>
+                        (k, t, d)
+                      case ai.starlake.quack.ondemand.autoscale.AutoscaleAction.ScaleIn(k, t, d) =>
+                        (k, t, d)
+                    sup.scale(k, t, d, force = false, reason = "autoscale").attempt.map {
+                      case Right(_) => Right(())
+                      case Left(e)  => Left(Option(e.getMessage).getOrElse(e.toString))
+                    }
+                  },
+                  isLeader = () => coordinator.forall(_.isLeader),
+                  audit = auditRecorder
+                )
+                val autoscaleFiber = autoscaleWiring.fiber
+
                 // Leader elector + LISTEN dispatch loop. No-op fiber when HA off.
                 val coordinatorFiber = coordinator match
                   case Some(c) => c.loop.start
@@ -1071,17 +1127,20 @@ object Main extends IOApp with LazyLogging:
                             rollupFiber.flatMap { rlFiber =>
                               maintenanceSchedulerFiber.flatMap { msFiber =>
                                 maintenanceDrainFiber.flatMap { mdFiber =>
-                                  moduleDispatcherFibers.flatMap { modDispFibers =>
-                                    moduleSingletonFibers.flatMap { modSingFibers =>
-                                      IO.never[Unit]
-                                        .guarantee(
-                                          fiber.cancel *> rcFiber.cancel *> coFiber.cancel *>
-                                            hrFiber.cancel *> jFiber.cancel *> pFiber.cancel *>
-                                            rlFiber.cancel *> msFiber.cancel *> mdFiber.cancel *>
-                                            modDispFibers.traverse_(_.cancel) *>
-                                            modSingFibers.traverse_(_.cancel) *>
-                                            gracefulShutdown
-                                        )
+                                  autoscaleFiber.flatMap { asFiber =>
+                                    moduleDispatcherFibers.flatMap { modDispFibers =>
+                                      moduleSingletonFibers.flatMap { modSingFibers =>
+                                        IO.never[Unit]
+                                          .guarantee(
+                                            fiber.cancel *> rcFiber.cancel *> coFiber.cancel *>
+                                              hrFiber.cancel *> jFiber.cancel *> pFiber.cancel *>
+                                              rlFiber.cancel *> msFiber.cancel *> mdFiber.cancel *>
+                                              asFiber.cancel *>
+                                              modDispFibers.traverse_(_.cancel) *>
+                                              modSingFibers.traverse_(_.cancel) *>
+                                              gracefulShutdown
+                                          )
+                                      }
                                     }
                                   }
                                 }

--- a/src/main/scala/ai/starlake/quack/boot/AutoscaleWiring.scala
+++ b/src/main/scala/ai/starlake/quack/boot/AutoscaleWiring.scala
@@ -1,0 +1,194 @@
+package ai.starlake.quack.boot
+
+import ai.starlake.quack.AutoscaleConfig
+import ai.starlake.quack.model.{PoolKey, Role}
+import ai.starlake.quack.ondemand.PoolSupervisor
+import ai.starlake.quack.ondemand.autoscale.{
+  Autoscale,
+  AutoscaleAction,
+  AutoscaleView,
+  PoolAutoState
+}
+import ai.starlake.quack.ondemand.state.ControlPlaneStore
+import ai.starlake.quack.ondemand.telemetry.{AuditActions, AuditRecorder}
+import cats.effect.{FiberIO, IO}
+import com.typesafe.scalalogging.LazyLogging
+
+/** The demand scale-out loop. `flushLocal` runs on EVERY replica (each edge only sees the
+  * statements it served, so its buckets must reach Postgres or the leader's window is blind to
+  * them); `purge`, the decision pass and the actions are leader-only.
+  *
+  * Failure bookkeeping lives here so the decision core stays pure: 3 consecutive scale failures put
+  * a pool into `cfg.failureBackoffSweeps` sweeps of skip (fed to `decide` as `skip`), and any
+  * success resets the counter. State is leader-local and in-heap: a failover restarts streaks,
+  * which delays the next action rather than doubling it.
+  */
+final class AutoscaleWiring(
+    cfg: AutoscaleConfig,
+    views: () => List[AutoscaleView],
+    flushLocal: () => Unit,
+    purge: () => Unit,
+    scale: AutoscaleAction => IO[Either[String, Unit]],
+    isLeader: () => Boolean,
+    audit: AuditRecorder = AuditRecorder.noop,
+    now: () => Long = () => System.currentTimeMillis()
+) extends LazyLogging:
+
+  // Only the sweep fiber mutates these, but a failover-driven read from another
+  // fiber must not see a stale map, hence @volatile on the whole-map swaps.
+  @volatile private var state: Map[PoolKey, PoolAutoState] = Map.empty
+  @volatile private var failures: Map[PoolKey, Int]        = Map.empty
+  @volatile private var backoff: Map[PoolKey, Int]         = Map.empty
+
+  private[boot] def stateForTest: Map[PoolKey, PoolAutoState] = state
+  private[boot] def backoffForTest: Map[PoolKey, Int]         = backoff
+
+  private def keyOf(a: AutoscaleAction): PoolKey = a match
+    case AutoscaleAction.ScaleOut(k, _, _) => k
+    case AutoscaleAction.ScaleIn(k, _, _)  => k
+
+  def sweep(): IO[Unit] =
+    // IO.defer around the leader check: sweep() is bound to a single IO value once
+    // (see `fiber`'s foreverM), so the leadership branch must be re-evaluated on every
+    // run rather than baked in at construction time -- otherwise a replica that boots
+    // before winning the advisory lock latches "not leader" forever.
+    IO.blocking(flushLocal()) *> IO.defer {
+      if !isLeader() then IO.unit
+      else
+        IO.blocking(purge()) *> IO.defer {
+          val vs    = views()
+          val byKey = vs.map(v => v.key -> v).toMap
+          // Snapshot the skip set BEFORE decrementing: a pool that entered backoff with
+          // n sweeps is skipped on exactly n sweeps, and the counter it just failed on
+          // is not one of them.
+          val skip               = backoff.keySet
+          val (actions, updated) = Autoscale.decide(now(), vs, state, skip, cfg)
+          state = updated
+          backoff = backoff.collect { case (k, n) if n > 1 => k -> (n - 1) }
+          actions.foldLeft(IO.unit) { (acc, a) =>
+            // IO.blocking on the bookkeeping: noteSuccess/noteFailure write an audit
+            // row synchronously (same contract as MaintenanceRunner.auditRun).
+            // IO.defer around scale(a): a synchronous throw from the action (e.g. a
+            // `require` inside PoolSupervisor.scale) must be deferred until this step of
+            // the fold actually runs, so `.attempt` can catch it -- otherwise it escapes
+            // while the fold is still being built and kills the whole sweep before
+            // noteFailure ever sees it.
+            acc *> IO.defer(scale(a)).attempt.flatMap { outcome =>
+              IO.blocking {
+                outcome match
+                  case Right(Right(())) => noteSuccess(a, byKey.get(keyOf(a)))
+                  case Right(Left(err)) => noteFailure(a, err)
+                  case Left(t) => noteFailure(a, Option(t.getMessage).getOrElse(t.toString))
+              }
+            }
+          }
+        }
+    }
+
+  private def describe(a: AutoscaleAction, view: Option[AutoscaleView]): String =
+    val (key, dir, target) = a match
+      case AutoscaleAction.ScaleOut(k, t, _) => (k, "out", t)
+      case AutoscaleAction.ScaleIn(k, t, _)  => (k, "in", t)
+    val from = view.map(_.distribution.total).getOrElse(-1)
+    val util = view.flatMap(_.utilization).map(u => f"$u%.2f").getOrElse("?")
+    s"${key.tenant}/${key.tenantDb}/${key.pool} $dir $from -> $target util=$util"
+
+  private def noteSuccess(a: AutoscaleAction, view: Option[AutoscaleView]): Unit =
+    val key = keyOf(a)
+    failures -= key
+    logger.info(s"autoscale: ${describe(a, view)}")
+    auditAction(a, view, "success", None)
+
+  private def noteFailure(a: AutoscaleAction, err: String): Unit =
+    val key = keyOf(a)
+    val n   = failures.getOrElse(key, 0) + 1
+    failures += key -> n
+    if n >= 3 then
+      backoff += key -> cfg.failureBackoffSweeps
+      failures -= key
+      logger.warn(
+        s"autoscale: $key failed $n times ($err); " +
+          s"backing off ${cfg.failureBackoffSweeps} sweeps"
+      )
+    else logger.warn(s"autoscale: scale failed for $key, will retry next sweep: $err")
+    auditAction(a, None, "failure", Some(err))
+
+  private def auditAction(
+      a: AutoscaleAction,
+      view: Option[AutoscaleView],
+      outcome: String,
+      error: Option[String]
+  ): Unit =
+    val (key, dir, target) = a match
+      case AutoscaleAction.ScaleOut(k, t, _) => (k, "out", t)
+      case AutoscaleAction.ScaleIn(k, t, _)  => (k, "in", t)
+    audit.restAs(
+      actor = "autoscale",
+      actorRealm = "system",
+      family = "control-plane",
+      action = AuditActions.PoolScale,
+      outcome = outcome,
+      tenant = Some(key.tenant),
+      target = Some(s"${key.tenantDb}/${key.pool}"),
+      detail = Map(
+        "trigger"    -> "autoscale",
+        "direction"  -> dir,
+        "targetSize" -> target.toString
+      )
+        ++ view.flatMap(_.utilization).map(u => "utilization" -> f"$u%.3f")
+        ++ error.map("error" -> _)
+    )
+
+  /** One sweep every `cfg.sweepInterval` (30s floor). `enabled = false` starts no loop at all: the
+    * sweep is the sole drainer of the edge's load buckets, so Main must not feed
+    * `PoolLoadStats.sink` when this returns a no-op fiber (see the events wiring there). A pool
+    * with no band is not a participant, and a pool with `minNodes == maxNodes` is held at that
+    * size.
+    */
+  def fiber: IO[FiberIO[Unit]] =
+    if !cfg.enabled then IO.unit.start
+    else
+      (sweep().handleErrorWith(t =>
+        IO.delay(logger.warn(s"autoscale sweep: pass failed, continuing: ${t.getMessage}"))
+      ) *> IO.sleep(cfg.sweepInterval)).foreverM.void.start
+
+object AutoscaleWiringSupport:
+
+  /** Build the sweep's views: pools with an owner-declared band only (no band = fixed size = not a
+    * participant). Utilization is the Little's-law concurrency estimate over the durable window
+    * (sum of statement durations / window length) divided by capacity, where capacity is the sum of
+    * `maxConcurrent` over the pool's routable read-capable nodes (`maxConcurrent = 0` meaning
+    * unlimited contributes `cfg.assumedConcurrencyPerNode`). Capacity <= 0 (no routable reader, or
+    * an assumedConcurrencyPerNode of 0) yields None: no decision is safe without known capacity.
+    *
+    * Suspended pools are included on purpose. The decision core needs to see the suspended -> live
+    * transition to arm its post-resume cooldown; filtering them here would make that branch dead
+    * code and let a wake burst scale the pool before its baseline nodes have warmed.
+    *
+    * `distribution` is the pool's DESIRED distribution (what scale/reconcile maintain), never a
+    * live node census: deciding off a census would compound a transient shortfall into a scale-out.
+    */
+  def views(
+      sup: PoolSupervisor,
+      store: ControlPlaneStore,
+      cfg: AutoscaleConfig
+  ): List[AutoscaleView] =
+    val from   = java.time.Instant.now().minusSeconds(cfg.windowMinutes * 60L)
+    val window = store.poolLoadWindow(from)
+    sup.list().flatMap { st =>
+      sup.autoscaleBand(st.key).flatMap { case (mn, mx) =>
+        sup.poolId(st.key).map { id =>
+          val snap     = sup.snapshot(st.key)
+          val capacity = snap.fold(0) { s =>
+            s.nodes.collect {
+              case n if n.role != Role.WriteOnly && s.loadOf(n.nodeId).routable =>
+                if n.maxConcurrent > 0 then n.maxConcurrent else cfg.assumedConcurrencyPerNode
+            }.sum
+          }
+          val est  = window.get(id).map(_._2.toDouble / (cfg.windowMinutes * 60_000.0))
+          val util =
+            if capacity <= 0 then None else Some(est.getOrElse(0.0) / capacity.toDouble)
+          AutoscaleView(st.key, mn, mx, st.distribution, st.suspended, st.disabled, util)
+        }
+      }
+    }

--- a/src/main/scala/ai/starlake/quack/boot/BootFactories.scala
+++ b/src/main/scala/ai/starlake/quack/boot/BootFactories.scala
@@ -27,7 +27,6 @@ object BootFactories extends LazyLogging:
       new LocalQuackBackend(
         mgrCfg.minPort,
         mgrCfg.maxPort,
-        mgrCfg.defaultMetastore.asMap,
         commandFor = LocalQuackBackend.defaultCommand(mgrCfg.spawnScript, mgrCfg.spawnScriptWindows)
       )
     case "kubernetes" | "k8s" =>
@@ -39,7 +38,6 @@ object BootFactories extends LazyLogging:
         mgrCfg.k8s.quackPort,
         mgrCfg.k8s.podLabel,
         mgrCfg.k8s.startupTimeoutSec,
-        mgrCfg.defaultMetastore.asMap,
         podTemplateEnabled = mgrCfg.k8s.podTemplateEnabled,
         serviceAccount = mgrCfg.k8s.serviceAccount,
         serviceType = mgrCfg.k8s.serviceType,

--- a/src/main/scala/ai/starlake/quack/model/AutoscaleBand.scala
+++ b/src/main/scala/ai/starlake/quack/model/AutoscaleBand.scala
@@ -1,0 +1,31 @@
+package ai.starlake.quack.model
+
+/** Validation for the owner-declared demand scale-out band. Shared by the REST handlers and the
+  * manifest importer so both surfaces refuse the same shapes.
+  *
+  * `minNodes == maxNodes` is legal and means "hold exactly this size, never scale": it is the
+  * per-pool way to opt out of the sweep while keeping the band recorded.
+  */
+object AutoscaleBand:
+  def validate(
+      minNodes: Option[Int],
+      maxNodes: Option[Int],
+      dist: RoleDistribution,
+      size: Int,
+      hardCap: Int
+  ): Option[String] =
+    (minNodes, maxNodes) match
+      case (None, None)         => None
+      case (Some(mn), Some(mx)) =>
+        val writeCapable = dist.writeonly + dist.dual
+        if mn < 1 then Some("minNodes must be >= 1")
+        else if mn > mx then Some("minNodes must be <= maxNodes")
+        else if mx > hardCap then Some(s"maxNodes must not exceed autoscale.hardCap ($hardCap)")
+        else if mn < writeCapable then
+          Some(
+            s"minNodes ($mn) must cover the write-capable nodes (writeonly + dual = $writeCapable)"
+          )
+        else if size < mn || size > mx then
+          Some(s"size ($size) must lie inside [minNodes, maxNodes] = [$mn, $mx]")
+        else None
+      case _ => Some("minNodes and maxNodes must be set together")

--- a/src/main/scala/ai/starlake/quack/model/Pool.scala
+++ b/src/main/scala/ai/starlake/quack/model/Pool.scala
@@ -43,7 +43,11 @@ final case class Pool(
     // QOD_NODE_LOCKDOWN flag; Some(b) forces lockdown on/off for this pool.
     // Resolved once in PoolSupervisor.effectiveLockdown and fed to BOTH
     // enforcement layers (edge screen + spawn-time engine SQL).
-    lockdown: Option[Boolean] = None
+    lockdown: Option[Boolean] = None,
+    // Owner-declared demand scale-out band. Both None = fixed-size pool
+    // (exact pre-0025 behavior). Set together or not at all; REST validates.
+    minNodes: Option[Int] = None,
+    maxNodes: Option[Int] = None
 ):
   /** Effective scheduling plan: either the explicit cohorts, or one synthesized placement-less
     * cohort carrying the flat distribution.

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -662,29 +662,36 @@ final class ManagerServer(
     // mounts (marketing pages) 404 for real instead of swallowing unmatched
     // paths into index.html.
     val moduleStatic: HttpRoutes[IO] =
-      moduleStaticMounts.foldLeft(HttpRoutes.empty[IO]) { (acc, m) =>
-        val diskRoot: Option[String] =
-          m.diskDir.filter(d => java.nio.file.Files.isDirectory(java.nio.file.Paths.get(d)))
-        val assets = diskRoot match
-          case Some(root) =>
-            staticcontent.fileService[IO](FileService.Config(root))
-          case None =>
-            staticcontent.resourceServiceBuilder[IO](m.classpathDir).toRoutes
-        def page(name: String, req: Request[IO]) = diskRoot match
-          case Some(root) => StaticFile.fromPath[IO](FsPath(root) / name, Some(req))
-          case None       => StaticFile.fromResource[IO](s"${m.classpathDir}/$name", Some(req))
-        val fallback: HttpRoutes[IO] =
-          if m.spaFallback then
-            HttpRoutes.of[IO] { req =>
-              page("index.html", req).getOrElseF(IO.pure(Response[IO](Status.NotFound)))
-            }
-          else
-            HttpRoutes.of[IO] { req =>
-              page("404.html", req)
-                .map(_.withStatus(Status.NotFound))
-                .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
-            }
-        acc <+> Router(m.urlPrefix -> (assets <+> fallback))
+      moduleStaticMounts.sortBy(m => -m.urlPrefix.length).foldLeft(HttpRoutes.empty[IO]) {
+        (acc, m) =>
+          val diskRoot: Option[String] =
+            m.diskDir.filter(d => java.nio.file.Files.isDirectory(java.nio.file.Paths.get(d)))
+          val assets = diskRoot match
+            case Some(root) =>
+              staticcontent.fileService[IO](FileService.Config(root))
+            case None =>
+              staticcontent.resourceServiceBuilder[IO](m.classpathDir).toRoutes
+          def page(name: String, req: Request[IO]) = diskRoot match
+            case Some(root) => StaticFile.fromPath[IO](FsPath(root) / name, Some(req))
+            case None       => StaticFile.fromResource[IO](s"${m.classpathDir}/$name", Some(req))
+          val fallback: HttpRoutes[IO] =
+            if m.spaFallback then
+              HttpRoutes.of[IO] { req =>
+                page("index.html", req).getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+              }
+            else
+              HttpRoutes.of[IO] { req =>
+                // The mount's own root still resolves to index.html; every other
+                // unmatched path under a non-SPA mount is a real 404 (marketing
+                // pages must not soft-404 into the index).
+                if req.uri.path == Uri.Path.Root then
+                  page("index.html", req).getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+                else
+                  page("404.html", req)
+                    .map(_.withStatus(Status.NotFound))
+                    .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+              }
+          acc <+> Router(m.urlPrefix -> (assets <+> fallback))
       }
 
     // Redirect the bare root (`/`) to `/ui/` so visiting the manager host

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -558,6 +558,9 @@ final class ManagerServer(
       PoolEndpoints.setPoolLockdown.serverLogic { case (req, token) =>
         pools.setLockdown(req, token)(sessions.scopeOf)
       },
+      PoolEndpoints.setPoolAutoscale.serverLogic { case (req, token) =>
+        pools.setPoolAutoscale(req, token)(sessions.scopeOf)
+      },
       NodeEndpoints.setMaxConcurrent.serverLogic { case (req, token) =>
         nodes.setMaxConcurrent(req, token)(sessions.scopeOf)
       },

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -702,24 +702,40 @@ final class ManagerServer(
           def directoryIndexCandidate(req: Request[IO]): String =
             val trimmed = req.pathInfo.renderString.stripPrefix("/").stripSuffix("/")
             if trimmed.isEmpty then "index.html" else s"$trimmed/index.html"
-          val fallback: HttpRoutes[IO] =
+          def notFoundPage(req: Request[IO]): IO[Response[IO]] =
+            page("404.html", req)
+              .map(_.withStatus(Status.NotFound))
+              .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+          // A request is "extensionless" when its Router-translated remaining
+          // path (`pathInfo`, see the note above) is the mount root, or its
+          // last segment carries no `.`: `/pricing`, `/pricing/`,
+          // `/enroll/complete/`. Real static assets always carry a file
+          // extension, so extensionless requests never legitimately belong to
+          // `assets`.
+          def isExtensionless(req: Request[IO]): Boolean =
+            val trimmed = req.pathInfo.renderString.stripPrefix("/").stripSuffix("/")
+            trimmed.isEmpty || !trimmed.split("/").last.contains(".")
+          val mounted =
             if m.spaFallback then
-              HttpRoutes.of[IO] { req =>
+              val fallback: HttpRoutes[IO] = HttpRoutes.of[IO] { req =>
                 page("index.html", req).getOrElseF(IO.pure(Response[IO](Status.NotFound)))
               }
+              Router(m.urlPrefix -> (assets <+> fallback))
             else
-              HttpRoutes.of[IO] { req =>
-                // Every unmatched path under a non-SPA mount first tries its own
-                // directory index (covers both the mount's root and nested
-                // directory-index pages like /pricing/ or /enroll/complete/);
-                // only a genuine miss falls through to the real 404.
-                page(directoryIndexCandidate(req), req).getOrElseF(
-                  page("404.html", req)
-                    .map(_.withStatus(Status.NotFound))
-                    .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
-                )
+              // Extensionless requests are routed to the page/404 lookup
+              // BEFORE `assets`, so `assets` never sees them. This closes a
+              // jar-packaging bug: `sbt assembly` packs zero-byte directory
+              // entries (e.g. `www/pricing/`) into the classpath jar, and
+              // http4s' resourceServiceBuilder matches a bare-directory GET
+              // against that entry and serves it as a 200 with an empty body,
+              // before the directory-index fallback below ever gets a chance
+              // - `assets <+> fallback` short-circuits on the first match.
+              val pages: HttpRoutes[IO] = HttpRoutes.of[IO] {
+                case req if isExtensionless(req) =>
+                  page(directoryIndexCandidate(req), req).getOrElseF(notFoundPage(req))
               }
-          val mounted = Router(m.urlPrefix -> (assets <+> fallback))
+              val notFound: HttpRoutes[IO] = HttpRoutes.of[IO](req => notFoundPage(req))
+              Router(m.urlPrefix -> (pages <+> assets <+> notFound))
           acc <+> (if m.spaFallback then mounted else withMarketingCacheHeaders(mounted))
       }
 

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -13,13 +13,15 @@ import cats.effect.{IO, Resource}
 import cats.implicits._
 import com.comcast.ip4s.{Host, Port}
 import com.typesafe.scalalogging.LazyLogging
-import org.http4s.{HttpRoutes, Method, Response, StaticFile, Status, Uri}
+import org.http4s.{HttpRoutes, Method, Request, Response, StaticFile, Status, Uri}
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.headers.Location
 import org.http4s.server.{staticcontent, Router}
+import org.http4s.server.staticcontent.FileService
 import org.typelevel.ci.CIString
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.http4s.Http4sServerInterpreter
+import fs2.io.file.{Path => FsPath}
 
 final class ManagerServer(
     cfg: ManagerConfig,
@@ -654,15 +656,34 @@ final class ManagerServer(
     val uiRoutes = Router("/ui" -> (uiAssets <+> spaFallback))
 
     // Module static mounts (SPI): same shape as the /ui mount above, one per
-    // registered ai.starlake.quack.spi.StaticMount.
+    // registered ai.starlake.quack.spi.StaticMount. A mount with a diskDir
+    // that exists on disk is served from the filesystem (live-updatable
+    // content); classpath resources are the fallback. spaFallback=false
+    // mounts (marketing pages) 404 for real instead of swallowing unmatched
+    // paths into index.html.
     val moduleStatic: HttpRoutes[IO] =
       moduleStaticMounts.foldLeft(HttpRoutes.empty[IO]) { (acc, m) =>
-        val assets = staticcontent.resourceServiceBuilder[IO](m.classpathDir).toRoutes
-        val fallback: HttpRoutes[IO] = HttpRoutes.of[IO] { req =>
-          StaticFile
-            .fromResource[IO](s"${m.classpathDir}/index.html", Some(req))
-            .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
-        }
+        val diskRoot: Option[String] =
+          m.diskDir.filter(d => java.nio.file.Files.isDirectory(java.nio.file.Paths.get(d)))
+        val assets = diskRoot match
+          case Some(root) =>
+            staticcontent.fileService[IO](FileService.Config(root))
+          case None =>
+            staticcontent.resourceServiceBuilder[IO](m.classpathDir).toRoutes
+        def page(name: String, req: Request[IO]) = diskRoot match
+          case Some(root) => StaticFile.fromPath[IO](FsPath(root) / name, Some(req))
+          case None       => StaticFile.fromResource[IO](s"${m.classpathDir}/$name", Some(req))
+        val fallback: HttpRoutes[IO] =
+          if m.spaFallback then
+            HttpRoutes.of[IO] { req =>
+              page("index.html", req).getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+            }
+          else
+            HttpRoutes.of[IO] { req =>
+              page("404.html", req)
+                .map(_.withStatus(Status.NotFound))
+                .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+            }
         acc <+> Router(m.urlPrefix -> (assets <+> fallback))
       }
 

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -674,6 +674,17 @@ final class ManagerServer(
           def page(name: String, req: Request[IO]) = diskRoot match
             case Some(root) => StaticFile.fromPath[IO](FsPath(root) / name, Some(req))
             case None       => StaticFile.fromResource[IO](s"${m.classpathDir}/$name", Some(req))
+          // Directory-index candidate for a request's Router-translated remaining
+          // path (`pathInfo`, NOT `uri.path` - Router leaves the original request
+          // path untouched and only adjusts the caret that `pathInfo` reads, so a
+          // check against `uri.path` would only ever fire by accident for a "/"
+          // mount). "/" -> "index.html", "/pricing/" -> "pricing/index.html",
+          // "/no/such/page" -> "no/such/page/index.html" (a lookup that's expected
+          // to miss). Mirrors FileService's directory auto-resolution, which
+          // ResourceService does not provide for classpath-backed mounts.
+          def directoryIndexCandidate(req: Request[IO]): String =
+            val trimmed = req.pathInfo.renderString.stripPrefix("/").stripSuffix("/")
+            if trimmed.isEmpty then "index.html" else s"$trimmed/index.html"
           val fallback: HttpRoutes[IO] =
             if m.spaFallback then
               HttpRoutes.of[IO] { req =>
@@ -681,15 +692,15 @@ final class ManagerServer(
               }
             else
               HttpRoutes.of[IO] { req =>
-                // The mount's own root still resolves to index.html; every other
-                // unmatched path under a non-SPA mount is a real 404 (marketing
-                // pages must not soft-404 into the index).
-                if req.uri.path == Uri.Path.Root then
-                  page("index.html", req).getOrElseF(IO.pure(Response[IO](Status.NotFound)))
-                else
+                // Every unmatched path under a non-SPA mount first tries its own
+                // directory index (covers both the mount's root and nested
+                // directory-index pages like /pricing/ or /enroll/complete/);
+                // only a genuine miss falls through to the real 404.
+                page(directoryIndexCandidate(req), req).getOrElseF(
                   page("404.html", req)
                     .map(_.withStatus(Status.NotFound))
                     .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
+                )
               }
           acc <+> Router(m.urlPrefix -> (assets <+> fallback))
       }

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -661,6 +661,23 @@ final class ManagerServer(
     // content); classpath resources are the fallback. spaFallback=false
     // mounts (marketing pages) 404 for real instead of swallowing unmatched
     // paths into index.html.
+    // CDN contract for marketing (non-SPA) mounts: hashed Vite assets are
+    // immutable, pages revalidate within minutes, 404s are never cached.
+    // See the enrollment-website design spec (qod-hosted docs) D4.
+    val hashedAsset = raw".*/assets/[^/]+-[A-Za-z0-9_]{8,}\.[a-z0-9]+".r
+    def withMarketingCacheHeaders(routes: HttpRoutes[IO]): HttpRoutes[IO] =
+      cats.data.Kleisli { (req: Request[IO]) =>
+        routes(req).map { resp =>
+          val cc =
+            if resp.status == Status.NotFound then "no-store"
+            else if hashedAsset.matches(req.uri.path.renderString) then
+              "public, max-age=31536000, immutable"
+            else "public, max-age=300, stale-while-revalidate=600"
+          resp.putHeaders(
+            org.http4s.Header.Raw(org.typelevel.ci.CIString("Cache-Control"), cc)
+          )
+        }
+      }
     val moduleStatic: HttpRoutes[IO] =
       moduleStaticMounts.sortBy(m => -m.urlPrefix.length).foldLeft(HttpRoutes.empty[IO]) {
         (acc, m) =>
@@ -702,7 +719,8 @@ final class ManagerServer(
                     .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
                 )
               }
-          acc <+> Router(m.urlPrefix -> (assets <+> fallback))
+          val mounted = Router(m.urlPrefix -> (assets <+> fallback))
+          acc <+> (if m.spaFallback then mounted else withMarketingCacheHeaders(mounted))
       }
 
     // Redirect the bare root (`/`) to `/ui/` so visiting the manager host

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -691,30 +691,43 @@ final class ManagerServer(
           def page(name: String, req: Request[IO]) = diskRoot match
             case Some(root) => StaticFile.fromPath[IO](FsPath(root) / name, Some(req))
             case None       => StaticFile.fromResource[IO](s"${m.classpathDir}/$name", Some(req))
+          // Decoded path segments of the request's Router-translated remaining
+          // path (`pathInfo`, see the note on directoryIndexCandidate below).
+          // Decoding first means a percent-encoded dot-segment (`%2e%2e`) is
+          // caught the same as a literal `..`.
+          def decodedSegments(req: Request[IO]): Vector[String] =
+            req.pathInfo.segments.map(_.decoded())
+          // `.` or `..` anywhere in the decoded path is a directory-traversal
+          // attempt: in disk mode `page()` resolves through `StaticFile.fromPath`,
+          // which (unlike classpath mode's `getResource`) has no containment
+          // guard, so `FsPath(root) / "../../outside/index.html"` would resolve
+          // outside the mount root. Refuse it before a candidate is ever built.
+          def hasDotSegment(segments: Vector[String]): Boolean =
+            segments.exists(s => s == "." || s == "..")
           // Directory-index candidate for a request's Router-translated remaining
           // path (`pathInfo`, NOT `uri.path` - Router leaves the original request
           // path untouched and only adjusts the caret that `pathInfo` reads, so a
           // check against `uri.path` would only ever fire by accident for a "/"
-          // mount). "/" -> "index.html", "/pricing/" -> "pricing/index.html",
-          // "/no/such/page" -> "no/such/page/index.html" (a lookup that's expected
-          // to miss). Mirrors FileService's directory auto-resolution, which
+          // mount). Built from the DECODED segments (not `renderString`) so a
+          // percent-encoded separator resolves the same as a literal one, e.g.
+          // "/our%20team/" -> "our team/index.html". "/" -> "index.html",
+          // "/pricing/" -> "pricing/index.html", "/no/such/page" ->
+          // "no/such/page/index.html" (a lookup that's expected to miss).
+          // Mirrors FileService's directory auto-resolution, which
           // ResourceService does not provide for classpath-backed mounts.
-          def directoryIndexCandidate(req: Request[IO]): String =
-            val trimmed = req.pathInfo.renderString.stripPrefix("/").stripSuffix("/")
-            if trimmed.isEmpty then "index.html" else s"$trimmed/index.html"
+          def directoryIndexCandidate(segments: Vector[String]): String =
+            if segments.isEmpty then "index.html" else s"${segments.mkString("/")}/index.html"
           def notFoundPage(req: Request[IO]): IO[Response[IO]] =
             page("404.html", req)
               .map(_.withStatus(Status.NotFound))
               .getOrElseF(IO.pure(Response[IO](Status.NotFound)))
-          // A request is "extensionless" when its Router-translated remaining
-          // path (`pathInfo`, see the note above) is the mount root, or its
-          // last segment carries no `.`: `/pricing`, `/pricing/`,
-          // `/enroll/complete/`. Real static assets always carry a file
-          // extension, so extensionless requests never legitimately belong to
-          // `assets`.
-          def isExtensionless(req: Request[IO]): Boolean =
-            val trimmed = req.pathInfo.renderString.stripPrefix("/").stripSuffix("/")
-            trimmed.isEmpty || !trimmed.split("/").last.contains(".")
+          // A request is "extensionless" when its decoded segments are empty
+          // (the mount root), or the last segment carries no `.`: `/pricing`,
+          // `/pricing/`, `/enroll/complete/`. Real static assets always carry a
+          // file extension, so extensionless requests never legitimately belong
+          // to `assets`.
+          def isExtensionless(segments: Vector[String]): Boolean =
+            segments.isEmpty || !segments.last.contains(".")
           val mounted =
             if m.spaFallback then
               val fallback: HttpRoutes[IO] = HttpRoutes.of[IO] { req =>
@@ -731,8 +744,10 @@ final class ManagerServer(
               // before the directory-index fallback below ever gets a chance
               // - `assets <+> fallback` short-circuits on the first match.
               val pages: HttpRoutes[IO] = HttpRoutes.of[IO] {
-                case req if isExtensionless(req) =>
-                  page(directoryIndexCandidate(req), req).getOrElseF(notFoundPage(req))
+                case req if isExtensionless(decodedSegments(req)) =>
+                  val segments = decodedSegments(req)
+                  if hasDotSegment(segments) then notFoundPage(req)
+                  else page(directoryIndexCandidate(segments), req).getOrElseF(notFoundPage(req))
               }
               val notFound: HttpRoutes[IO] = HttpRoutes.of[IO](req => notFoundPage(req))
               Router(m.urlPrefix -> (pages <+> assets <+> notFound))

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -1326,6 +1326,9 @@ final class PoolSupervisor(
       podTemplateYaml: String = "",
       // Per-pool lockdown override persisted at create time. None = inherit.
       lockdown: Option[Boolean] = None,
+      // Owner-declared scale-out band, persisted at create time. Both None = fixed size.
+      minNodes: Option[Int] = None,
+      maxNodes: Option[Int] = None,
       gateBypass: Boolean = false
   ): IO[List[RunningNode]] =
     gateCheck(
@@ -1414,7 +1417,9 @@ final class PoolSupervisor(
                   cpu = cpu,
                   memory = memory,
                   podTemplateYaml = podTemplateYaml,
-                  lockdown = lockdown
+                  lockdown = lockdown,
+                  minNodes = minNodes,
+                  maxNodes = maxNodes
                 )
                 IO.blocking(store.upsertPool(poolEntity)) *> IO.delay {
                   poolRows.put(poolEntity.id, poolEntity)
@@ -1509,6 +1514,44 @@ final class PoolSupervisor(
     */
   def effectiveLockdown(key: PoolKey): Boolean =
     poolIdByKey.get(key).flatMap(poolRows.get).flatMap(_.lockdown).getOrElse(lockdownEnabled)
+
+  /** The owner-declared scale-out band, resolved from the persisted row (the band stays out of
+    * PoolState on purpose, like lockdown). None = pool unknown OR fixed size.
+    */
+  def autoscaleBand(key: PoolKey): Option[(Int, Int)] =
+    poolIdByKey.get(key).flatMap(poolRows.get).flatMap(p => p.minNodes.zip(p.maxNodes))
+
+  /** Persists under the pool's advisory lock so the write serializes with reconcile's respawn (same
+    * lock), mirroring [[setPoolLockdown]]. Does NOT validate the band shape (min < max, size inside
+    * the band, hardCap): that is the handler's job via `AutoscaleBand.validate`. Some sets the
+    * band, None clears it back to fixed size.
+    */
+  def setPoolAutoscale(
+      key: PoolKey,
+      band: Option[(Int, Int)]
+  ): IO[Either[SupervisorError, Pool]] =
+    locks.withLock(key) {
+      IO.blocking {
+        withCacheRecovery("setPoolAutoscale") {
+          pools.get(key) match
+            case None    => Left(SupervisorError.NotFound(s"pool not found: $key"))
+            case Some(_) =>
+              poolIdByKey.get(key).flatMap(poolRows.get) match
+                case None =>
+                  Left(
+                    SupervisorError.Internal(
+                      s"pool entity missing for $key (control-plane out of sync)"
+                    )
+                  )
+                case Some(p) =>
+                  val updated = p.copy(minNodes = band.map(_._1), maxNodes = band.map(_._2))
+                  store.upsertPool(updated)
+                  poolRows.put(updated.id, updated)
+                  publish.topologyChanged()
+                  Right(updated)
+        }
+      }
+    }
 
   /** Persists under the pool's advisory lock so the write serializes with reconcile's respawn (same
     * lock): either the persist lands before reconcile builds a NodeSpec off
@@ -1613,7 +1656,8 @@ final class PoolSupervisor(
       targetSize: Int,
       newDist: RoleDistribution,
       force: Boolean,
-      gateBypass: Boolean = false
+      gateBypass: Boolean = false,
+      reason: String = "manual"
   ): IO[List[RunningNode]] =
     require(newDist.isValidFor(targetSize), "role distribution does not sum to targetSize")
     val from = get(key).map(_.distribution.total).getOrElse(0)
@@ -1630,9 +1674,18 @@ final class PoolSupervisor(
       case Left(reason) =>
         IO.raiseError(new ai.starlake.quack.spi.QuotaExceededException(reason))
       case Right(()) =>
-        locks.withLock(key) {
-          withCacheRecoveryIO("scale")(scaleUnlocked(key, targetSize, newDist, force))
-        }
+        locks
+          .withLock(key) {
+            withCacheRecoveryIO("scale")(scaleUnlocked(key, targetSize, newDist, force))
+          }
+          .flatTap { nodes =>
+            IO(
+              events.emit(
+                ManagerEvent
+                  .PoolScaled(key.tenant, key.tenantDb, key.pool, from, nodes.size, reason)
+              )
+            )
+          }
     }
 
   private def scaleUnlocked(

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -209,24 +209,48 @@ final class PoolSupervisor(
 
   // ---------- Bootstrap / replay ----------
 
-  /** Per-tenant-db naming, applied ONLY to `kind=ducklake` (where each tenant-db is its own
-    * Postgres database named after `td.name`, with parquet alongside at
-    * `parent(defaultDataPath)/td.name`). Operators override via `dbName`/`dataPath` in
-    * `td.metastore` or `td.dataPath`. For `duckdb-file` / `memory` the convention doesn't apply:
-    * fall through to `defaultMetastore ++ td.metastore`.
+  /** Per-tenant-db naming and data location, resolved per kind on top of `defaultMetastore ++
+    * td.metastore`. The manager default describes the BOOTSTRAP tenant-db (a DuckLake directory
+    * plus its own `dbName`), so inheriting it wholesale is wrong for every other kind.
+    *
+    *   - `ducklake`: each tenant-db is its own Postgres database named after `td.name`, with
+    *     parquet alongside at `parent(defaultDataPath)/td.name`. Operators override via
+    *     `dbName`/`dataPath` in `td.metastore` or `td.dataPath`.
+    *   - `duckdb-file`: `dataPath` is a FILE (the node script runs `ATTACH '$dataPath'`), never the
+    *     default DuckLake DIRECTORY, so it comes from `td.dataPath`, else `td.metastore`, else the
+    *     key is dropped entirely. `dbName` falls back to `td.name`, never to the default's (which
+    *     names an unrelated catalog).
+    *   - `memory`: `dataPath` is meaningless and is dropped. `dbName` falls back to DuckDB's
+    *     built-in `memory` catalog, so the health probe's `CREATE SCHEMA IF NOT EXISTS
+    *     <dbName>.<schemaName>` targets a catalog the node actually has instead of failing on every
+    *     tick and leaving the node unroutable.
+    *
+    * `schemaName` is left as the merge yields it for every kind (the default `main` is correct).
     */
   private def effectiveMetastoreFor(td: TenantDb): Map[String, String] =
     val merged = defaultMetastore ++ td.metastore
-    if td.kind != TenantDbKind.DuckLake then merged
-    else
-      val withDb   = merged.updated("dbName", td.metastore.getOrElse("dbName", td.name))
-      val rootData = defaultMetastore.getOrElse("dataPath", "")
-      val tdData   =
-        if td.dataPath.nonEmpty then td.dataPath
-        else if td.metastore.contains("dataPath") then td.metastore("dataPath")
-        else if rootData.isEmpty then ""
-        else PoolSupervisor.replaceLastSegment(rootData, td.name)
-      if tdData.nonEmpty then withDb.updated("dataPath", tdData) else withDb
+    td.kind match
+      case TenantDbKind.DuckLake =>
+        val withDb   = merged.updated("dbName", td.metastore.getOrElse("dbName", td.name))
+        val rootData = defaultMetastore.getOrElse("dataPath", "")
+        val tdData   =
+          if td.dataPath.nonEmpty then td.dataPath
+          else if td.metastore.contains("dataPath") then td.metastore("dataPath")
+          else if rootData.isEmpty then ""
+          else PoolSupervisor.replaceLastSegment(rootData, td.name)
+        if tdData.nonEmpty then withDb.updated("dataPath", tdData) else withDb
+
+      case TenantDbKind.DuckDbFile =>
+        val withDb = merged.updated("dbName", td.metastore.getOrElse("dbName", td.name))
+        val tdData =
+          if td.dataPath.nonEmpty then td.dataPath
+          else td.metastore.getOrElse("dataPath", "")
+        if tdData.nonEmpty then withDb.updated("dataPath", tdData) else withDb.removed("dataPath")
+
+      case TenantDbKind.InMemory =>
+        merged
+          .updated("dbName", td.metastore.getOrElse("dbName", "memory"))
+          .removed("dataPath")
 
   /** True when `key`'s tenant-db is in [[dataPathBlocked]]. False when the pool has no persisted
     * row (InMemory-only test pools): such a pool never wrote to the store, so it can't race a

--- a/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
@@ -72,7 +72,15 @@ final case class CreatePoolRequest(
     memory: String = "",
     podTemplateYaml: String = "",
     // Per-pool node-lockdown override: "inherit" (default) | "on" | "off". See LockdownTriState.
-    lockdown: String = "inherit"
+    lockdown: String = "inherit",
+    /** Owner-declared demand scale-out band. Both bounds must be set together (one-sided is refused
+      * with 400 `invalid_band`); both absent = fixed size, the pool never autoscales. Validated by
+      * [[ai.starlake.quack.model.AutoscaleBand.validate]] against the requested distribution/size
+      * and the manager's `autoscale.hardCap`. Elastic pools cannot carry authored cohorts (scaling
+      * clears them).
+      */
+    minNodes: Option[Int] = None,
+    maxNodes: Option[Int] = None
 )
 
 final case class NodeInfo(
@@ -120,7 +128,10 @@ final case class PoolResponse(
     cpu: String = "",                   // Kubernetes cpu request=limit; empty when unset
     memory: String = "",                // Kubernetes memory request=limit; empty when unset
     lockdown: String = "inherit",       // stored tri-state override
-    lockdownEffective: Boolean = false  // tri-state resolved against the global flag
+    lockdownEffective: Boolean = false, // tri-state resolved against the global flag
+    // Owner-declared demand scale-out band; both None on a fixed-size pool.
+    minNodes: Option[Int] = None,
+    maxNodes: Option[Int] = None
 )
 
 final case class SetPoolResourcesRequest(
@@ -144,6 +155,18 @@ final case class SetPoolLockdownRequest(
     pool: String,
     // "inherit" | "on" | "off" - see [[ai.starlake.quack.model.LockdownTriState]]
     lockdown: String
+)
+
+/** Sets or clears the pool's demand scale-out band. Both bounds Some = set (validated against the
+  * pool's CURRENT distribution and size); both None = clear back to fixed size; one-sided is
+  * refused with 400 `invalid_band`.
+  */
+final case class SetPoolAutoscaleRequest(
+    tenant: String,
+    tenantDb: String,
+    pool: String,
+    minNodes: Option[Int] = None,
+    maxNodes: Option[Int] = None
 )
 
 final case class ScalePoolRequest(
@@ -1044,6 +1067,7 @@ object Dtos:
   given Codec[SetPoolResourcesRequest]  = deriveCodec
   given Codec[SetPoolTemplateRequest]   = deriveCodec
   given Codec[SetPoolLockdownRequest]   = deriveCodec
+  given Codec[SetPoolAutoscaleRequest]  = ConfiguredCodec.derived
   given Codec[PoolListResponse]         = deriveCodec
   given Codec[HealthResponse]           = deriveCodec
   given Codec[SetMaxConcurrentRequest]  = deriveCodec

--- a/src/main/scala/ai/starlake/quack/ondemand/api/EndpointSchemas.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/EndpointSchemas.scala
@@ -20,6 +20,7 @@ object EndpointSchemas:
   given Schema[SetPoolResourcesRequest]  = Schema.derived
   given Schema[SetPoolTemplateRequest]   = Schema.derived
   given Schema[SetPoolLockdownRequest]   = Schema.derived
+  given Schema[SetPoolAutoscaleRequest]  = Schema.derived
   given Schema[ActiveStatementInfo]      = Schema.derived
   given Schema[ActiveStatementsResponse] = Schema.derived
   given Schema[KillStatementRequest]     = Schema.derived

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PoolEndpoints.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PoolEndpoints.scala
@@ -155,3 +155,15 @@ object PoolEndpoints:
       .in(jsonBody[SetPoolLockdownRequest])
       .in(authToken)
       .out(jsonBody[PoolResponse])
+
+  val setPoolAutoscale: PublicEndpoint[
+    (SetPoolAutoscaleRequest, Option[String]),
+    (sttp.model.StatusCode, ErrorResponse),
+    PoolResponse,
+    Any
+  ] =
+    base.post
+      .in("pool" / "setAutoscale")
+      .in(jsonBody[SetPoolAutoscaleRequest])
+      .in(authToken)
+      .out(jsonBody[PoolResponse])

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PoolHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PoolHandlers.scala
@@ -1,7 +1,7 @@
 package ai.starlake.quack.ondemand.api
 
 import ai.starlake.quack.edge.adapter.{EngineStatsTracker, NodeLoadTracker}
-import ai.starlake.quack.model.{LockdownTriState, PoolKey, QuantitySyntax}
+import ai.starlake.quack.model.{AutoscaleBand, LockdownTriState, PoolKey, QuantitySyntax}
 import ai.starlake.quack.ondemand.{PoolSupervisor, SupervisorError}
 import ai.starlake.quack.ondemand.auth.SessionScope
 import ai.starlake.quack.ondemand.telemetry.{AuditActions, AuditRecorder}
@@ -14,6 +14,9 @@ final class PoolHandlers(
     tracker: NodeLoadTracker,
     engineStats: EngineStatsTracker = new EngineStatsTracker,
     podTemplateEnabled: Boolean = false,
+    // Upper bound accepted for maxNodes at validation time (autoscale.hardCap):
+    // a typo guard, not a quota.
+    autoscaleHardCap: Int = 16,
     audit: AuditRecorder = AuditRecorder.noop
 ):
 
@@ -36,6 +39,8 @@ final class PoolHandlers(
   private def respond(key: PoolKey): Option[PoolResponse] =
     sup.get(key).map { p =>
       val poolEntityCohorts = sup.poolId(key).flatMap(sup.poolEntity).map(_.cohorts).getOrElse(Nil)
+      // Same pool-row resolution as the lockdown fields below; None on a fixed-size pool.
+      val band = sup.autoscaleBand(key)
       PoolResponse(
         tenant = key.tenant,
         tenantDb = key.tenantDb,
@@ -77,7 +82,9 @@ final class PoolHandlers(
         lockdown = LockdownTriState.render(
           sup.poolId(key).flatMap(sup.poolEntity).flatMap(_.lockdown)
         ),
-        lockdownEffective = sup.effectiveLockdown(key)
+        lockdownEffective = sup.effectiveLockdown(key),
+        minNodes = band.map(_._1),
+        maxNodes = band.map(_._2)
       )
     }
 
@@ -156,6 +163,19 @@ final class PoolHandlers(
       apiKey: Option[String],
       gateBypass: Boolean
   ): Out[PoolResponse] =
+    // Band shape (one-sided, min >= max, hardCap, write-capable floor, size inside
+    // the band) plus the cohort conflict: autoscaling rewrites the role
+    // distribution, which clears authored cohorts, so the two cannot be declared
+    // together.
+    val bandShapeErr =
+      AutoscaleBand
+        .validate(req.minNodes, req.maxNodes, req.roleDistribution, req.size, autoscaleHardCap)
+    val bandErr =
+      if req.minNodes.isDefined && req.cohorts.nonEmpty then
+        Some(
+          bandShapeErr.getOrElse("elastic pools cannot use authored cohorts (scaling clears them)")
+        )
+      else bandShapeErr
     LockdownTriState.parse(req.lockdown) match
       case Left(msg) =>
         IO.pure(Left((StatusCode.BadRequest, ErrorResponse("invalid", msg))))
@@ -184,6 +204,15 @@ final class PoolHandlers(
               (
                 StatusCode.BadRequest,
                 ErrorResponse("invalid_distribution", "role counts do not sum to size")
+              )
+            )
+          )
+        else if bandErr.isDefined then
+          IO.pure(
+            Left(
+              (
+                StatusCode.BadRequest,
+                ErrorResponse("invalid_band", bandErr.getOrElse("invalid autoscale band"))
               )
             )
           )
@@ -234,6 +263,8 @@ final class PoolHandlers(
                       memory = req.memory,
                       podTemplateYaml = req.podTemplateYaml,
                       lockdown = lockdownValue,
+                      minNodes = req.minNodes,
+                      maxNodes = req.maxNodes,
                       gateBypass = gateBypass
                     )
                     .map(_ =>
@@ -307,40 +338,67 @@ final class PoolHandlers(
                   )
                 )
               )
+            // A pool with a declared band stays inside it: a manual scale outside
+            // would be undone by the next autoscale sweep, so refuse it and point
+            // at the band editor instead.
             else
-              sup
-                .scale(
-                  key,
-                  req.targetSize,
-                  req.roleDistribution,
-                  req.force,
-                  gateBypass = gateBypass
-                )
-                .attempt
-                .flatMap {
-                  case Left(q: ai.starlake.quack.spi.QuotaExceededException) =>
-                    IO.pure(
-                      Left((StatusCode.TooManyRequests, ErrorResponse("quota_exceeded", q.reason)))
-                    )
-                  case Left(t)  => IO.raiseError(t)
-                  case Right(_) =>
-                    audit.rest(
-                      apiKey,
-                      "control-plane",
-                      AuditActions.PoolScale,
-                      "ok",
-                      tenant = Some(req.tenant),
-                      target = Some(key.toString),
-                      detail = Map("targetSize" -> req.targetSize.toString)
-                    )
-                    IO.pure(
-                      Right(
-                        respond(key).getOrElse(
-                          PoolResponse(req.tenant, req.tenantDb, req.pool, Nil, "ready", Map.empty)
+              sup.autoscaleBand(key) match
+                case Some((mn, mx)) if req.targetSize < mn || req.targetSize > mx =>
+                  IO.pure(
+                    Left(
+                      (
+                        StatusCode.BadRequest,
+                        ErrorResponse(
+                          "outside_band",
+                          s"targetSize ${req.targetSize} is outside the autoscale band " +
+                            s"[$mn, $mx]; adjust the band first via pool/setAutoscale"
                         )
                       )
                     )
-                }
+                  )
+                case _ =>
+                  sup
+                    .scale(
+                      key,
+                      req.targetSize,
+                      req.roleDistribution,
+                      req.force,
+                      gateBypass = gateBypass
+                    )
+                    .attempt
+                    .flatMap {
+                      case Left(q: ai.starlake.quack.spi.QuotaExceededException) =>
+                        IO.pure(
+                          Left(
+                            (StatusCode.TooManyRequests, ErrorResponse("quota_exceeded", q.reason))
+                          )
+                        )
+                      case Left(t)  => IO.raiseError(t)
+                      case Right(_) =>
+                        audit.rest(
+                          apiKey,
+                          "control-plane",
+                          AuditActions.PoolScale,
+                          "ok",
+                          tenant = Some(req.tenant),
+                          target = Some(key.toString),
+                          detail = Map("targetSize" -> req.targetSize.toString)
+                        )
+                        IO.pure(
+                          Right(
+                            respond(key).getOrElse(
+                              PoolResponse(
+                                req.tenant,
+                                req.tenantDb,
+                                req.pool,
+                                Nil,
+                                "ready",
+                                Map.empty
+                              )
+                            )
+                          )
+                        )
+                    }
 
   def stopPool(req: StopPoolRequest, apiKey: Option[String])(
       scopeOf: String => Option[SessionScope]
@@ -717,4 +775,79 @@ final class PoolHandlers(
                           )
                         )
                   }
+            }
+
+  /** Sets or clears the pool's demand scale-out band. Both bounds absent clears it back to a fixed
+    * size; a declared band is validated against the pool's CURRENT distribution and size, so an
+    * operator whose band would exclude today's size scales the pool first, then declares the band.
+    * The write itself does NOT move any node: the sweep converges the pool on its next tick.
+    */
+  def setPoolAutoscale(req: SetPoolAutoscaleRequest, apiKey: Option[String])(
+      scopeOf: String => Option[SessionScope]
+  ): Out[PoolResponse] =
+    TenantScopeCheck.reject(apiKey, req.tenant)(scopeOf) match
+      case Some(err) =>
+        audit.rest(
+          apiKey,
+          "control-plane",
+          AuditActions.PoolSetAutoscale,
+          "denied",
+          tenant = Some(req.tenant)
+        )
+        IO.pure(Left(err))
+      case None =>
+        val key     = PoolKey(req.tenant, req.tenantDb, req.pool)
+        val bandErr = (req.minNodes, req.maxNodes) match
+          case (None, None) => None // clear
+          case _            =>
+            sup.get(key) match
+              // Unknown pool: skip validation and let the supervisor answer with
+              // its NotFound, so a bad key never leaks as a 400 band error.
+              case None     => None
+              case Some(st) =>
+                val poolEntityCohorts =
+                  sup.poolId(key).flatMap(sup.poolEntity).map(_.cohorts).getOrElse(Nil)
+                if poolEntityCohorts.nonEmpty then
+                  Some("elastic pools cannot use authored cohorts (scaling clears them)")
+                else
+                  AutoscaleBand.validate(
+                    req.minNodes,
+                    req.maxNodes,
+                    st.distribution,
+                    st.distribution.total,
+                    autoscaleHardCap
+                  )
+        bandErr match
+          case Some(msg) =>
+            IO.pure(Left((StatusCode.BadRequest, ErrorResponse("invalid_band", msg))))
+          case None =>
+            sup.setPoolAutoscale(key, req.minNodes.zip(req.maxNodes)).map {
+              case Left(err: SupervisorError.NotFound) =>
+                Left((StatusCode.NotFound, ErrorResponse("not_found", err.message)))
+              case Left(err) =>
+                Left((StatusCode.Conflict, ErrorResponse("update_failed", err.message)))
+              case Right(_) =>
+                audit.rest(
+                  apiKey,
+                  "control-plane",
+                  AuditActions.PoolSetAutoscale,
+                  "ok",
+                  tenant = Some(req.tenant),
+                  target = Some(key.toString),
+                  detail = Map(
+                    "band" -> req.minNodes
+                      .zip(req.maxNodes)
+                      .map((mn, mx) => s"[$mn, $mx]")
+                      .getOrElse("cleared")
+                  )
+                )
+                respond(key) match
+                  case Some(r) => Right(r)
+                  case None    =>
+                    Left(
+                      (
+                        StatusCode.NotFound,
+                        ErrorResponse("not_found", s"pool $key disappeared after update")
+                      )
+                    )
             }

--- a/src/main/scala/ai/starlake/quack/ondemand/autoscale/Autoscale.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/autoscale/Autoscale.scala
@@ -1,0 +1,102 @@
+package ai.starlake.quack.ondemand.autoscale
+
+import ai.starlake.quack.AutoscaleConfig
+import ai.starlake.quack.model.{PoolKey, RoleDistribution}
+
+/** The sweep's projection of one elastic pool. utilization is Little's-law estimated concurrency /
+  * capacity, None when capacity is unknown (no routable read-capable node): no decision is safe
+  * then.
+  */
+final case class AutoscaleView(
+    key: PoolKey,
+    minNodes: Int,
+    maxNodes: Int,
+    distribution: RoleDistribution,
+    suspended: Boolean,
+    disabled: Boolean,
+    utilization: Option[Double]
+)
+
+/** Leader-local per-pool decision state. Reset on failover errs conservative: streaks restart, so
+  * the next action is delayed, never doubled.
+  */
+final case class PoolAutoState(
+    outStreak: Int = 0,
+    inStreak: Int = 0,
+    lastActionAtMs: Option[Long] = None,
+    wasSuspended: Boolean = false
+)
+
+enum AutoscaleAction:
+  case ScaleOut(key: PoolKey, targetSize: Int, dist: RoleDistribution)
+  case ScaleIn(key: PoolKey, targetSize: Int, dist: RoleDistribution)
+
+object Autoscale:
+
+  /** Pure decision core: snapshot in, actions + updated state out. Only the readonly count ever
+    * changes; writers are invariant by construction. Four hysteresis layers: watermark gap,
+    * streaks, cooldowns, step of 1.
+    *
+    * Invariant: scale-in never removes the last read-capable node, and never fires when there is no
+    * readonly node to remove (scale-in only ever decrements readonly, never dual). A pool needs
+    * readonly >= 1 AND readonly + dual > 1 to be scaled in -- an all-dual pool (readonly == 0) or a
+    * pool with exactly one remaining reader is never scaled in, even below minNodes-derived floors,
+    * because dropping it leaves no node able to serve SELECTs -- utilization then reads None
+    * (unknown capacity) and the pool can never recover on its own.
+    */
+  def decide(
+      nowMs: Long,
+      views: List[AutoscaleView],
+      state: Map[PoolKey, PoolAutoState],
+      skip: Set[PoolKey],
+      cfg: AutoscaleConfig
+  ): (List[AutoscaleAction], Map[PoolKey, PoolAutoState]) =
+    val actions   = List.newBuilder[AutoscaleAction]
+    val nextState = views.map { v =>
+      val prev = state.getOrElse(v.key, PoolAutoState())
+      val next =
+        if v.suspended then prev.copy(outStreak = 0, inStreak = 0, wasSuspended = true)
+        else if prev.wasSuspended then
+          // Resume transition: start a cooldown so the wake burst cannot grow
+          // the pool before its baseline nodes have warmed.
+          PoolAutoState(lastActionAtMs = Some(nowMs))
+        else if v.disabled || skip.contains(v.key) then prev.copy(outStreak = 0, inStreak = 0)
+        else
+          // No sentinel default: unknown capacity (no routable read-capable node) is handled
+          // explicitly by the None arm, not folded into the watermark math below.
+          v.utilization match
+            case None       => prev.copy(outStreak = 0, inStreak = 0)
+            case Some(util) =>
+              val size                              = v.distribution.total
+              def cooled(cooldownSec: Int): Boolean =
+                prev.lastActionAtMs.forall(t => nowMs - t >= cooldownSec * 1000L)
+              // Scale-in only ever decrements readonly (never dual), so it needs at least
+              // one readonly node to remove; and at least one read-capable node
+              // (readonly + dual) must survive the decrement, or every SELECT starts
+              // failing with no routable reader left to recover capacity visibility from.
+              val canScaleIn =
+                v.distribution.readonly > 0 && v.distribution.readonly + v.distribution.dual > 1
+              if util >= cfg.highWatermark && size < v.maxNodes then
+                val streak = prev.outStreak + 1
+                if streak >= cfg.outStreak && cooled(cfg.scaleOutCooldownSec) then
+                  actions += AutoscaleAction.ScaleOut(
+                    v.key,
+                    size + 1,
+                    v.distribution.copy(readonly = v.distribution.readonly + 1)
+                  )
+                  PoolAutoState(lastActionAtMs = Some(nowMs))
+                else prev.copy(outStreak = streak, inStreak = 0)
+              else if util <= cfg.lowWatermark && size > v.minNodes && canScaleIn then
+                val streak = prev.inStreak + 1
+                if streak >= cfg.inStreak && cooled(cfg.scaleInCooldownSec) then
+                  actions += AutoscaleAction.ScaleIn(
+                    v.key,
+                    size - 1,
+                    v.distribution.copy(readonly = v.distribution.readonly - 1)
+                  )
+                  PoolAutoState(lastActionAtMs = Some(nowMs))
+                else prev.copy(inStreak = streak, outStreak = 0)
+              else prev.copy(outStreak = 0, inStreak = 0)
+      v.key -> next
+    }.toMap
+    (actions.result(), nextState)

--- a/src/main/scala/ai/starlake/quack/ondemand/manifest/ConfigManifest.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/manifest/ConfigManifest.scala
@@ -85,7 +85,13 @@ final case class ManifestPool(
     // (default) | "on" | "off". Decoded to Pool.lockdown (Option[Boolean]) via
     // LockdownTriState.parse on import. Defaulted so pre-lockdown YAMLs decode
     // unchanged as "inherit" (= no override).
-    lockdown: String = "inherit"
+    lockdown: String = "inherit",
+    // Owner-declared demand scale-out band, round-tripped verbatim from
+    // Pool.minNodes/maxNodes. Both None (the default) decode as a fixed-size
+    // pool, so pre-autoscale YAMLs decode unchanged. Set together or not at
+    // all; AutoscaleBand.validate enforces that on import.
+    minNodes: Option[Int] = None,
+    maxNodes: Option[Int] = None
 )
 
 final case class ManifestTenant(

--- a/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestExporter.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestExporter.scala
@@ -140,7 +140,9 @@ object ManifestExporter:
           cpu = p.cpu,
           memory = p.memory,
           podTemplateYaml = p.podTemplateYaml,
-          lockdown = LockdownTriState.render(p.lockdown)
+          lockdown = LockdownTriState.render(p.lockdown),
+          minNodes = p.minNodes,
+          maxNodes = p.maxNodes
         )
       }
 

--- a/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestImporter.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/manifest/ManifestImporter.scala
@@ -2,6 +2,7 @@
 package ai.starlake.quack.ondemand.manifest
 
 import ai.starlake.quack.model.{
+  AutoscaleBand,
   FederatedSecret,
   FederatedSource,
   LockdownTriState,
@@ -107,6 +108,21 @@ object ManifestImporter:
         LockdownTriState.parse(p.lockdown).left.foreach { msg =>
           errs += s"tenant '${t.name}' pool '${p.name}': $msg"
         }
+        // Reject a malformed demand scale-out band (one-sided, inverted,
+        // below the write-capable floor, over the hard cap, or outside the
+        // declared size) the same way -- accumulate rather than throw. The
+        // manifest has no operator-configured autoscale.hardCap, so the
+        // importer admits any cap the pool's own size satisfies.
+        val dist = RoleDistribution(
+          writeonly = p.roleDistribution.writeonly,
+          readonly = p.roleDistribution.readonly,
+          dual = p.roleDistribution.dual
+        )
+        AutoscaleBand
+          .validate(p.minNodes, p.maxNodes, dist, size = dist.total, hardCap = Int.MaxValue)
+          .foreach { msg =>
+            errs += s"tenant '${t.name}' pool '${p.name}': $msg"
+          }
         // Per-cohort sums must match the pool's roleDistribution and total.
         if p.cohorts.nonEmpty then
           val sumW = p.cohorts.map(_.distribution.writeonly).sum
@@ -357,7 +373,9 @@ object ManifestImporter:
               podTemplateYaml = mp.podTemplateYaml,
               // validate() already rejected any non-tri-state value, so this
               // parse cannot fail here; None (inherit) on the impossible miss.
-              lockdown = LockdownTriState.parse(mp.lockdown).getOrElse(None)
+              lockdown = LockdownTriState.parse(mp.lockdown).getOrElse(None),
+              minNodes = mp.minNodes,
+              maxNodes = mp.maxNodes
             )
             store.upsertPool(upserted)
             localPools.put(mp.name, upserted)

--- a/src/main/scala/ai/starlake/quack/ondemand/runtime/KubernetesQuackBackend.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/runtime/KubernetesQuackBackend.scala
@@ -34,7 +34,6 @@ final class KubernetesQuackBackend(
     quackPort: Int,
     podLabel: String,
     startupTimeoutSec: Int,
-    defaultMetastore: Map[String, String] = Map.empty,
     readPodReady: Pod => Boolean = pod => Option(pod.getStatus).map(_.getPhase).contains("Running"),
     readEnv: String => Option[String] = name => Option(System.getenv(name)),
     podTemplateEnabled: Boolean = false,
@@ -78,8 +77,15 @@ final class KubernetesQuackBackend(
 
   private def buildPod(spec: NodeSpec, token: String): Pod =
     val envs = new java.util.ArrayList[EnvVar]()
-    // Defaults first, per-pool overrides next, then well-known QUACK_* keys.
-    val merged = defaultMetastore ++ spec.metastore
+    // spec.metastore is ALREADY the fully-resolved, per-kind node metastore --
+    // PoolSupervisor.effectiveMetastoreFor merged the manager defaults with the
+    // tenant-db's own params and dropped whatever the kind doesn't want (e.g. no
+    // `dataPath` for a pathless duckdb-file / in-memory tenant-db). Do NOT overlay
+    // a separate defaults map here: re-merging manager defaults on top of this
+    // would resurrect a key `effectiveMetastoreFor` deliberately removed (e.g. the
+    // bootstrap tenant-db's DuckLake directory reappearing as `dataPath` on a
+    // pathless duckdb-file node, which then fails ATTACH with "Is a directory").
+    val merged = spec.metastore
     merged.foreach { case (k, v) =>
       val e = new EnvVar()
       e.setName(k)
@@ -89,8 +95,8 @@ final class KubernetesQuackBackend(
     // Mirror the env-inheritance LocalQuackBackend gets for free (via
     // ProcessBuilder): forward object-store credentials present on the
     // manager process so spawn-quack-node.sh can build CREATE SECRET for
-    // s3:// / az:// / gs:// data paths. `defaultMetastore` wins if the
-    // operator has explicitly pinned a value there.
+    // s3:// / az:// / gs:// data paths. `spec.metastore` wins if it already
+    // carries an explicit value for one of these keys.
     KubernetesQuackBackend.cloudCredEnvVars.foreach { name =>
       if !merged.contains(name) then
         readEnv(name).foreach { v =>

--- a/src/main/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackend.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackend.scala
@@ -12,7 +12,6 @@ import scala.collection.concurrent.TrieMap
 final class LocalQuackBackend(
     min: Int,
     max: Int,
-    defaultMetastore: Map[String, String] = Map.empty,
     commandFor: (NodeSpec, Int, String) => List[String] =
       LocalQuackBackend.defaultCommand(LocalQuackBackend.DefaultSpawnScript)
 ) extends QuackBackend:
@@ -44,7 +43,14 @@ final class LocalQuackBackend(
         if current.isEmpty then prefix else s"$prefix${java.io.File.pathSeparator}$current"
       )
     }
-    defaultMetastore.foreach { case (k, v) => env.put(k, v) }
+    // spec.metastore is ALREADY the fully-resolved, per-kind node metastore --
+    // PoolSupervisor.effectiveMetastoreFor merged the manager defaults with the
+    // tenant-db's own params and dropped whatever the kind doesn't want (e.g. no
+    // `dataPath` for a pathless duckdb-file / in-memory tenant-db). Do NOT overlay
+    // a separate defaults map here: re-merging manager defaults on top of this
+    // would resurrect a key `effectiveMetastoreFor` deliberately removed (e.g. the
+    // bootstrap tenant-db's DuckLake directory reappearing as `dataPath` on a
+    // pathless duckdb-file node, which then fails ATTACH with "Is a directory").
     spec.metastore.foreach { case (k, v) => env.put(k, v) }
     env.put("kind", spec.kindWire)
     if spec.extraSetupSql.nonEmpty then env.put("extraSetupSql", spec.extraSetupSql)

--- a/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
@@ -44,6 +44,25 @@ trait ControlPlaneStore:
   def listPools(tenantDbId: String): List[Pool]
   def deletePool(id: String): Unit
 
+  /** Add `statements`/`totalDurationMs` to the 1-minute demand bucket `(poolId, bucketStart)`,
+    * creating it if absent. Upsert-add rather than overwrite so concurrent replicas summing
+    * counters into the same bucket don't clobber each other.
+    */
+  def addPoolLoad(
+      poolId: String,
+      bucketStart: java.time.Instant,
+      statements: Long,
+      totalDurationMs: Long
+  ): Unit
+
+  /** Sum of `(statements, totalDurationMs)` per pool across every bucket `>= from`. Feeds the
+    * autoscale sweep's demand signal.
+    */
+  def poolLoadWindow(from: java.time.Instant): Map[String, (Long, Long)]
+
+  /** Delete every bucket older than `olderThan`. Returns the number of rows removed. */
+  def purgePoolLoad(olderThan: java.time.Instant): Int
+
   /** Insert/update a running node under the given pool surrogate id. `RunningNode.poolKey` is a
     * natural key (tenant/pool) carried by the runtime and does not always match a single Postgres
     * row, so the FK to `qodstate_pool.id` is supplied explicitly by the caller.

--- a/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
@@ -258,8 +258,8 @@ final class PostgresControlPlaneStore(
         |  (id, tenant_id, tenant_db_id, name, size,
         |   dist_writeonly, dist_readonly, dist_dual,
         |   max_concurrent_per_node, idle_timeout_sec, disabled, cohorts, init_sql,
-        |   cpu, memory, pod_template_yaml, suspended, lockdown)
-        |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?, ?)
+        |   cpu, memory, pod_template_yaml, suspended, lockdown, min_nodes, max_nodes)
+        |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?, ?, ?, ?, ?, ?, ?, ?)
         |ON CONFLICT (id) DO UPDATE SET
         |  tenant_id               = EXCLUDED.tenant_id,
         |  tenant_db_id            = EXCLUDED.tenant_db_id,
@@ -277,7 +277,9 @@ final class PostgresControlPlaneStore(
         |  memory                  = EXCLUDED.memory,
         |  pod_template_yaml       = EXCLUDED.pod_template_yaml,
         |  suspended               = EXCLUDED.suspended,
-        |  lockdown                = EXCLUDED.lockdown""".stripMargin
+        |  lockdown                = EXCLUDED.lockdown,
+        |  min_nodes               = EXCLUDED.min_nodes,
+        |  max_nodes               = EXCLUDED.max_nodes""".stripMargin
     )
     try
       ps.setString(1, p.id)
@@ -302,6 +304,12 @@ final class PostgresControlPlaneStore(
       p.lockdown match
         case Some(v) => ps.setBoolean(18, v)
         case None    => ps.setNull(18, Types.BOOLEAN)
+      p.minNodes match
+        case Some(v) => ps.setInt(19, v)
+        case None    => ps.setNull(19, Types.INTEGER)
+      p.maxNodes match
+        case Some(v) => ps.setInt(20, v)
+        case None    => ps.setNull(20, Types.INTEGER)
       ps.executeUpdate()
     finally ps.close()
   }
@@ -311,7 +319,7 @@ final class PostgresControlPlaneStore(
       """SELECT id, tenant_id, tenant_db_id, name, size,
         |       dist_writeonly, dist_readonly, dist_dual,
         |       max_concurrent_per_node, idle_timeout_sec, disabled, cohorts, init_sql,
-        |       cpu, memory, pod_template_yaml, suspended, lockdown
+        |       cpu, memory, pod_template_yaml, suspended, lockdown, min_nodes, max_nodes
         |FROM qodstate_pool WHERE tenant_db_id = ? ORDER BY name""".stripMargin
     )
     try
@@ -349,8 +357,60 @@ final class PostgresControlPlaneStore(
       podTemplateYaml = Option(rs.getString("pod_template_yaml")).getOrElse(""),
       // Column added in changeset 0024; NULL = inherit the global flag.
       lockdown =
-        Option(rs.getObject("lockdown")).map(_.asInstanceOf[java.lang.Boolean].booleanValue)
+        Option(rs.getObject("lockdown")).map(_.asInstanceOf[java.lang.Boolean].booleanValue),
+      // Columns added in changeset 0025; NULL = fixed-size pool (no band).
+      minNodes = Option(rs.getObject("min_nodes")).map(_.asInstanceOf[Number].intValue),
+      maxNodes = Option(rs.getObject("max_nodes")).map(_.asInstanceOf[Number].intValue)
     )
+
+  // ---------------- Pool load (autoscale demand buckets) ----------------
+
+  def addPoolLoad(
+      poolId: String,
+      bucketStart: java.time.Instant,
+      statements: Long,
+      totalDurationMs: Long
+  ): Unit = withConn { c =>
+    val ps = c.prepareStatement(
+      """INSERT INTO qodstate_pool_load (pool_id, bucket_start, statements, total_duration_ms)
+        |VALUES (?, ?, ?, ?)
+        |ON CONFLICT (pool_id, bucket_start) DO UPDATE SET
+        |  statements        = qodstate_pool_load.statements + EXCLUDED.statements,
+        |  total_duration_ms = qodstate_pool_load.total_duration_ms + EXCLUDED.total_duration_ms""".stripMargin
+    )
+    try
+      ps.setString(1, poolId)
+      ps.setTimestamp(2, Timestamp.from(bucketStart))
+      ps.setLong(3, statements)
+      ps.setLong(4, totalDurationMs)
+      ps.executeUpdate()
+      ()
+    finally ps.close()
+  }
+
+  def poolLoadWindow(from: java.time.Instant): Map[String, (Long, Long)] = withConn { c =>
+    val ps = c.prepareStatement(
+      """SELECT pool_id, SUM(statements) AS s, SUM(total_duration_ms) AS d
+        |FROM qodstate_pool_load WHERE bucket_start >= ? GROUP BY pool_id""".stripMargin
+    )
+    try
+      ps.setTimestamp(1, Timestamp.from(from))
+      val rs = ps.executeQuery()
+      try
+        val out = Map.newBuilder[String, (Long, Long)]
+        while rs.next() do out += rs.getString("pool_id") -> (rs.getLong("s"), rs.getLong("d"))
+        out.result()
+      finally rs.close()
+    finally ps.close()
+  }
+
+  def purgePoolLoad(olderThan: java.time.Instant): Int = withConn { c =>
+    val ps = c.prepareStatement("DELETE FROM qodstate_pool_load WHERE bucket_start < ?")
+    try
+      ps.setTimestamp(1, Timestamp.from(olderThan))
+      ps.executeUpdate()
+    finally ps.close()
+  }
 
   // ---------------- Node ----------------
 
@@ -1343,7 +1403,7 @@ final class PostgresControlPlaneStore(
       ),
       pools = selectAll(
         c,
-        "SELECT id, tenant_id, tenant_db_id, name, size, dist_writeonly, dist_readonly, dist_dual, max_concurrent_per_node, idle_timeout_sec, disabled, cohorts, init_sql, cpu, memory, pod_template_yaml, suspended, lockdown FROM qodstate_pool ORDER BY name",
+        "SELECT id, tenant_id, tenant_db_id, name, size, dist_writeonly, dist_readonly, dist_dual, max_concurrent_per_node, idle_timeout_sec, disabled, cohorts, init_sql, cpu, memory, pod_template_yaml, suspended, lockdown, min_nodes, max_nodes FROM qodstate_pool ORDER BY name",
         readPool
       ),
       nodes = selectAll(

--- a/src/main/scala/ai/starlake/quack/ondemand/telemetry/AuditActions.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/telemetry/AuditActions.scala
@@ -31,6 +31,7 @@ object AuditActions:
   val PoolSetResources     = "pool.setResources"
   val PoolSetPodTemplate   = "pool.setPodTemplate"
   val PoolSetLockdown      = "pool.setLockdown"
+  val PoolSetAutoscale     = "pool.setAutoscale"
   val PoolPermissionGrant  = "pool.permission.grant"
   val PoolPermissionRevoke = "pool.permission.revoke"
   // users, roles, groups
@@ -115,6 +116,7 @@ object AuditActions:
     PoolSetResources,
     PoolSetPodTemplate,
     PoolSetLockdown,
+    PoolSetAutoscale,
     PoolPermissionGrant,
     PoolPermissionRevoke,
     UserCreate,

--- a/src/main/scala/ai/starlake/quack/route/PoolLoadStats.scala
+++ b/src/main/scala/ai/starlake/quack/route/PoolLoadStats.scala
@@ -1,0 +1,55 @@
+package ai.starlake.quack.route
+
+import ai.starlake.quack.model.PoolKey
+import ai.starlake.quack.spi.{ManagerEvent, ManagerEventSink}
+
+/** Per-pool 1-minute load buckets feeding the autoscale utilization estimate (Little's law:
+  * totalDurationMs over the window / window length). Fed from StatementExecuted via `sink`, so
+  * probe traffic is excluded by the edge's existing recordExecution gating. Thread-safe; the sweep
+  * drains closed buckets and flushes them upsert-add to qodstate_pool_load.
+  *
+  * Exactly ONE drainer must run against an instance (the autoscale sweep). Two concurrent drainers
+  * would each get a disjoint half of the closed buckets, so neither pass sees the pool's real load.
+  * Nothing else bounds the map: if no drainer runs, it grows one entry per (pool, minute) forever.
+  */
+final class PoolLoadStats(clock: () => Long = () => System.currentTimeMillis()):
+  import PoolLoadStats.*
+
+  private val buckets =
+    new java.util.concurrent.ConcurrentHashMap[(PoolKey, Long), Sample]()
+
+  def record(key: PoolKey, durationMs: Long): Unit =
+    val b = bucketStart(clock())
+    buckets.merge(
+      (key, b),
+      Sample(1L, durationMs),
+      (a, x) => Sample(a.statements + x.statements, a.totalDurationMs + x.totalDurationMs)
+    )
+    ()
+
+  /** Removes and returns every bucket strictly older than the current minute.
+    *
+    * The two-arg remove is load-bearing: a `record()` that merges into the same bucket between the
+    * read and the removal changes the value, the remove then fails, and the entry is left in place
+    * (with the late statement's contribution) for the next sweep instead of being dropped. Only
+    * buckets actually removed are returned, so the flush never double-counts; the flush being
+    * upsert-add makes carrying a bucket over to a later sweep safe.
+    */
+  def drainClosed(): Map[(PoolKey, Long), Sample] =
+    val open    = bucketStart(clock())
+    val it      = buckets.entrySet().iterator()
+    val drained = Map.newBuilder[(PoolKey, Long), Sample]
+    while it.hasNext do
+      val e = it.next()
+      if e.getKey._2 < open && buckets.remove(e.getKey, e.getValue) then
+        drained += e.getKey -> e.getValue
+    drained.result()
+
+  val sink: ManagerEventSink =
+    case ManagerEvent.StatementExecuted(tenant, tenantDb, pool, _, _, durationMs, _) =>
+      record(PoolKey(tenant, tenantDb, pool), durationMs)
+    case _ => ()
+
+object PoolLoadStats:
+  final case class Sample(statements: Long, totalDurationMs: Long)
+  def bucketStart(ms: Long): Long = ms - (ms % 60_000L)

--- a/src/main/scala/ai/starlake/quack/spi/ManagerEvent.scala
+++ b/src/main/scala/ai/starlake/quack/spi/ManagerEvent.scala
@@ -41,6 +41,18 @@ object ManagerEvent:
   final case class PoolResumed(tenant: String, tenantDb: String, pool: String, reason: String)
       extends ManagerEvent
 
+  /** A pool's node count changed through scale (manual REST call or the autoscale sweep). Emitted
+    * after the mutation commits. `reason` is "manual" or "autoscale".
+    */
+  final case class PoolScaled(
+      tenant: String,
+      tenantDb: String,
+      pool: String,
+      fromSize: Int,
+      toSize: Int,
+      reason: String
+  ) extends ManagerEvent
+
   /** A new session was established. `via` identifies the entry point:
     *   - `"flightsql"`: an Arrow FlightSQL handshake.
     *   - `"rest"`: a REST password login (`AuthHandlers.login`).
@@ -56,3 +68,9 @@ trait ManagerEventSink:
 
 object ManagerEventSink:
   val noop: ManagerEventSink = (_: ManagerEvent) => ()
+
+  /** Delivers each event to every sink in order. Sinks must not throw (the routing hot path calls
+    * emit inline); no error isolation is added here.
+    */
+  def fanout(sinks: ManagerEventSink*): ManagerEventSink =
+    (e: ManagerEvent) => sinks.foreach(_.emit(e))

--- a/src/main/scala/ai/starlake/quack/spi/ManagerModule.scala
+++ b/src/main/scala/ai/starlake/quack/spi/ManagerModule.scala
@@ -3,10 +3,22 @@ package ai.starlake.quack.spi
 import cats.effect.IO
 import sttp.tapir.server.ServerEndpoint
 
-/** A static SPA mount: `urlPrefix` on the wire (e.g. "/portal") served from `classpathDir`
-  * resources (e.g. "/portal") with an index.html SPA fallback, exactly like the core "/ui" mount.
+/** A static content mount contributed by a module.
+  *
+  * `diskDir`: when set AND the directory exists, content is served from the filesystem instead of
+  * the classpath (live-updatable without a redeploy, e.g. the marketing site's QOD_WWW_DIR);
+  * otherwise the bundled classpath resources under `classpathDir` serve as the fallback.
+  *
+  * `spaFallback`: true (default) routes any unmatched path to `index.html` with status 200 (SPA
+  * client routing, e.g. the portal); false serves the mount's `404.html` with a genuine 404 status
+  * (marketing pages must not soft-404).
   */
-final case class StaticMount(urlPrefix: String, classpathDir: String)
+final case class StaticMount(
+    urlPrefix: String,
+    classpathDir: String,
+    diskDir: Option[String] = None,
+    spaFallback: Boolean = true
+)
 
 /** The plug-in contract for jars discovered via
   * `META-INF/services/ai.starlake.quack.spi.ManagerModule`.
@@ -23,6 +35,7 @@ trait ManagerModule:
   def endpoints: List[ServerEndpoint[Any, IO]]
   def publicPathPrefixes: Set[String]
   def staticMounts: List[StaticMount] = Nil
+
   /** Veto hooks for structure mutations (quota policy). Read by the manager AFTER start() returns,
     * same contract as endpoints: a module may build gates inside start().
     */

--- a/src/test/resources/www-test/404.html
+++ b/src/test/resources/www-test/404.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>404</title></head><body>www-not-found</body></html>

--- a/src/test/resources/www-test/assets/app-a1b2c3d4.js
+++ b/src/test/resources/www-test/assets/app-a1b2c3d4.js
@@ -1,0 +1,1 @@
+console.log("hashed-asset");

--- a/src/test/resources/www-test/index.html
+++ b/src/test/resources/www-test/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>www-test</title></head><body>www-index</body></html>

--- a/src/test/resources/www-test/pricing/index.html
+++ b/src/test/resources/www-test/pricing/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>pricing</title></head><body>www-pricing</body></html>

--- a/src/test/scala/ai/starlake/quack/AutoscaleConfigSpec.scala
+++ b/src/test/scala/ai/starlake/quack/AutoscaleConfigSpec.scala
@@ -1,0 +1,65 @@
+package ai.starlake.quack
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import pureconfig.ConfigSource
+
+/** Pins defaults and the camelCase ProductHint for the autoscale block. */
+class AutoscaleConfigSpec extends AnyFlatSpec with Matchers:
+  import Main.given
+
+  "AutoscaleConfig" should "load defaults from application.conf" in:
+    val cfg = ConfigSource.default.at("quack-on-demand").loadOrThrow[ManagerConfig]
+    cfg.autoscale.enabled shouldBe true
+    cfg.autoscale.sweepSeconds shouldBe 60
+    cfg.autoscale.windowMinutes shouldBe 5
+    cfg.autoscale.highWatermark shouldBe 0.8
+    cfg.autoscale.lowWatermark shouldBe 0.3
+    cfg.autoscale.outStreak shouldBe 2
+    cfg.autoscale.inStreak shouldBe 10
+    cfg.autoscale.scaleOutCooldownSec shouldBe 180
+    cfg.autoscale.scaleInCooldownSec shouldBe 600
+    cfg.autoscale.assumedConcurrencyPerNode shouldBe 4
+    cfg.autoscale.hardCap shouldBe 16
+    cfg.autoscale.failureBackoffSweeps shouldBe 5
+
+  it should "honor camelCase overlays" in:
+    val overlay = ConfigSource.string(
+      """quack-on-demand { autoscale { highWatermark = 0.9, sweepSeconds = 45 } }"""
+    )
+    val cfg = overlay
+      .withFallback(ConfigSource.default)
+      .at("quack-on-demand")
+      .loadOrThrow[ManagerConfig]
+    cfg.autoscale.highWatermark shouldBe 0.9
+    cfg.autoscale.sweepSeconds shouldBe 45
+
+  it should "clamp the sweep interval to the 30s floor" in:
+    AutoscaleConfig(sweepSeconds = 5).sweepInterval.toSeconds shouldBe 30L
+
+  it should "pass sweepSeconds through unclamped above the floor" in:
+    AutoscaleConfig(sweepSeconds = 60).sweepInterval.toSeconds shouldBe 60L
+
+  it should "refuse an inverted watermark band" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(
+      highWatermark = 0.3,
+      lowWatermark = 0.8
+    )
+
+  it should "refuse a non-positive outStreak" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(outStreak = 0)
+
+  it should "refuse a non-positive inStreak" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(inStreak = 0)
+
+  it should "refuse a non-positive windowMinutes" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(windowMinutes = 0)
+
+  it should "refuse a non-positive failureBackoffSweeps" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(failureBackoffSweeps = 0)
+
+  it should "refuse a non-positive hardCap" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(hardCap = 0)
+
+  it should "refuse a negative scaleOutCooldownSec" in:
+    an[IllegalArgumentException] should be thrownBy AutoscaleConfig(scaleOutCooldownSec = -1)

--- a/src/test/scala/ai/starlake/quack/boot/AutoscaleWiringSpec.scala
+++ b/src/test/scala/ai/starlake/quack/boot/AutoscaleWiringSpec.scala
@@ -1,0 +1,154 @@
+package ai.starlake.quack.boot
+
+import ai.starlake.quack.AutoscaleConfig
+import ai.starlake.quack.model.{PoolKey, RoleDistribution}
+import ai.starlake.quack.ondemand.autoscale.{AutoscaleAction, AutoscaleView}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AutoscaleWiringSpec extends AnyFlatSpec with Matchers:
+  private val poolKey = PoolKey("t", "db", "p")
+  private val cfg     = AutoscaleConfig(outStreak = 1) // act on the first hot sweep
+  private def hotView =
+    AutoscaleView(poolKey, 1, 3, RoleDistribution(0, 1, 0), false, false, Some(0.9))
+
+  "sweep" should "flush local buckets on every replica but only decide as leader" in:
+    var flushed = 0
+    var scaled  = 0
+    val w       = new AutoscaleWiring(
+      cfg,
+      views = () => List(hotView),
+      flushLocal = () => flushed += 1,
+      purge = () => (),
+      scale = _ => IO { scaled += 1; Right(()) },
+      isLeader = () => false
+    )
+    w.sweep().unsafeRunSync()
+    flushed shouldBe 1
+    scaled shouldBe 0
+
+  it should "apply a scale-out decision as leader" in:
+    var applied = List.empty[AutoscaleAction]
+    val w       = new AutoscaleWiring(
+      cfg,
+      views = () => List(hotView),
+      flushLocal = () => (),
+      purge = () => (),
+      scale = a => IO { applied = applied :+ a; Right(()) },
+      isLeader = () => true
+    )
+    w.sweep().unsafeRunSync()
+    applied shouldBe List(AutoscaleAction.ScaleOut(poolKey, 2, RoleDistribution(0, 2, 0)))
+
+  it should "back off a pool after 3 consecutive failures and recover after the window" in:
+    var calls = 0
+    val w     = new AutoscaleWiring(
+      cfg.copy(failureBackoffSweeps = 2, scaleOutCooldownSec = 0),
+      views = () => List(hotView),
+      flushLocal = () => (),
+      purge = () => (),
+      scale = _ => IO { calls += 1; Left("boom") },
+      isLeader = () => true
+    )
+    w.sweep().unsafeRunSync() // fail 1
+    w.sweep().unsafeRunSync() // fail 2
+    w.sweep().unsafeRunSync() // fail 3 -> backoff starts
+    calls shouldBe 3
+    w.sweep().unsafeRunSync() // backoff sweep 1: skipped
+    w.sweep().unsafeRunSync() // backoff sweep 2: skipped
+    calls shouldBe 3
+    w.sweep().unsafeRunSync() // retry
+    calls shouldBe 4
+
+  it should "not let a scale error kill the sweep" in:
+    val w = new AutoscaleWiring(
+      cfg.copy(scaleOutCooldownSec = 0),
+      views = () => List(hotView),
+      flushLocal = () => (),
+      purge = () => (),
+      scale = _ => IO.raiseError(new RuntimeException("quota")),
+      isLeader = () => true
+    )
+    noException should be thrownBy w.sweep().unsafeRunSync()
+
+  it should "flush even when the leader's decide pass throws" in:
+    var flushed = 0
+    val w       = new AutoscaleWiring(
+      cfg,
+      views = () => throw new RuntimeException("store down"),
+      flushLocal = () => flushed += 1,
+      purge = () => (),
+      scale = _ => IO.pure(Right(())),
+      isLeader = () => true
+    )
+    an[RuntimeException] should be thrownBy w.sweep().unsafeRunSync()
+    flushed shouldBe 1
+
+  it should "re-evaluate the leader gate on every run, not just once when sweep() is constructed" in:
+    var leader  = false
+    var applied = List.empty[AutoscaleAction]
+    val w       = new AutoscaleWiring(
+      cfg,
+      views = () => List(hotView),
+      flushLocal = () => (),
+      purge = () => (),
+      scale = a => IO { applied = applied :+ a; Right(()) },
+      isLeader = () => leader
+    )
+    val s = w.sweep()
+    s.unsafeRunSync() // not leader yet: no decision
+    applied shouldBe Nil
+    leader = true
+    s.unsafeRunSync() // same bound IO, now leader: must decide fresh
+    applied shouldBe List(AutoscaleAction.ScaleOut(poolKey, 2, RoleDistribution(0, 2, 0)))
+
+  it should "survive a scale that throws synchronously and still count the failure toward backoff" in:
+    val w = new AutoscaleWiring(
+      cfg.copy(failureBackoffSweeps = 2, scaleOutCooldownSec = 0),
+      views = () => List(hotView),
+      flushLocal = () => (),
+      purge = () => (),
+      scale = _ => throw new RuntimeException("boom-sync"),
+      isLeader = () => true
+    )
+    noException should be thrownBy w.sweep().unsafeRunSync() // fail 1
+    noException should be thrownBy w.sweep().unsafeRunSync() // fail 2
+    noException should be thrownBy w.sweep().unsafeRunSync() // fail 3 -> backoff starts
+    w.backoffForTest.get(poolKey) shouldBe Some(2)
+
+  it should "reset the failure streak after a success" in:
+    var calls = 0
+    val w     = new AutoscaleWiring(
+      cfg.copy(failureBackoffSweeps = 5, scaleOutCooldownSec = 0),
+      views = () => List(hotView),
+      flushLocal = () => (),
+      purge = () => (),
+      scale = _ =>
+        IO {
+          calls += 1
+          if calls % 3 == 0 then Right(()) else Left("boom")
+        },
+      isLeader = () => true
+    )
+    (1 to 6).foreach(_ => w.sweep().unsafeRunSync())
+    // Two failures then a success on every third sweep: the counter never
+    // reaches 3, so no pool ever enters backoff.
+    calls shouldBe 6
+    w.backoffForTest.isEmpty shouldBe true
+
+  // The disabled fiber completes instead of looping. Main keys the PoolLoadStats
+  // sink off the same flag, because this sweep is the sink's sole drainer.
+  "fiber" should "start no loop when autoscale is disabled" in:
+    var flushed = 0
+    val w       = new AutoscaleWiring(
+      cfg.copy(enabled = false),
+      views = () => List(hotView),
+      flushLocal = () => flushed += 1,
+      purge = () => (),
+      scale = _ => IO.pure(Right(())),
+      isLeader = () => true
+    )
+    w.fiber.flatMap(_.join).unsafeRunSync().isSuccess shouldBe true
+    flushed shouldBe 0

--- a/src/test/scala/ai/starlake/quack/model/AutoscaleBandSpec.scala
+++ b/src/test/scala/ai/starlake/quack/model/AutoscaleBandSpec.scala
@@ -1,0 +1,39 @@
+package ai.starlake.quack.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AutoscaleBandSpec extends AnyFlatSpec with Matchers:
+  private val dist = RoleDistribution(writeonly = 1, readonly = 2, dual = 0)
+
+  "AutoscaleBand.validate" should "accept no band" in:
+    AutoscaleBand.validate(None, None, dist, size = 3, hardCap = 16) shouldBe None
+
+  it should "accept a well-formed band" in:
+    AutoscaleBand.validate(Some(1), Some(4), dist, size = 3, hardCap = 16) shouldBe None
+
+  it should "reject one-sided bands" in:
+    AutoscaleBand.validate(Some(1), None, dist, 3, 16).isDefined shouldBe true
+    AutoscaleBand.validate(None, Some(4), dist, 3, 16).isDefined shouldBe true
+
+  it should "reject min below 1" in:
+    AutoscaleBand.validate(Some(0), Some(4), dist, 3, 16).isDefined shouldBe true
+
+  it should "accept min == max (pinned size: the band never scales)" in:
+    // size must equal the band value, since size has to lie inside [3, 3].
+    AutoscaleBand.validate(Some(3), Some(3), dist, size = 3, hardCap = 16) shouldBe None
+
+  it should "reject min above max" in:
+    AutoscaleBand.validate(Some(4), Some(3), dist, 3, 16).isDefined shouldBe true
+
+  it should "reject max above the hard cap" in:
+    AutoscaleBand.validate(Some(1), Some(17), dist, 3, 16).isDefined shouldBe true
+
+  it should "reject a floor below the write-capable node count" in:
+    // writeonly + dual = 2 write-capable nodes; a floor of 1 would force removing one.
+    val writers = RoleDistribution(writeonly = 1, readonly = 1, dual = 1)
+    AutoscaleBand.validate(Some(1), Some(4), writers, 3, 16).isDefined shouldBe true
+
+  it should "reject a size outside the band" in:
+    AutoscaleBand.validate(Some(2), Some(4), dist, size = 1, hardCap = 16).isDefined shouldBe true
+    AutoscaleBand.validate(Some(1), Some(2), dist, size = 3, hardCap = 16).isDefined shouldBe true

--- a/src/test/scala/ai/starlake/quack/module/PoolSupervisorEventsSpec.scala
+++ b/src/test/scala/ai/starlake/quack/module/PoolSupervisorEventsSpec.scala
@@ -129,3 +129,30 @@ class PoolSupervisorEventsSpec extends AnyFlatSpec with Matchers:
     tenantDeletedIdx should be >= 0
     dbDeletedIdx should be < tenantDeletedIdx
   }
+
+  it should "emit PoolScaled with fromSize, toSize and reason after a resize" in {
+    val sup = new PoolSupervisor(
+      new StubQuackBackend,
+      new NodeLoadTracker,
+      new InMemoryControlPlaneStore(),
+      events = sink
+    )
+
+    val tenant = sup.createTenant(Tenant("scaleup")).unsafeRunSync().toOption.get
+    val td     = sup
+      .createTenantDb("scaleup", "default", TenantDbKind.InMemory, Map.empty, dataPath = "")
+      .unsafeRunSync()
+      .toOption
+      .get
+    val key = PoolKey("scaleup", td.name, "sales")
+    sup.createPool(key, RoleDistribution(0, 1, 0)).unsafeRunSync()
+    received.clear()
+
+    sup
+      .scale(key, targetSize = 2, RoleDistribution(0, 2, 0), force = false, reason = "autoscale")
+      .unsafeRunSync()
+
+    received.asScala.toList should contain(
+      ManagerEvent.PoolScaled(key.tenant, key.tenantDb, key.pool, 1, 2, "autoscale")
+    )
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
@@ -210,6 +210,35 @@ class PoolSupervisorSpec extends AnyFlatSpec with Matchers:
     sup.createPool(key, RoleDistribution(0, 0, 1), lockdown = Some(true)).unsafeRunSync()
     backend.specs.last.lockdownSql should include("SET autoinstall_known_extensions = false")
 
+  // ---- autoscaleBand / setPoolAutoscale: owner-declared scale-out band ----
+
+  "PoolSupervisor.autoscaleBand" should "persist and expose the autoscale band" in:
+    val sup = freshSupervisor()
+    sup.createPool(key, RoleDistribution(0, 1, 0), minNodes = Some(1), maxNodes = Some(3))
+      .unsafeRunSync()
+    sup.autoscaleBand(key) shouldBe Some((1, 3))
+
+  it should "return None for a fixed-size pool" in:
+    val sup = freshSupervisor()
+    sup.createPool(key, RoleDistribution(0, 1, 0)).unsafeRunSync()
+    sup.autoscaleBand(key) shouldBe None
+
+  "PoolSupervisor.setPoolAutoscale" should "set and clear the band" in:
+    val sup = freshSupervisor()
+    sup.createPool(key, RoleDistribution(0, 1, 0)).unsafeRunSync()
+    sup.autoscaleBand(key) shouldBe None
+    sup.setPoolAutoscale(key, Some((1, 4))).unsafeRunSync().isRight shouldBe true
+    sup.autoscaleBand(key) shouldBe Some((1, 4))
+    sup.setPoolAutoscale(key, None).unsafeRunSync().isRight shouldBe true
+    sup.autoscaleBand(key) shouldBe None
+
+  it should "return Left for an unknown pool" in:
+    val sup = freshSupervisor()
+    sup
+      .setPoolAutoscale(PoolKey("no", "such", "pool"), Some((1, 2)))
+      .unsafeRunSync()
+      .isLeft shouldBe true
+
   // ---- initSql: free-form per-pool SQL prepended to the federation blob ----
   //
   // Operators set things like `SET memory_limit='8GB';` or `INSTALL httpfs;`

--- a/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
@@ -904,6 +904,11 @@ class PoolSupervisorSpec extends AnyFlatSpec with Matchers:
     spec.metastore("pgHost") shouldBe "tenant-host"
     spec.metastore("pgPort") shouldBe "5432"
     spec.metastore("shared") shouldBe "tenant-val"
+    // Backend-seam pin for the backend-overlay fix: the dataPath the
+    // CapturingBackend actually receives on NodeSpec.metastore must be the
+    // tenant-db's own field, not something a backend-level defaults overlay
+    // could have swapped in or resurrected.
+    spec.metastore("dataPath") shouldBe "/data/acme_default"
 
   "PoolSupervisor.effectiveMetastoreFor" should
     "return the tenant-db's dataPath when multiple tenant-dbs coexist" in:
@@ -926,14 +931,169 @@ class PoolSupervisorSpec extends AnyFlatSpec with Matchers:
     sup.effectiveMetastoreFor("eu", "eu_default")("dataPath") shouldBe "/data/eu-west"
     sup.effectiveMetastoreFor("us", "us_default")("dataPath") shouldBe "s3://us-east-data/"
 
-  it should "fall back to the global default when the tenant-db has no override" in:
+  /** Supervisor whose store already carries `(tenant acme, tenant-db)`, hydrated through
+    * `restore()`. Needed for the tenant-db shapes `createTenantDb`'s validator refuses at the REST
+    * boundary (a duckdb-file row with no dataPath at all, a memory row carrying an explicit
+    * metastore) but that DO reach the in-memory cache via manifest import, config import, or a
+    * legacy persisted row. */
+  private def supWithSeededTenantDb(
+      defaults: Map[String, String],
+      kind: TenantDbKind,
+      metastore: Map[String, String],
+      dataPath: String,
+      tdName: String = "acme_default"
+  ): (PoolSupervisor, CapturingBackend) =
+    val st      = new InMemoryControlPlaneStore()
+    val backend = new CapturingBackend
+    val sup = new PoolSupervisor(
+      backend, new NodeLoadTracker, st,
+      defaultMetastore = defaults
+    )
+    st.upsertTenant(Tenant("acme", "acme"))
+    st.upsertTenantDb(
+      ai.starlake.quack.model.TenantDb(
+        id = "td-seed", tenantId = "acme", name = tdName,
+        kind = kind, metastore = metastore, dataPath = dataPath
+      )
+    )
+    sup.restore()
+    (sup, backend)
+
+  /** Manager default: a DuckLake DIRECTORY plus the bootstrap tenant-db's own naming. Inheriting
+    * any of it into a duckdb-file / memory tenant-db is the bug the cases below pin. */
+  private val bugDefaults: Map[String, String] =
+    Map("dataPath" -> "./ducklake/tpch", "dbName" -> "tpch", "schemaName" -> "main")
+
+  it should "honor the duckdb-file tenant-db's dataPath FIELD instead of the default directory" in:
+    // Regression: the ATTACH in spawn-quack-node.sh's duckdb-file branch expects a .duckdb FILE.
+    // Inheriting the manager default (a DuckLake directory) made every node fail with
+    // "Is a directory" and never acquire its catalog.
     val sup = new PoolSupervisor(
       new CapturingBackend, new NodeLoadTracker, new InMemoryControlPlaneStore(),
-      defaultMetastore = Map("dataPath" -> "/data/global")
+      defaultMetastore = bugDefaults
+    )
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    sup.createTenantDb("acme", "default",
+      TenantDbKind.DuckDbFile,
+      Map("dbName" -> "acme_default", "schemaName" -> "main"),
+      dataPath = "/data/acme_default.duckdb"
+    ).unsafeRunSync()
+    val eff = sup.effectiveMetastoreFor("acme", "acme_default")
+    eff("dataPath")   shouldBe "/data/acme_default.duckdb"
+    eff("dbName")     shouldBe "acme_default"
+    eff("schemaName") shouldBe "main"
+
+  it should "default a duckdb-file tenant-db's dbName to the tenant-db name, not the default" in:
+    val (sup, _) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckDbFile,
+      metastore = Map("schemaName" -> "main"),
+      dataPath  = "/data/acme_default.duckdb"
+    )
+    val eff = sup.effectiveMetastoreFor("acme", "acme_default")
+    eff("dbName")   shouldBe "acme_default"
+    eff("dataPath") shouldBe "/data/acme_default.duckdb"
+
+  it should "drop dataPath entirely for a duckdb-file tenant-db with no path anywhere" in:
+    val (sup, _) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckDbFile,
+      metastore = Map("schemaName" -> "main"),
+      dataPath  = ""
+    )
+    val eff = sup.effectiveMetastoreFor("acme", "acme_default")
+    eff.contains("dataPath") shouldBe false
+    eff("dbName")            shouldBe "acme_default"
+
+  it should "let an explicit metastore dataPath/dbName win for a duckdb-file tenant-db" in:
+    val (sup, _) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckDbFile,
+      metastore = Map("dataPath" -> "/explicit/file.duckdb", "dbName" -> "explicit_db",
+        "schemaName" -> "main"),
+      dataPath  = ""
+    )
+    val eff = sup.effectiveMetastoreFor("acme", "acme_default")
+    eff("dataPath") shouldBe "/explicit/file.duckdb"
+    eff("dbName")   shouldBe "explicit_db"
+
+  it should "resolve a memory tenant-db to the built-in `memory` catalog with no dataPath" in:
+    // Regression: inheriting the default dbName made Main's health probe run
+    // `CREATE SCHEMA IF NOT EXISTS tpch.main` on a node that only has the `memory` catalog,
+    // so the probe failed on every tick and the node stayed permanently unroutable.
+    val sup = new PoolSupervisor(
+      new CapturingBackend, new NodeLoadTracker, new InMemoryControlPlaneStore(),
+      defaultMetastore = bugDefaults
     )
     sup.createTenant(Tenant("legacy")).unsafeRunSync()
     sup.createTenantDb("legacy", "default", TenantDbKind.InMemory, Map.empty, "").unsafeRunSync()
-    sup.effectiveMetastoreFor("legacy", "legacy_default")("dataPath") shouldBe "/data/global"
+    val eff = sup.effectiveMetastoreFor("legacy", "legacy_default")
+    eff.contains("dataPath") shouldBe false
+    eff("dbName")            shouldBe "memory"
+    eff("schemaName")        shouldBe "main"
+
+  it should "let an explicit metastore dbName win for a memory tenant-db, still without dataPath" in:
+    val (sup, _) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.InMemory,
+      metastore = Map("dbName" -> "explicit_mem", "dataPath" -> "/ignored"),
+      dataPath  = "/also-ignored"
+    )
+    val eff = sup.effectiveMetastoreFor("acme", "acme_default")
+    eff("dbName")            shouldBe "explicit_mem"
+    eff.contains("dataPath") shouldBe false
+
+  it should "leave the DuckLake derivation untouched (sibling dataPath + composed dbName)" in:
+    val (sup, _) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckLake,
+      metastore = Map("pgHost" -> "h", "pgPort" -> "5432", "pgUser" -> "u",
+        "pgPassword" -> "s", "schemaName" -> "main"),
+      dataPath  = ""
+    )
+    val eff = sup.effectiveMetastoreFor("acme", "acme_default")
+    eff("dbName")   shouldBe "acme_default"
+    eff("dataPath") shouldBe "./ducklake/acme_default"
+
+  it should "keep honoring an explicit DuckLake dataPath field" in:
+    val (sup, _) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckLake,
+      metastore = Map("pgHost" -> "h", "pgPort" -> "5432", "pgUser" -> "u",
+        "pgPassword" -> "s", "schemaName" -> "main"),
+      dataPath  = "s3://bucket/acme_default"
+    )
+    sup.effectiveMetastoreFor("acme", "acme_default")("dataPath") shouldBe
+      "s3://bucket/acme_default"
+
+  // ---------- Backend seam: the residual metastore shape actually reaches NodeSpec ----------
+  //
+  // The tests above pin `effectiveMetastoreFor`'s output directly. The bug this fixes lived one
+  // layer further out: both QuackBackend impls re-overlaid `defaultMetastore` on top of
+  // `spec.metastore` inside `start()`, which could resurrect a key `effectiveMetastoreFor`
+  // deliberately dropped before the backend ever saw it. These cases go through `createPool` so
+  // `CapturingBackend.specs` records exactly what a real backend's `start(spec)` would receive.
+
+  it should
+    "carry NO dataPath key on the captured NodeSpec for a seeded pathless duckdb-file tenant-db" in:
+    val (sup, backend) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckDbFile,
+      metastore = Map("schemaName" -> "main"),
+      dataPath  = ""
+    )
+    sup.createPool(key, RoleDistribution(0, 0, 1)).unsafeRunSync()
+    val spec = backend.specs.head
+    spec.metastore.contains("dataPath") shouldBe false
+    spec.metastore("dbName") shouldBe "acme_default"
+
+  it should
+    "let the tenant-db's dataPath FIELD win over its metastore map entry on the captured NodeSpec" in:
+    // Minor 4a from review: td.dataPath and td.metastore("dataPath") both set, to DIFFERENT
+    // values. effectiveMetastoreFor's DuckDbFile branch checks td.dataPath first, so the field
+    // must be what reaches the backend, not the map entry.
+    val (sup, backend) = supWithSeededTenantDb(
+      bugDefaults, TenantDbKind.DuckDbFile,
+      metastore = Map("dataPath" -> "/map/loses.duckdb", "dbName" -> "acme_default",
+        "schemaName" -> "main"),
+      dataPath  = "/field/wins.duckdb"
+    )
+    sup.createPool(key, RoleDistribution(0, 0, 1)).unsafeRunSync()
+    val spec = backend.specs.head
+    spec.metastore("dataPath") shouldBe "/field/wins.duckdb"
 
   // ---------- NodeSpec.objectStoreSql (per-db object-store CREATE SECRET) ----------
 

--- a/src/test/scala/ai/starlake/quack/ondemand/api/DtosWireContractSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/DtosWireContractSpec.scala
@@ -46,6 +46,7 @@ class DtosWireContractSpec extends AnyFlatSpec with Matchers:
     decode[CreatePoolRequest](json) shouldBe Right(
       CreatePoolRequest("acme", "acme_db", "bi", 1, RoleDistribution(0, 0, 1))
     )
+    decode[CreatePoolRequest](json).map(r => (r.minNodes, r.maxNodes)) shouldBe Right((None, None))
 
   it should "round-trip with every non-default field populated" in:
     val req = CreatePoolRequest(
@@ -69,9 +70,44 @@ class DtosWireContractSpec extends AnyFlatSpec with Matchers:
       initSql = Some("INSTALL httpfs"),
       cpu = "2",
       memory = "4Gi",
-      podTemplateYaml = "metadata: {}"
+      podTemplateYaml = "metadata: {}",
+      minNodes = Some(1),
+      maxNodes = Some(4)
     )
     decode[CreatePoolRequest](req.asJson.noSpaces) shouldBe Right(req)
+
+  // ----- SetPoolAutoscaleRequest: one-sided and absent bands ---------------
+
+  "SetPoolAutoscaleRequest" should "default both band bounds to None when absent" in:
+    decode[SetPoolAutoscaleRequest]("""{"tenant":"a","tenantDb":"d","pool":"p"}""") shouldBe
+      Right(SetPoolAutoscaleRequest("a", "d", "p"))
+
+  it should "round-trip a populated band" in:
+    val req = SetPoolAutoscaleRequest("a", "d", "p", Some(1), Some(4))
+    decode[SetPoolAutoscaleRequest](req.asJson.noSpaces) shouldBe Right(req)
+
+  // ----- PoolResponse: band mirror ----------------------------------------
+
+  // PoolResponse derives a strict codec, so the absent-field case is built by
+  // dropping the two band keys from a full encoding rather than by hand-writing
+  // a minimal object (every non-Option field stays required).
+  "PoolResponse" should "default the band to None when the keys are absent from the wire" in:
+    val json = PoolResponse("acme", "acme_db", "bi", Nil, "ready").asJson
+      .mapObject(_.remove("minNodes").remove("maxNodes"))
+      .noSpaces
+    decode[PoolResponse](json).map(r => (r.minNodes, r.maxNodes)) shouldBe Right((None, None))
+
+  it should "round-trip a populated band" in:
+    val resp = PoolResponse(
+      tenant = "acme",
+      tenantDb = "acme_db",
+      pool = "bi",
+      nodes = Nil,
+      status = "ready",
+      minNodes = Some(1),
+      maxNodes = Some(4)
+    )
+    decode[PoolResponse](resp.asJson.noSpaces) shouldBe Right(resp)
 
   // ----- Pool ops: force defaults to false --------------------------------
 

--- a/src/test/scala/ai/starlake/quack/ondemand/api/PoolHandlersSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/PoolHandlersSpec.scala
@@ -36,7 +36,9 @@ class PoolHandlersSpec extends AnyFlatSpec with Matchers:
       pool: String = "sales",
       size: Int = 2,
       dist: RoleDistribution = RoleDistribution(0, 1, 1),
-      maxConcurrentPerNode: Int = 0
+      maxConcurrentPerNode: Int = 0,
+      minNodes: Option[Int] = None,
+      maxNodes: Option[Int] = None
   ): CreatePoolRequest =
     CreatePoolRequest(
       tenant = "acme",
@@ -44,7 +46,24 @@ class PoolHandlersSpec extends AnyFlatSpec with Matchers:
       pool = pool,
       size = size,
       roleDistribution = dist,
-      maxConcurrentPerNode = maxConcurrentPerNode
+      maxConcurrentPerNode = maxConcurrentPerNode,
+      minNodes = minNodes,
+      maxNodes = maxNodes
+    )
+
+  private def scaleReq(
+      pool: String = "sales",
+      targetSize: Int = 2,
+      dist: RoleDistribution = RoleDistribution(0, 1, 1),
+      force: Boolean = false
+  ): ScalePoolRequest =
+    ScalePoolRequest(
+      tenant = "acme",
+      tenantDb = "acme_default",
+      pool = pool,
+      targetSize = targetSize,
+      roleDistribution = dist,
+      force = force
     )
 
   "createPool" should "create a pool and return node info with maxConcurrent" in:
@@ -485,3 +504,148 @@ class PoolHandlersSpec extends AnyFlatSpec with Matchers:
       .get
     resp.suspended shouldBe true
     resp.nodes shouldBe empty
+
+  // Task 8: owner-declared autoscale band on the REST surface
+
+  "createPool with a band" should "reject a one-sided band on create" in:
+    val h   = freshHandlers
+    val out = h
+      .createPool(req(size = 1, dist = RoleDistribution(0, 1, 0), minNodes = Some(1)), None)(
+        (_: String) => None
+      )
+      .unsafeRunSync()
+    out.left.toOption.map(_._2.error) shouldBe Some("invalid_band")
+
+  it should "reject a band with authored cohorts (scaling clears cohorts)" in:
+    val h = freshHandlers
+    val r = req(size = 2, dist = RoleDistribution(0, 2, 0), minNodes = Some(1), maxNodes = Some(4))
+      .copy(cohorts =
+        List(
+          PoolCohortDto(
+            placement = NodePlacementDto(nodeSelector = Map("zone" -> "a")),
+            distribution = RoleDistribution(0, 2, 0)
+          )
+        )
+      )
+    val out = h.createPool(r, None)((_: String) => None).unsafeRunSync()
+    out.left.toOption.map(_._2.error) shouldBe Some("invalid_band")
+
+  it should "create an elastic pool and report its band" in:
+    val h   = freshHandlers
+    val out = h
+      .createPool(
+        req(size = 1, dist = RoleDistribution(0, 1, 0), minNodes = Some(1), maxNodes = Some(3)),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    out.toOption.map(r => (r.minNodes, r.maxNodes)) shouldBe Some((Some(1), Some(3)))
+
+  "scalePool" should "refuse a manual scale outside the band with the band in the message" in:
+    val h = freshHandlers
+    h.createPool(
+      req(size = 1, dist = RoleDistribution(0, 1, 0), minNodes = Some(1), maxNodes = Some(3)),
+      None
+    )((_: String) => None)
+      .unsafeRunSync()
+    val out = h
+      .scalePool(scaleReq(targetSize = 5, dist = RoleDistribution(0, 5, 0)), None)((_: String) =>
+        None
+      )
+      .unsafeRunSync()
+    out.left.toOption.map(_._1) shouldBe Some(StatusCode.BadRequest)
+    out.left.toOption.map(_._2.error) shouldBe Some("outside_band")
+    out.left.toOption.map(_._2.message).getOrElse("") should include("[1, 3]")
+
+  it should "allow a manual scale inside the band" in:
+    val h = freshHandlers
+    h.createPool(
+      req(size = 1, dist = RoleDistribution(0, 1, 0), minNodes = Some(1), maxNodes = Some(3)),
+      None
+    )((_: String) => None)
+      .unsafeRunSync()
+    val out = h
+      .scalePool(scaleReq(targetSize = 3, dist = RoleDistribution(0, 3, 0)), None)((_: String) =>
+        None
+      )
+      .unsafeRunSync()
+    out shouldBe a[Right[?, ?]]
+
+  "setPoolAutoscale" should "set and clear the band" in:
+    val h = freshHandlers
+    h.createPool(req(size = 1, dist = RoleDistribution(0, 1, 0)), None)((_: String) => None)
+      .unsafeRunSync()
+    val set = h
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest("acme", "acme_default", "sales", Some(1), Some(4)),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    set.toOption.flatMap(_.minNodes) shouldBe Some(1)
+    set.toOption.flatMap(_.maxNodes) shouldBe Some(4)
+    val cleared = h
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest("acme", "acme_default", "sales", None, None),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    cleared.toOption.flatMap(_.minNodes) shouldBe None
+    cleared.toOption.flatMap(_.maxNodes) shouldBe None
+
+  it should "reject a band that does not cover the pool's current size" in:
+    val h = freshHandlers
+    h.createPool(req(size = 2, dist = RoleDistribution(0, 2, 0)), None)((_: String) => None)
+      .unsafeRunSync()
+    val out = h
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest("acme", "acme_default", "sales", Some(3), Some(5)),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    out.left.toOption.map(_._1) shouldBe Some(StatusCode.BadRequest)
+    out.left.toOption.map(_._2.error) shouldBe Some("invalid_band")
+
+  it should "reject a band on a pool with authored cohorts (scaling clears cohorts)" in:
+    val h = freshHandlers
+    h.createPool(
+      req(size = 2, dist = RoleDistribution(0, 2, 0)).copy(cohorts =
+        List(
+          PoolCohortDto(
+            placement = NodePlacementDto(nodeSelector = Map("zone" -> "a")),
+            distribution = RoleDistribution(0, 2, 0)
+          )
+        )
+      ),
+      None
+    )((_: String) => None)
+      .unsafeRunSync()
+    val out = h
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest("acme", "acme_default", "sales", Some(1), Some(4)),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    out.left.toOption.map(_._1) shouldBe Some(StatusCode.BadRequest)
+    out.left.toOption.map(_._2.error) shouldBe Some("invalid_band")
+
+  it should "404 on an unknown pool" in:
+    val h   = freshHandlers
+    val out = h
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest("acme", "acme_default", "nope", Some(1), Some(4)),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    out.left.toOption.map(_._1) shouldBe Some(StatusCode.NotFound)
+    out.left.toOption.map(_._2.error) shouldBe Some("not_found")
+
+  it should "403 for a foreign-tenant session" in:
+    val h = freshHandlers
+    h.createPool(req(size = 1, dist = RoleDistribution(0, 1, 0)), None)((_: String) => None)
+      .unsafeRunSync()
+    val out = h
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest("acme", "acme_default", "sales", Some(1), Some(4)),
+        Some("tok")
+      )(_ => Some(tenantScope("globex")))
+      .unsafeRunSync()
+    out.left.toOption.map(_._1) shouldBe Some(StatusCode.Forbidden)

--- a/src/test/scala/ai/starlake/quack/ondemand/autoscale/AutoscaleSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/autoscale/AutoscaleSpec.scala
@@ -1,0 +1,137 @@
+package ai.starlake.quack.ondemand.autoscale
+
+import ai.starlake.quack.AutoscaleConfig
+import ai.starlake.quack.model.{PoolKey, RoleDistribution}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AutoscaleSpec extends AnyFlatSpec with Matchers:
+  private val key: PoolKey = PoolKey("t", "db", "p")
+  private val cfg          = AutoscaleConfig() // outStreak 2, inStreak 10, cooldowns 180/600s
+  private def view(
+      util: Option[Double],
+      dist: RoleDistribution = RoleDistribution(0, 1, 0),
+      min: Int = 1,
+      max: Int = 3,
+      suspended: Boolean = false,
+      disabled: Boolean = false
+  ) = AutoscaleView(key, min, max, dist, suspended, disabled, util)
+  private val now = 1_000_000L
+
+  "decide" should "not act on the first hot sweep (streak below outStreak)" in:
+    val (actions, st) = Autoscale.decide(now, List(view(Some(0.9))), Map.empty, Set.empty, cfg)
+    actions shouldBe Nil
+    st(key).outStreak shouldBe 1
+
+  it should "add one reader after outStreak hot sweeps" in:
+    val warm          = Map(key -> PoolAutoState(outStreak = 1))
+    val (actions, st) = Autoscale.decide(now, List(view(Some(0.9))), warm, Set.empty, cfg)
+    actions shouldBe List(AutoscaleAction.ScaleOut(key, 2, RoleDistribution(0, 2, 0)))
+    st(key).outStreak shouldBe 0
+    st(key).lastActionAtMs shouldBe Some(now)
+
+  it should "respect the ceiling" in:
+    val warm         = Map(key -> PoolAutoState(outStreak = 1))
+    val (actions, _) =
+      Autoscale.decide(now, List(view(Some(0.9), RoleDistribution(0, 3, 0))), warm, Set.empty, cfg)
+    actions shouldBe Nil
+
+  it should "respect the scale-out cooldown" in:
+    val recent       = Map(key -> PoolAutoState(outStreak = 1, lastActionAtMs = Some(now - 1_000)))
+    val (actions, _) = Autoscale.decide(now, List(view(Some(0.9))), recent, Set.empty, cfg)
+    actions shouldBe Nil
+
+  it should "scale out once the cooldown has elapsed" in:
+    val old = Map(key -> PoolAutoState(outStreak = 1, lastActionAtMs = Some(now - 181_000)))
+    val (actions, _) = Autoscale.decide(now, List(view(Some(0.9))), old, Set.empty, cfg)
+    actions should have size 1
+
+  it should "remove one reader after inStreak quiet sweeps, never below the floor" in:
+    val quiet        = Map(key -> PoolAutoState(inStreak = 9))
+    val (actions, _) = Autoscale.decide(
+      now,
+      List(view(Some(0.1), RoleDistribution(0, 2, 0))),
+      quiet,
+      Set.empty,
+      cfg
+    )
+    actions shouldBe List(AutoscaleAction.ScaleIn(key, 1, RoleDistribution(0, 1, 0)))
+    // at the floor: no action even with a full streak
+    val (atFloor, _) =
+      Autoscale.decide(now, List(view(Some(0.1))), quiet, Set.empty, cfg)
+    atFloor shouldBe Nil
+
+  it should "never strip the last read-capable node on scale-in" in:
+    val dist         = RoleDistribution(writeonly = 1, readonly = 1, dual = 0)
+    val full         = Map(key -> PoolAutoState(inStreak = 9))
+    val (actions, _) =
+      Autoscale.decide(now, List(view(Some(0.1), dist, min = 1, max = 4)), full, Set.empty, cfg)
+    actions shouldBe Nil // last reader protected
+
+  it should "never scale in a writer-only pool" in:
+    val dist         = RoleDistribution(writeonly = 2, readonly = 0, dual = 0)
+    val full         = Map(key -> PoolAutoState(inStreak = 9))
+    val (actions, _) =
+      Autoscale.decide(now, List(view(Some(0.1), dist, min = 1, max = 4)), full, Set.empty, cfg)
+    actions shouldBe Nil
+
+  it should "never touch writers" in:
+    val dist         = RoleDistribution(writeonly = 1, readonly = 1, dual = 1)
+    val quiet        = Map(key -> PoolAutoState(inStreak = 9))
+    val (actions, _) =
+      Autoscale.decide(now, List(view(Some(0.1), dist, min = 3, max = 5)), quiet, Set.empty, cfg)
+    actions shouldBe Nil // size 3 == floor 3; and the floor >= writeonly + dual by validation
+
+  it should "reset streaks in the hysteresis dead band" in:
+    val warm          = Map(key -> PoolAutoState(outStreak = 1, inStreak = 5))
+    val (actions, st) = Autoscale.decide(now, List(view(Some(0.5))), warm, Set.empty, cfg)
+    actions shouldBe Nil
+    st(key).outStreak shouldBe 0
+    st(key).inStreak shouldBe 0
+
+  it should "treat a resume transition as a cooldown-starting action" in:
+    val (a1, s1) =
+      Autoscale.decide(now, List(view(Some(0.9), suspended = true)), Map.empty, Set.empty, cfg)
+    a1 shouldBe Nil
+    s1(key).wasSuspended shouldBe true
+    val (a2, s2) = Autoscale.decide(now + 1_000, List(view(Some(0.9))), s1, Set.empty, cfg)
+    a2 shouldBe Nil // resume cooldown just started
+    s2(key).wasSuspended shouldBe false
+    s2(key).lastActionAtMs shouldBe Some(now + 1_000)
+
+  it should "skip pools in failure backoff, disabled pools and unknown-capacity pools" in:
+    val warm = Map(key -> PoolAutoState(outStreak = 1))
+    Autoscale.decide(now, List(view(Some(0.9))), warm, Set(key), cfg)._1 shouldBe Nil
+    Autoscale
+      .decide(now, List(view(Some(0.9), disabled = true)), warm, Set.empty, cfg)
+      ._1 shouldBe Nil
+    Autoscale.decide(now, List(view(None)), warm, Set.empty, cfg)._1 shouldBe Nil
+
+  it should "never scale in an all-dual pool below one node (no negative readonly)" in:
+    val dist         = RoleDistribution(writeonly = 0, readonly = 0, dual = 2)
+    val full         = Map(key -> PoolAutoState(inStreak = 9))
+    val (actions, _) =
+      Autoscale.decide(now, List(view(Some(0.1), dist, min = 1, max = 2)), full, Set.empty, cfg)
+    actions shouldBe Nil
+
+  it should "still scale in a mixed pool with a spare dual node" in:
+    val dist         = RoleDistribution(writeonly = 0, readonly = 1, dual = 1)
+    val full         = Map(key -> PoolAutoState(inStreak = 9))
+    val (actions, _) =
+      Autoscale.decide(now, List(view(Some(0.1), dist, min = 1, max = 2)), full, Set.empty, cfg)
+    actions shouldBe List(AutoscaleAction.ScaleIn(key, 1, RoleDistribution(0, 0, 1)))
+
+  it should "never scale a pinned band (minNodes == maxNodes) in either direction" in:
+    val dist   = RoleDistribution(writeonly = 0, readonly = 2, dual = 0)
+    val pinned = view(Some(0.9), dist, min = 2, max = 2)
+    val hot    = Map(key -> PoolAutoState(outStreak = 1))
+    Autoscale.decide(now, List(pinned), hot, Set.empty, cfg)._1 shouldBe Nil
+    val quiet = Map(key -> PoolAutoState(inStreak = 9))
+    Autoscale
+      .decide(now, List(view(Some(0.1), dist, min = 2, max = 2)), quiet, Set.empty, cfg)
+      ._1 shouldBe Nil
+
+  it should "prune state for pools that vanished" in:
+    val (_, st) =
+      Autoscale.decide(now, Nil, Map(key -> PoolAutoState(outStreak = 1)), Set.empty, cfg)
+    st shouldBe Map.empty

--- a/src/test/scala/ai/starlake/quack/ondemand/manifest/ManifestRoundTripSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/manifest/ManifestRoundTripSpec.scala
@@ -90,7 +90,10 @@ class ManifestRoundTripSpec extends AnyFlatSpec with Matchers:
         cpu = "2",
         memory = "8Gi",
         podTemplateYaml = "apiVersion: v1\nkind: Pod\nspec:\n  nodeName: n1\n",
-        lockdown = Some(true)
+        lockdown = Some(true),
+        // writeonly + dual = 2 write-capable nodes, so the floor must be >= 2.
+        minNodes = Some(2),
+        maxNodes = Some(4)
       )
     )
 
@@ -181,6 +184,11 @@ class ManifestRoundTripSpec extends AnyFlatSpec with Matchers:
     // Same guarantee for the scale-to-zero flag: an import must not wake a
     // suspended pool back up by resetting it to false.
     restoredPool.suspended shouldBe true
+    // The owner-declared demand scale-out band must survive the export ->
+    // import cycle too: the importer's apply path threads minNodes/maxNodes
+    // into the Pool(...) build, not just the exporter's read side.
+    restoredPool.minNodes shouldBe Some(2)
+    restoredPool.maxNodes shouldBe Some(4)
 
     // Step 7: second export from the imported store
     val manifest2 = ManifestExporter.build(dst, ExportedAt, AdminVersion, Hostname)
@@ -585,4 +593,67 @@ class ManifestRoundTripSpec extends AnyFlatSpec with Matchers:
     val tenantId = dst.listTenants().find(_.displayName == "tpch").map(_.id).get
     val db       = dst.listTenantDbs(tenantId).find(_.name == "tpch_tpch1").get
     dst.listPools(db.id).find(_.name == "sales").get.suspended shouldBe false
+  }
+
+  // ------------------------------------------------------------------
+  // Test 10: a pool manifest that OMITS the autoscale band imports as
+  // fixed-size (Pool.minNodes/maxNodes == None/None), so a pre-autoscale
+  // YAML never acquires a spurious band.
+  // ------------------------------------------------------------------
+
+  it should "import a pool that omits the autoscale band as fixed-size" in {
+    val yaml =
+      """apiVersion: quack-on-demand/v1
+        |kind: ConfigManifest
+        |exportedAt: '2026-06-05T12:00:00Z'
+        |exportedFrom: { managerVersion: x, hostname: y }
+        |tenants:
+        |  - name: tpch
+        |    tenantDbs:
+        |      - name: tpch_tpch1
+        |    pools:
+        |      - name: sales
+        |        tenantDb: tpch_tpch1
+        |        roleDistribution: { writeonly: 0, readonly: 0, dual: 1 }
+        |""".stripMargin
+    val parsed = parser.parse(yaml).flatMap(_.as[ConfigManifest]).fold(throw _, identity)
+    parsed.tenants.head.pools.head.minNodes shouldBe None
+    parsed.tenants.head.pools.head.maxNodes shouldBe None
+
+    val dst = new InMemoryControlPlaneStore()
+    ManifestImporter.apply(parsed, dst) shouldBe Right(())
+
+    val tenantId = dst.listTenants().find(_.displayName == "tpch").map(_.id).get
+    val db       = dst.listTenantDbs(tenantId).find(_.name == "tpch_tpch1").get
+    val pool     = dst.listPools(db.id).find(_.name == "sales").get
+    pool.minNodes shouldBe None
+    pool.maxNodes shouldBe None
+  }
+
+  // ------------------------------------------------------------------
+  // Test 11: a one-sided autoscale band is rejected by validation rather
+  // than silently coerced or applied.
+  // ------------------------------------------------------------------
+
+  it should "reject a pool manifest with a one-sided autoscale band" in {
+    val yaml =
+      """apiVersion: quack-on-demand/v1
+        |kind: ConfigManifest
+        |exportedAt: '2026-06-05T12:00:00Z'
+        |exportedFrom: { managerVersion: x, hostname: y }
+        |tenants:
+        |  - name: tpch
+        |    tenantDbs:
+        |      - name: tpch_tpch1
+        |    pools:
+        |      - name: sales
+        |        tenantDb: tpch_tpch1
+        |        roleDistribution: { writeonly: 0, readonly: 0, dual: 1 }
+        |        minNodes: 1
+        |""".stripMargin
+    val parsed = parser.parse(yaml).flatMap(_.as[ConfigManifest]).fold(throw _, identity)
+    val dst    = new InMemoryControlPlaneStore()
+    val result = ManifestImporter.apply(parsed, dst)
+    result.isLeft shouldBe true
+    result.left.toOption.get.exists(_.contains("set together")) shouldBe true
   }

--- a/src/test/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackendSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/runtime/LocalQuackBackendSpec.scala
@@ -44,13 +44,12 @@ class LocalQuackBackendSpec extends AnyFlatSpec with Matchers:
     try node.maxConcurrent shouldBe 5
     finally backend.stop(PoolKey("t", "t_default", "p"), "node-3").unsafeRunSync()
 
-  it should "propagate defaultMetastore + NodeSpec.metastore as env vars (spec overrides default)" in:
+  it should "propagate NodeSpec.metastore as env vars with no backend-level defaults overlay" in:
     val capture = java.io.File.createTempFile("env-capture-", ".txt")
     capture.deleteOnExit()
     val backend = new LocalQuackBackend(
       min = 23040,
       max = 23041,
-      defaultMetastore = Map("pgHost" -> "default-host", "pgUser" -> "default-user"),
       commandFor = (_, _, _) => envDumpCmd(capture.getAbsolutePath, 5)
     )
     val spec = NodeSpec(
@@ -66,10 +65,40 @@ class LocalQuackBackendSpec extends AnyFlatSpec with Matchers:
       val deadline = System.currentTimeMillis() + 3000
       while capture.length() == 0 && System.currentTimeMillis() < deadline do Thread.sleep(50)
       val out = java.nio.file.Files.readString(capture.toPath)
-      out should include("pgHost=override-host") // spec wins
-      out should include("pgUser=default-user")  // default fills gap
-      out should include("dbName=specdb")        // spec-only key
+      out should include("pgHost=override-host") // spec.metastore is the sole source
+      out should include("dbName=specdb")
+      // Regression for the backend-overlay bug: LocalQuackBackend no longer
+      // takes a `defaultMetastore` constructor param, so nothing can
+      // resurrect a key `PoolSupervisor.effectiveMetastoreFor` deliberately
+      // dropped (e.g. `dataPath` on a pathless duckdb-file / in-memory node).
+      // A key absent from spec.metastore must stay absent from the node env.
+      out should not include "pgUser="
     finally backend.stop(PoolKey("t", "t_default", "p"), "node-env").unsafeRunSync()
+
+  it should "omit a key spec.metastore does not carry (e.g. dataPath dropped by effectiveMetastoreFor)" in:
+    val capture = java.io.File.createTempFile("env-capture-nodatapath-", ".txt")
+    capture.deleteOnExit()
+    val backend = new LocalQuackBackend(
+      min = 23042,
+      max = 23043,
+      commandFor = (_, _, _) => envDumpCmd(capture.getAbsolutePath, 5)
+    )
+    // Mirrors what effectiveMetastoreFor produces for a pathless duckdb-file
+    // tenant-db: dataPath removed entirely, not merely blank.
+    val spec = NodeSpec(
+      PoolKey("t", "t_default", "p"),
+      "node-nodatapath",
+      Role.Dual,
+      metastore = Map("pgHost" -> "h", "dbName" -> "specdb"),
+      s3 = Map.empty
+    )
+    backend.start(spec).unsafeRunSync()
+    try
+      val deadline = System.currentTimeMillis() + 3000
+      while capture.length() == 0 && System.currentTimeMillis() < deadline do Thread.sleep(50)
+      val out = java.nio.file.Files.readString(capture.toPath)
+      out should not include "dataPath="
+    finally backend.stop(PoolKey("t", "t_default", "p"), "node-nodatapath").unsafeRunSync()
 
   it should "emit objectStoreSql as an env var when the spec carries one, and omit it when empty" in:
     val capture = java.io.File.createTempFile("env-capture-objsql-", ".txt")

--- a/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
@@ -69,6 +69,32 @@ final class InMemoryControlPlaneStore extends ControlPlaneStore:
     pools.remove(id)
     poolPermissions.values.filter(_.poolId.contains(id)).foreach(p => poolPermissions.remove(p.id))
 
+  // ---------------- Pool load (autoscale demand buckets) ----------------
+  private val poolLoad =
+    scala.collection.concurrent.TrieMap.empty[(String, Instant), (Long, Long)]
+
+  def addPoolLoad(
+      poolId: String,
+      bucketStart: Instant,
+      statements: Long,
+      totalDurationMs: Long
+  ): Unit =
+    poolLoad.updateWith((poolId, bucketStart)) {
+      case Some((s, d)) => Some((s + statements, d + totalDurationMs))
+      case None         => Some((statements, totalDurationMs))
+    }
+    ()
+
+  def poolLoadWindow(from: Instant): Map[String, (Long, Long)] =
+    poolLoad.toList
+      .filter { case ((_, b), _) => !b.isBefore(from) }
+      .groupMapReduce(_._1._1)(_._2)((a, b) => (a._1 + b._1, a._2 + b._2))
+
+  def purgePoolLoad(olderThan: Instant): Int =
+    val victims = poolLoad.keys.filter(_._2.isBefore(olderThan)).toList
+    victims.foreach(poolLoad.remove)
+    victims.size
+
   // node_id -> pool_id index (matches the Postgres FK shape).
   private val nodeIndex = TrieMap.empty[String, String]
 

--- a/src/test/scala/ai/starlake/quack/ondemand/state/LiquibaseRunnerSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/LiquibaseRunnerSpec.scala
@@ -59,6 +59,7 @@ class LiquibaseRunnerSpec extends AnyFlatSpec with Matchers:
           "qodstate_maintenance_run",
           "qodstate_node",
           "qodstate_pool",
+          "qodstate_pool_load",
           "qodstate_pool_permission",
           "qodstate_revoked_jti",
           "qodstate_role",
@@ -102,8 +103,9 @@ class LiquibaseRunnerSpec extends AnyFlatSpec with Matchers:
       // 3 statement-history/rollup tables (stmt_history, stmt_rollup,
       // rollup_watermark, Liquibase 0019) +
       // 1 snapshot-tag table (snapshot_tag, Liquibase 0020) +
-      // 2 maintenance tables (policy + run, Liquibase 0021).
+      // 2 maintenance tables (policy + run, Liquibase 0021) +
+      // 1 autoscale-demand table (pool_load, Liquibase 0026).
       // qodstate_tenant_identity is gone -- auth provider is a tenant attribute now.
-      rs.getInt(1) shouldBe 24
+      rs.getInt(1) shouldBe 25
     finally c.close()
   }

--- a/src/test/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStoreSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStoreSpec.scala
@@ -197,6 +197,43 @@ class PostgresControlPlaneStoreSpec extends AnyFlatSpec with Matchers:
       back.lockdown shouldBe value
   }
 
+  it should "round-trip the pool autoscale band" in withStore { store =>
+    store.upsertTenant(tenant)
+    store.upsertTenantDb(tenantDb)
+    val banded = pool.copy(minNodes = Some(1), maxNodes = Some(4))
+    store.upsertPool(banded)
+    store.listPools(banded.tenantDbId).find(_.id == banded.id).get.minNodes shouldBe Some(1)
+    store.listPools(banded.tenantDbId).find(_.id == banded.id).get.maxNodes shouldBe Some(4)
+    val cleared = banded.copy(minNodes = None, maxNodes = None)
+    store.upsertPool(cleared)
+    store.listPools(banded.tenantDbId).find(_.id == banded.id).get.minNodes shouldBe None
+    store.listPools(banded.tenantDbId).find(_.id == banded.id).get.maxNodes shouldBe None
+  }
+
+  it should "upsert-add pool load buckets so concurrent replicas sum" in withStore { store =>
+    store.upsertTenant(tenant)
+    store.upsertTenantDb(tenantDb)
+    store.upsertPool(pool)
+    val b0 = Instant.parse("2026-08-12T10:00:00Z")
+    store.addPoolLoad(pool.id, b0, statements = 2, totalDurationMs = 1000)
+    store.addPoolLoad(pool.id, b0, statements = 3, totalDurationMs = 500) // second replica
+    store.poolLoadWindow(b0) shouldBe Map(pool.id -> (5L, 1500L))
+  }
+
+  it should "sum pool load over the window and purge old buckets" in withStore { store =>
+    store.upsertTenant(tenant)
+    store.upsertTenantDb(tenantDb)
+    store.upsertPool(pool)
+    val b0 = Instant.parse("2026-08-12T10:00:00Z")
+    val b1 = b0.plusSeconds(60)
+    store.addPoolLoad(pool.id, b0, 1, 100)
+    store.addPoolLoad(pool.id, b1, 1, 200)
+    store.poolLoadWindow(b0) shouldBe Map(pool.id -> (2L, 300L))
+    store.poolLoadWindow(b1) shouldBe Map(pool.id -> (1L, 200L))
+    store.purgePoolLoad(olderThan = b1) shouldBe 1
+    store.poolLoadWindow(b0) shouldBe Map(pool.id -> (1L, 200L))
+  }
+
   it should "preserve idleTimeoutSec as a populated Option" in withStore { store =>
     store.upsertTenant(tenant)
     store.upsertTenantDb(tenantDb)

--- a/src/test/scala/ai/starlake/quack/route/PoolLoadStatsSpec.scala
+++ b/src/test/scala/ai/starlake/quack/route/PoolLoadStatsSpec.scala
@@ -1,0 +1,44 @@
+package ai.starlake.quack.route
+
+import ai.starlake.quack.model.PoolKey
+import ai.starlake.quack.spi.{ManagerEvent, ManagerEventSink}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PoolLoadStatsSpec extends AnyFlatSpec with Matchers:
+  private val key: PoolKey = PoolKey("t", "db", "p")
+
+  "PoolLoadStats" should "accumulate statements and duration per minute bucket" in:
+    var nowMs = 120_000L
+    val stats = new PoolLoadStats(clock = () => nowMs)
+    stats.record(key, 500L)
+    stats.record(key, 1500L)
+    nowMs = 200_000L // next minute: bucket 120000 is now closed
+    val drained = stats.drainClosed()
+    drained shouldBe Map((key, 120_000L) -> PoolLoadStats.Sample(2L, 2000L))
+    stats.drainClosed() shouldBe Map.empty // drain removes
+
+  it should "keep the open bucket" in:
+    val nowMs = 120_000L
+    val stats = new PoolLoadStats(clock = () => nowMs)
+    stats.record(key, 500L)
+    stats.drainClosed() shouldBe Map.empty // current minute still open
+
+  it should "record StatementExecuted through its sink and ignore other events" in:
+    var nowMs = 120_000L
+    val stats = new PoolLoadStats(clock = () => nowMs)
+    stats.sink.emit(
+      ManagerEvent.StatementExecuted("t", "db", "p", "READ", "u", durationMs = 250L, ok = true)
+    )
+    stats.sink.emit(ManagerEvent.TenantCreated("t"))
+    nowMs = 200_000L
+    stats.drainClosed() shouldBe Map((key, 120_000L) -> PoolLoadStats.Sample(1L, 250L))
+
+  "ManagerEventSink.fanout" should "deliver to every sink" in:
+    var a                     = 0
+    var b                     = 0
+    val fan: ManagerEventSink =
+      ManagerEventSink.fanout((_: ManagerEvent) => a += 1, (_: ManagerEvent) => b += 1)
+    fan.emit(ManagerEvent.TenantCreated("t"))
+    a shouldBe 1
+    b shouldBe 1

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -1,0 +1,50 @@
+package ai.starlake.quack.security
+
+import ai.starlake.quack.spi.StaticMount
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+/** Pins the diskDir override added for the marketing site: a mount with a diskDir that exists is
+  * served from the filesystem (live-updatable content), and falls back to the classpath resources
+  * when diskDir is absent or missing on disk.
+  */
+class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers:
+
+  private def bootWith(mounts: List[StaticMount]): ManagerServerHarness.Harness =
+    val fix = SecurityFixtures.freshStore()
+    ManagerServerHarness.boot(fix.store, moduleStaticMounts = mounts)
+
+  "a mount with a diskDir" should "serve files from disk instead of the classpath" in {
+    val dir = Files.createTempDirectory("qod-www-disk")
+    Files.writeString(dir.resolve("index.html"), "<html><body>disk-index</body></html>")
+    val harness =
+      bootWith(List(StaticMount("/www", "/www-test", diskDir = Some(dir.toString))))
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/www/")
+      resp.statusCode() shouldBe 200
+      resp.body() should include("disk-index")
+      resp.body() should not include "www-index"
+    finally harness.shutdown()
+  }
+
+  it should "fall back to classpath resources when the diskDir does not exist" in {
+    val harness = bootWith(
+      List(StaticMount("/www", "/www-test", diskDir = Some("/nonexistent/qod-www")))
+    )
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/www/")
+      resp.statusCode() shouldBe 200
+      resp.body() should include("www-index")
+    finally harness.shutdown()
+  }
+
+  "a mount without diskDir" should "keep serving classpath resources" in {
+    val harness = bootWith(List(StaticMount("/www", "/www-test")))
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/www/")
+      resp.statusCode() shouldBe 200
+      resp.body() should include("www-index")
+    finally harness.shutdown()
+  }

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -109,3 +109,28 @@ class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHe
       resp.headers().firstValue("Location").get() shouldBe "/ui/"
     finally harness.shutdown()
   }
+
+  "cache headers on a non-SPA mount" should "mark hashed assets immutable" in {
+    val harness = bootWith(List(StaticMount("/", "/www-test", spaFallback = false)))
+    try
+      val asset = get(harness.httpClient, s"${harness.baseUrl}/assets/app-a1b2c3d4.js")
+      asset.statusCode() shouldBe 200
+      asset.headers().firstValue("Cache-Control").get() shouldBe
+        "public, max-age=31536000, immutable"
+
+      val page = get(harness.httpClient, s"${harness.baseUrl}/")
+      page.headers().firstValue("Cache-Control").get() shouldBe
+        "public, max-age=300, stale-while-revalidate=600"
+
+      val missing = get(harness.httpClient, s"${harness.baseUrl}/no/such/page")
+      missing.headers().firstValue("Cache-Control").get() shouldBe "no-store"
+    finally harness.shutdown()
+  }
+
+  "cache headers" should "not be added to SPA mounts" in {
+    val harness = bootWith(List(StaticMount("/portal", "/portal-test")))
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/portal/")
+      resp.headers().firstValue("Cache-Control").isPresent shouldBe false
+    finally harness.shutdown()
+  }

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -127,6 +127,23 @@ class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHe
     finally harness.shutdown()
   }
 
+  "an extensionless zero-byte file on a non-SPA mount" should "still 404, not be served as 200-empty" in {
+    // Pins the live-smoke jar bug: `sbt assembly` packs zero-byte directory
+    // entries into the classpath jar, and http4s' resourceServiceBuilder
+    // matched a bare-directory request against one and served it as a 200
+    // with an empty body, ahead of the directory-index fallback. `blank` is a
+    // real zero-byte extensionless file, which reproduces the same "assets
+    // wins over pages" ordering bug on plain file: classpath URLs too - pre-fix
+    // this asserts 200-empty, post-fix the pages route owns it and 404s.
+    val harness = bootWith(List(StaticMount("/", "/www-test", spaFallback = false)))
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/blank")
+      resp.statusCode() shouldBe 404
+      resp.body() should include("www-not-found")
+      resp.headers().firstValue("Cache-Control").get() shouldBe "no-store"
+    finally harness.shutdown()
+  }
+
   "cache headers" should "not be added to SPA mounts" in {
     val harness = bootWith(List(StaticMount("/portal", "/portal-test")))
     try

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -48,3 +48,42 @@ class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHe
       resp.body() should include("www-index")
     finally harness.shutdown()
   }
+
+  "a root mount with spaFallback=false" should "serve index at / and a real 404 elsewhere" in {
+    val harness = bootWith(List(StaticMount("/", "/www-test", spaFallback = false)))
+    try
+      val root = get(harness.httpClient, s"${harness.baseUrl}/")
+      root.statusCode() shouldBe 200
+      root.body() should include("www-index")
+
+      val missing = get(harness.httpClient, s"${harness.baseUrl}/no/such/page")
+      missing.statusCode() shouldBe 404
+      missing.body() should include("www-not-found")
+    finally harness.shutdown()
+  }
+
+  it should "lose to longer-prefix mounts regardless of declaration order" in {
+    val harness = bootWith(
+      List(
+        StaticMount("/", "/www-test", spaFallback = false),
+        StaticMount("/portal", "/portal-test")
+      )
+    )
+    try
+      val portal = get(harness.httpClient, s"${harness.baseUrl}/portal/")
+      portal.statusCode() shouldBe 200
+      portal.body() should include("portal-index")
+    finally harness.shutdown()
+  }
+
+  "the bare root with no root mount" should "still redirect to /ui/" in {
+    val harness = bootWith(List(StaticMount("/portal", "/portal-test")))
+    try
+      // SecurityHttpHelpers' client uses HttpClient.newHttpClient(), whose
+      // default redirect policy is NEVER, so the 302 itself is observable
+      // instead of being auto-followed.
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/")
+      resp.statusCode() shouldBe 302
+      resp.headers().firstValue("Location").get() shouldBe "/ui/"
+    finally harness.shutdown()
+  }

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -62,6 +62,28 @@ class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHe
     finally harness.shutdown()
   }
 
+  it should "resolve nested directory-index pages on classpath-backed mounts" in {
+    val harness = bootWith(List(StaticMount("/", "/www-test", spaFallback = false)))
+    try
+      val pricing = get(harness.httpClient, s"${harness.baseUrl}/pricing/")
+      pricing.statusCode() shouldBe 200
+      pricing.body() should include("www-pricing")
+    finally harness.shutdown()
+  }
+
+  "a non-root mount with spaFallback=false" should "serve its own index and a real 404" in {
+    val harness = bootWith(List(StaticMount("/legal", "/www-test", spaFallback = false)))
+    try
+      val index = get(harness.httpClient, s"${harness.baseUrl}/legal/")
+      index.statusCode() shouldBe 200
+      index.body() should include("www-index")
+
+      val missing = get(harness.httpClient, s"${harness.baseUrl}/legal/no/such")
+      missing.statusCode() shouldBe 404
+      missing.body() should include("www-not-found")
+    finally harness.shutdown()
+  }
+
   it should "lose to longer-prefix mounts regardless of declaration order" in {
     val harness = bootWith(
       List(

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -151,3 +151,41 @@ class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHe
       resp.headers().firstValue("Cache-Control").isPresent shouldBe false
     finally harness.shutdown()
   }
+
+  "a root mount with a diskDir" should "refuse a dot-segment path instead of resolving StaticFile.fromPath outside the mount root" in {
+    // Finding: bounded directory traversal via unnormalized `..` in pathInfo on
+    // disk-mode non-SPA static mounts (StaticFile.fromPath has no containment
+    // guard, unlike classpath mode's getResource).
+    val parent = Files.createTempDirectory("qod-www-disk-trav")
+    val root   = Files.createDirectory(parent.resolve("root"))
+    Files.writeString(root.resolve("index.html"), "<html><body>disk-index</body></html>")
+    Files.writeString(root.resolve("404.html"), "<html><body>disk-not-found</body></html>")
+    val outside = Files.createDirectory(parent.resolve("outside"))
+    Files.writeString(outside.resolve("index.html"), "escaped")
+    val harness = bootWith(
+      List(StaticMount("/", "/www-test", diskDir = Some(root.toString), spaFallback = false))
+    )
+    try
+      // Percent-encoded so java.net.URI / HttpClient send the ".." to the
+      // server verbatim instead of normalizing it away client-side.
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/%2e%2e/outside/")
+      resp.statusCode() shouldBe 404
+      resp.body() should include("disk-not-found")
+      resp.body() should not include "escaped"
+    finally harness.shutdown()
+  }
+
+  it should "resolve percent-encoded spaces in the directory-index candidate" in {
+    val dir = Files.createTempDirectory("qod-www-disk-space")
+    Files.writeString(dir.resolve("index.html"), "<html><body>disk-index</body></html>")
+    val ourTeam = Files.createDirectory(dir.resolve("our team"))
+    Files.writeString(ourTeam.resolve("index.html"), "www-space")
+    val harness = bootWith(
+      List(StaticMount("/", "/www-test", diskDir = Some(dir.toString), spaFallback = false))
+    )
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/our%20team/")
+      resp.statusCode() shouldBe 200
+      resp.body() should include("www-space")
+    finally harness.shutdown()
+  }

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -76,6 +76,11 @@ export interface PoolResponse {
   lockdown?: string;
   // The tri-state resolved against the global nodeLockdown.enabled flag.
   lockdownEffective?: boolean;
+  // Owner-declared demand scale-out band. Both absent on a fixed-size pool;
+  // when set, the manager autoscales the pool within [minNodes, maxNodes]
+  // and manual scales outside the band are refused.
+  minNodes?: number;
+  maxNodes?: number;
 }
 
 export interface SetPoolDisabledRequest {

--- a/website/docs/cli/admin.md
+++ b/website/docs/cli/admin.md
@@ -96,6 +96,10 @@ Once a tenant is live, these are the one-liners reached for most often:
 qod pool scale --tenant initech --db initech_analytics --pool bi \
   --target-size 4 --writeonly 1 --readonly 2 --dual 1
 
+# Let the pool size itself between 2 and 6 nodes with demand (omit both bounds to clear)
+qod pool set-autoscale --tenant initech --db initech_analytics --pool bi \
+  --min-nodes 2 --max-nodes 6
+
 # Pull one misbehaving node out of routing rotation without stopping it
 qod node quarantine --tenant initech --db initech_analytics --pool bi --node-id <NODE_ID>
 
@@ -106,4 +110,4 @@ qod maintenance run --tenant initech --db initech_analytics
 qod audit list --tenant initech --limit 20
 ```
 
-See the [Command reference](/cli/reference) for every noun and verb, including federation, manifest export/import, and time-travel catalog browsing.
+See the [Command reference](/cli/reference) for every noun and verb, including federation, manifest export/import, and time-travel catalog browsing, and [Autoscaling pools](/operating/autoscaling) for what the band does once it is set.

--- a/website/docs/cli/reference.md
+++ b/website/docs/cli/reference.md
@@ -46,6 +46,7 @@ Purposes below are one line each; run `qod <noun> <verb> --help` for the full fl
 | `qod pool stop` | Stop a pool's nodes. |
 | `qod pool delete` | Delete a pool. |
 | `qod pool set-disabled` | Enable or disable a pool. |
+| `qod pool set-autoscale` | Set or clear a pool's autoscale band (omit both bounds to clear). |
 | `qod pool set-resources` | Set CPU/memory requests for a pool's nodes. |
 | `qod pool set-pod-template` | Set the Kubernetes pod template YAML for a pool. |
 

--- a/website/docs/operating/autoscaling.md
+++ b/website/docs/operating/autoscaling.md
@@ -1,0 +1,164 @@
+---
+id: autoscaling
+title: Autoscaling pools
+---
+
+A pool has a fixed number of nodes until its owner declares an **autoscale band**: a minimum and a maximum node count. Inside that band the manager adds read nodes when the pool is busy and removes them when it goes quiet, without anyone calling `pool/scale`. Outside the band nothing happens: the band is the whole permission, and a pool that has none never moves on its own.
+
+This page covers declaring a band, the load signal behind the decisions, the timing rules, and how the band interacts with suspend and resume. For roles, sizing, and manual scaling see [Pools and cohorts](/operating/pools-cohorts).
+
+Autoscaling behaves identically on both deployment shapes. On the local backend the added nodes are child processes of the manager (a single container grows and shrinks in place); on Kubernetes they are node pods. Nothing about the feature is Kubernetes-only.
+
+## The band
+
+| Field | Meaning |
+|---|---|
+| `minNodes` | The floor. The pool never shrinks below it, and it is the size the pool returns to when idle. |
+| `maxNodes` | The ceiling. The pool never grows past it, whatever the load. |
+
+Both bounds are set together or not at all. Anyone who can manage the pool can set them: at creation time on `POST /api/pool/create`, or later with `POST /api/pool/setAutoscale`. Omitting both bounds on `setAutoscale` clears the band and returns the pool to a fixed size.
+
+Setting `minNodes` equal to `maxNodes` is legal and means "hold exactly this size, never scale". It is the per-pool way to freeze a pool without giving up the band: the sweep can move the pool neither up nor down, and manual scaling is constrained to that one size. Use it when you want the size pinned on the record; clear the band instead when you want manual scaling free again.
+
+Five rules are enforced when a band is declared, each returning `400 invalid_band`:
+
+1. `1 <= minNodes <= maxNodes`. Equal bounds pin the pool at that size.
+2. `maxNodes` may not exceed `autoscale.hardCap` (default 16), the manager-wide ceiling an operator sets once.
+3. `minNodes` must cover the pool's write-capable nodes (`writeonly + dual`). Scaling only ever touches read nodes, so the floor has to leave room for the writers.
+4. The pool's current size must lie inside the band. A stopped pool has size 0, which is outside every band, so scale it up first and then declare the band.
+5. A pool with authored [cohorts](/operating/pools-cohorts) cannot be elastic. Scaling rewrites the role distribution, which clears cohorts, so the two cannot be declared together.
+
+Setting a band moves no nodes. The next sweep converges the pool.
+
+### When to use one
+
+Declare a band when the pool's load is bursty and you would otherwise size it for the peak: a BI pool that is busy during business hours, a pool behind a scheduled ETL window, a shared analytics pool with an unpredictable number of concurrent dashboards. Set `minNodes` to the size that carries the quiet baseline (including your write nodes) and `maxNodes` to what you are willing to pay for at peak.
+
+Leave the band off for pools whose size is a deliberate constant: single-node development pools, pools pinned to specific hardware through cohorts, and pools whose cost must not vary. If you want that constant enforced rather than merely conventional, declare the band with `minNodes == maxNodes` instead of omitting it.
+
+## The load signal
+
+Every statement the edge serves is recorded against its pool with its duration, accumulated into per-pool one-minute buckets in memory. Each manager replica flushes its own closed buckets into the `qodstate_pool_load` table (adding to whatever is already there for that minute), because a replica only sees the statements it served itself. Buckets are purged after an hour.
+
+From that table the manager estimates the pool's **utilization** over a five-minute window:
+
+- **Demand** is the average concurrency implied by the work done: the sum of statement durations in the window divided by the length of the window. Five minutes of wall clock carrying ten minutes of statement time means an average of two statements in flight.
+- **Capacity** is the sum of `maxConcurrentPerNode` over the pool's routable read-capable nodes (`readonly` and `dual`, healthy and not draining). A node with no cap set (`0`, meaning unbounded) counts as `autoscale.assumedConcurrencyPerNode`, 4 by default.
+- **Utilization** is demand divided by capacity.
+
+If capacity is zero, because no read-capable node is currently routable, utilization is unknown and no decision is taken for that pool on that sweep. Guessing there would be the one case where a wrong guess cannot be corrected.
+
+Decisions are made off the pool's *desired* role distribution, not a live node census, so a node that is briefly missing while it restarts does not read as a shortfall and trigger a scale-out.
+
+## Watermarks, streaks, and cooldowns
+
+A sweep runs every `autoscale.sweepSeconds` (60 by default). In a manager cluster only the HA leader decides and acts; every replica still flushes its buckets.
+
+| Direction | Trigger | Consecutive sweeps needed | Cooldown after any action |
+|---|---|---|---|
+| Scale out (add one `readonly` node) | utilization at or above `highWatermark` (0.8) | `outStreak`, 2 | `scaleOutCooldownSec`, 180s |
+| Scale in (remove one `readonly` node) | utilization at or below `lowWatermark` (0.3) | `inStreak`, 10 | `scaleInCooldownSec`, 600s |
+
+Four independent brakes keep the pool from oscillating: the gap between the two watermarks (nothing at all happens between 0.3 and 0.8), the streak requirement, the per-pool cooldown, and a step size of exactly one node per action. Any sweep that does not confirm the trend resets the streak to zero.
+
+The asymmetry is deliberate. Scaling out is cheap and reversible, and a queue that is already backing up is not helped by waiting, so two sweeps of sustained pressure (about two minutes) is enough. Scaling in is disruptive and easy to regret: a node is a warm cache, and reclaiming it during a lull only to need it back three minutes later is worse than keeping it. Ten sweeps below the low watermark (about ten minutes) plus a ten-minute cooldown means a pool sheds nodes slowly, one at a time.
+
+Two invariants bound scale-in beyond `minNodes`:
+
+- Only `readonly` nodes are ever removed. `writeonly` and `dual` counts are invariant, so write capacity never changes underneath you.
+- The last read-capable node is never removed. A pool with no `readonly` node left, or with only one reader remaining, is not scaled in even when the arithmetic would allow it, because a pool that cannot serve a SELECT can no longer report the capacity it would need to recover.
+
+If a scale action fails three times in a row for one pool, the pool is skipped for `failureBackoffSweeps` sweeps (5 by default) so a broken pool does not retry itself in a loop. Any success resets the counter.
+
+## Interaction with suspend and resume
+
+Autoscaling never touches the zero boundary. Scale-in stops at `minNodes`; going to zero is the job of pool suspension, which keeps the role distribution and wakes the pool on the next FlightSQL statement.
+
+The two features stack into a staircase for an idle pool:
+
+1. Peak: the pool has grown toward `maxNodes` under load.
+2. Load drops: scale-in walks it down one node per action until it sits at `minNodes`.
+3. The pool stays idle: a suspend policy scales it to zero, keeping its role distribution.
+4. A statement arrives: the pool resumes at `minNodes` and serves the query after the wake.
+
+Steps 1 and 2 are this feature. Step 3 is a policy decision, and the automatic idle-suspend sweep ships in the hosted service; in a self-managed deployment you suspend and resume explicitly through `POST /api/pool/suspend` and `POST /api/pool/resume`, or leave the pool sitting at `minNodes`.
+
+Resuming a pool starts a scale-out cooldown. The burst of queries that arrives right after a wake is not evidence of sustained demand, and the pool's baseline nodes have not warmed their caches yet, so the manager gives them time before considering the pool overloaded.
+
+## Manual scaling and `outside_band`
+
+`POST /api/pool/scale` on a pool that has a band refuses a `targetSize` outside it:
+
+```json
+{"code":"outside_band",
+ "message":"targetSize 8 is outside the autoscale band [2, 6]; adjust the band first via pool/setAutoscale"}
+```
+
+This is not a permission problem. A manual scale outside the band would simply be undone by the next sweep, so the manager refuses it and points at the setting that actually decides the range. Widen the band (or clear it) first, then scale. Inside the band, manual scaling works exactly as before; the next sweep takes over from wherever you left the pool.
+
+## Observability
+
+Every action taken by the sweep leaves three traces:
+
+- One manager log line, for example `autoscale: acme/acme_sales/bi out 2 -> 3 util=0.91`. Failures log a warning with the error and the backoff decision.
+- One [audit log](/administration/audit-log) row with actor `autoscale`, action `pool.scale`, and detail carrying the direction, target size, and the utilization that triggered it.
+- One `PoolScaled` manager event carrying `fromSize`, `toSize`, and the reason, for any module listening on the SPI.
+
+Autoscale actions go through the same mutation gate as a human-driven scale, so where quotas apply they apply here too: an action that would exceed a tenant's node quota is refused and recorded as a failure.
+
+## Configuration
+
+Global settings live under `quack-on-demand.autoscale`. They apply to every pool; the per-pool decision is the band. Every setting below is inert until at least one pool declares a band.
+
+| Key | Env var | Default | Meaning |
+|---|---|---|---|
+| `enabled` | `QOD_AUTOSCALE_ENABLED` | `true` | Manager-wide kill switch for the sweep. Bands stay recorded and validated; they are simply not acted on. |
+| `sweepSeconds` | `QOD_AUTOSCALE_SWEEP_SEC` | `60` | Sweep interval, clamped to a 30s floor. |
+| `windowMinutes` | `QOD_AUTOSCALE_WINDOW_MINUTES` | `5` | Length of the load window used for the utilization estimate. |
+| `highWatermark` | `QOD_AUTOSCALE_HIGH_WATERMARK` | `0.8` | Utilization at or above which scale-out is considered. |
+| `lowWatermark` | `QOD_AUTOSCALE_LOW_WATERMARK` | `0.3` | Utilization at or below which scale-in is considered. Must be below `highWatermark`. |
+| `outStreak` | `QOD_AUTOSCALE_OUT_STREAK` | `2` | Consecutive sweeps above the high watermark before a node is added. |
+| `inStreak` | `QOD_AUTOSCALE_IN_STREAK` | `10` | Consecutive sweeps below the low watermark before a node is removed. |
+| `scaleOutCooldownSec` | `QOD_AUTOSCALE_OUT_COOLDOWN_SEC` | `180` | Per-pool quiet period after any action, or a resume, before scaling out. |
+| `scaleInCooldownSec` | `QOD_AUTOSCALE_IN_COOLDOWN_SEC` | `600` | Per-pool quiet period after any action before scaling in. |
+| `assumedConcurrencyPerNode` | `QOD_AUTOSCALE_ASSUMED_CONCURRENCY` | `4` | Capacity credited to a node with no `maxConcurrentPerNode` cap. |
+| `hardCap` | `QOD_AUTOSCALE_HARD_CAP` | `16` | Manager-wide ceiling on any pool's `maxNodes`. |
+| `failureBackoffSweeps` | `QOD_AUTOSCALE_FAILURE_BACKOFF_SWEEPS` | `5` | Sweeps to skip a pool after three consecutive failed actions. |
+
+`enabled = false` is the operator-wide brake, for a manager where elasticity has to stop moving right now regardless of what pool owners declared. Stopping a *single* pool is a per-pool decision instead: set `minNodes == maxNodes` to hold it at its current size, or clear the band to take it out of the sweep entirely. See the [Configuration reference](/reference/configuration) for the full list of keys.
+
+## Worked example
+
+A BI pool that needs one writer at all times, one reader at the quiet baseline, and up to five readers at peak. The floor is 2 (the writer plus one reader) and the ceiling is 6.
+
+```bash
+# Create the pool at its baseline size with the band declared
+curl -sS -X POST http://localhost:20900/api/pool/create \
+  -H "X-API-Key: $QOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","tenantDb":"acme_sales","pool":"bi","size":2,
+       "roleDistribution":{"writeonly":1,"readonly":1,"dual":0},
+       "minNodes":2,"maxNodes":6}'
+
+# Widen the ceiling later
+curl -sS -X POST http://localhost:20900/api/pool/setAutoscale \
+  -H "X-API-Key: $QOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","tenantDb":"acme_sales","pool":"bi","minNodes":2,"maxNodes":8}'
+
+# Clear the band: omit both bounds. The pool keeps its current size, fixed.
+curl -sS -X POST http://localhost:20900/api/pool/setAutoscale \
+  -H "X-API-Key: $QOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","tenantDb":"acme_sales","pool":"bi"}'
+```
+
+The same three operations with the [qod CLI](/cli/):
+
+```bash
+qod pool create --tenant acme --db acme_sales --pool bi --size 2 \
+  --writeonly 1 --readonly 1 --min-nodes 2 --max-nodes 6
+
+qod pool set-autoscale --tenant acme --db acme_sales --pool bi --min-nodes 2 --max-nodes 8
+
+qod pool set-autoscale --tenant acme --db acme_sales --pool bi
+```
+
+`qod pool list` reports the band alongside the pool's size, so you can see at a glance which pools are elastic and where they currently sit inside their range.

--- a/website/docs/operating/pools-cohorts.md
+++ b/website/docs/operating/pools-cohorts.md
@@ -38,6 +38,7 @@ qod pool create --tenant acme --db acme_sales --pool bi --size 3 \
 | `idleTimeoutSec` | `-1` | Per-pool idle-timeout setting, persisted on the pool. `-1` means unset. It is recorded on `qodstate_pool` and surfaced back on reads; no automatic idle-shutdown loop acts on it today. |
 | `maxConcurrentPerNode` | `0` | Per-node concurrency cap used for capacity-aware routing. `0` means unbounded. |
 | `cohorts` | `[]` | Optional Kubernetes placement plan (see below). Empty schedules every node with no constraint. |
+| `minNodes` / `maxNodes` | unset | Optional [autoscale band](/operating/autoscaling). Set both or neither; when set, the pool sizes itself within those bounds. Cannot be combined with `cohorts`. |
 | `disabled` | `false` | When true the pool is spawned warm but the edge rejects fresh handshakes until it is enabled. |
 
 The pool inherits its metastore (Postgres connection and data path) from the tenant-db; you do not pass storage config on `pool/create`.
@@ -63,6 +64,8 @@ qod pool stop --tenant acme --db acme_sales --pool bi
 ```
 
 A graceful stop (no `--force`) drains in-flight statements before terminating nodes. `--force` terminates immediately. The same `--force` flag applies when `scale` shrinks a pool.
+
+A pool can also size itself: declare a `minNodes`/`maxNodes` band and the manager adds and removes read nodes with demand, within those bounds. See [Autoscaling pools](/operating/autoscaling). A pool with a band refuses a manual `scale` outside it.
 
 ## Node pod sizing (Kubernetes)
 

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -115,6 +115,23 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | `quack-on-demand.auth.management.oidc.clientSecret` | `QOD_MGMT_OIDC_CLIENT_SECRET` | `***` | yes | OIDC client secret for admin-UI SSO (system scope). |
 | `quack-on-demand.auth.management.oidc.scopes` | `QOD_MGMT_OIDC_SCOPES` | `openid email profile` |  | OIDC scopes requested for admin-UI SSO. Default 'openid email profile'. |
 
+## `quack-on-demand.autoscale`
+
+| Key | Env var | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `quack-on-demand.autoscale.enabled` | `QOD_AUTOSCALE_ENABLED` | `true` |  | Global kill switch for the demand scale-out sweep. |
+| `quack-on-demand.autoscale.sweepSeconds` | `QOD_AUTOSCALE_SWEEP_SEC` | `60` |  | Sweep interval in seconds; clamped to a 30s floor. |
+| `quack-on-demand.autoscale.windowMinutes` | `QOD_AUTOSCALE_WINDOW_MINUTES` | `5` |  | Load window W for the Little's-law concurrency estimate. |
+| `quack-on-demand.autoscale.highWatermark` | `QOD_AUTOSCALE_HIGH_WATERMARK` | `0.8` |  | Scale-out utilization threshold. |
+| `quack-on-demand.autoscale.lowWatermark` | `QOD_AUTOSCALE_LOW_WATERMARK` | `0.3` |  | Scale-in utilization threshold; must be &lt; highWatermark. |
+| `quack-on-demand.autoscale.outStreak` | `QOD_AUTOSCALE_OUT_STREAK` | `2` |  | Consecutive sweeps above highWatermark before adding a reader. |
+| `quack-on-demand.autoscale.inStreak` | `QOD_AUTOSCALE_IN_STREAK` | `10` |  | Consecutive sweeps below lowWatermark before removing a reader. |
+| `quack-on-demand.autoscale.scaleOutCooldownSec` | `QOD_AUTOSCALE_OUT_COOLDOWN_SEC` | `180` |  | Per-pool cooldown after any scale action or resume before scaling out. |
+| `quack-on-demand.autoscale.scaleInCooldownSec` | `QOD_AUTOSCALE_IN_COOLDOWN_SEC` | `600` |  | Per-pool cooldown after any scale action before scaling in. |
+| `quack-on-demand.autoscale.assumedConcurrencyPerNode` | `QOD_AUTOSCALE_ASSUMED_CONCURRENCY` | `4` |  | Capacity contribution of a node with maxConcurrent = 0 (unlimited). |
+| `quack-on-demand.autoscale.hardCap` | `QOD_AUTOSCALE_HARD_CAP` | `16` |  | Upper bound on maxNodes at validation time; a typo guard, not a quota. |
+| `quack-on-demand.autoscale.failureBackoffSweeps` | `QOD_AUTOSCALE_FAILURE_BACKOFF_SWEEPS` | `5` |  | Sweeps to skip a pool after 3 consecutive scale failures. |
+
 ## `quack-on-demand.catalog`
 
 | Key | Env var | Default | Sensitive | Description |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -56,6 +56,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'operating/tenants-databases',
             'operating/pools-cohorts',
+            'operating/autoscaling',
             'operating/federation',
           ],
         },


### PR DESCRIPTION
## Summary

Two independent changes, one commit each:

**`fix(node)` 67f470d - kind-aware metastore resolution.** Two user-reported failures shared one root cause: `effectiveMetastoreFor` fell through to a raw `defaultMetastore ++ td.metastore` merge for non-DuckLake kinds. A duckdb-file tenant-db with its path in the `td.dataPath` field inherited the default DuckLake directory (node ATTACH failed "Is a directory"); a memory tenant-db inherited the default `dbName`/`schemaName` so the health probe ran CREATE SCHEMA against a nonexistent catalog and the node stayed permanently unroutable. Now: duckdb-file honors `td.dataPath` and defaults `dbName` to the tenant-db name; memory drops `dataPath` and probes the built-in `memory` catalog; DuckLake branch byte-identical. Both backends stop re-overlaying defaults into the node env (`NodeSpec.metastore` authoritative), and the spawn scripts mkdir per kind (parent dir only for duckdb-file file paths). CLI-bundled script copies synced.

**`feat(manager)` e5f2771 - demand scale-out.** Pools declare an optional `minNodes`/`maxNodes` band (`pool/create`, new `POST /api/pool/setAutoscale`, manifest, CLI `--min-nodes/--max-nodes` + `qod pool set-autoscale`). A leader-gated sweep grows readers under sustained load and sheds them when quiet, never leaving the band:

- Load signal: `StatementExecuted` durations -> per-pool 1-minute buckets (`PoolLoadStats`), flushed upsert-add by every replica into new `qodstate_pool_load` (changesets 0025/0026), purged hourly; utilization = Little's-law estimate over routable read capacity.
- Decisions: pure core (`Autoscale.decide`) with four hysteresis layers (watermarks 0.8/0.3, streaks 2/10, cooldowns 180/600s, step of one reader). Writers never touched; scale-in never removes the last read-capable node; resume starts a cooldown; 3 consecutive failures back a pool off. Actions go through the quota mutation gate (`scale(reason = "autoscale")`) and emit the new `ManagerEvent.PoolScaled`.
- `minNodes == maxNodes` is a legal band that locks the size (manual `pool/scale` outside any band is refused with `outside_band`). `QOD_AUTOSCALE_ENABLED` (default true) is the manager-wide switch and also gates the load-stats sink, whose sole drainer is the sweep.
- Docs: CLAUDE.md, operator runbook recipe, new `website/docs/operating/autoscaling.md`, regenerated config reference and OpenAPI contract with CLI parity gates green.

## Test plan

- Full suite: 2137 tests, 2135 green; the 2 failures are environmental on the dev machine (a stale live manager on :20900 broke `EndToEndSmokeSpec`; `DemoDifferentiatorSpec` is known machine-broken there). Feature suites: AutoscaleSpec 16, AutoscaleWiringSpec 9, AutoscaleBandSpec 8, AutoscaleConfigSpec 11, PoolLoadStatsSpec 4, plus store/handler/supervisor/manifest coverage.
- CLI: 247 passed / 1 skipped incl. REST-parity and bundled-script gates; `OpenApiFreshnessSpec` green.
- Bugfix pinned at three seams: `effectiveMetastoreFor` unit cases, `NodeSpec` capture at the supervisor seam, and the child env at `LocalQuackBackendSpec` (red-then-green against the restored overlay).

## Known follow-ups (non-blocking, tracked)

- `AutoscaleWiringSupport.views` builder has no direct test (logic review-verified).
- Pre-existing HA bug found during review, NOT fixed here: `MaintenanceWiring`'s leader gate is latched at boot (same class as one fixed in this PR's sweep).
- `stopPool` emits `PoolScaled(from, 0, "manual")` on running pools only; manifest import bypasses `autoscale.hardCap` by design; bands are accepted on duckdb-file/memory kinds where extra readers do not share writer data.
- `spawn-quack-node.ps1` changes are parse-unverified (no pwsh on the dev machine).
- qod-hosted must use a catch-all on `ManagerEvent` matches before consuming this core version (new `PoolScaled` case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
