### PR TITLE
Re-evaluate the maintenance leader gate per tick; pin the zero-module /ui redirect

### DIFF
--- a/src/main/scala/ai/starlake/quack/boot/MaintenanceWiring.scala
+++ b/src/main/scala/ai/starlake/quack/boot/MaintenanceWiring.scala
@@ -121,35 +121,44 @@ final class MaintenanceWiring(
     if maintenance.enabled then scheduler.start
     else IO.unit.start
 
-  /** Drain loop: while leader and below maxConcurrent in-flight, claim queued runs and fork each
-    * execution under the tenant-db's __maint advisory lock so two replicas (or a replica and a
-    * stray retry) never run the same lake at once. The tick keeps claiming until the queue is empty
-    * or capacity is reached, so tickSec only spaces empty polls.
+  private val inFlight = new java.util.concurrent.atomic.AtomicInteger(0)
+
+  /** One drain pass: while leader and below maxConcurrent in-flight, claim queued runs and fork
+    * each execution under the tenant-db's __maint advisory lock so two replicas (or a replica and a
+    * stray retry) never run the same lake at once. Keeps claiming until the queue is empty or
+    * capacity is reached, so `tickSec` (in [[drainFiber]]) only spaces empty polls.
+    *
+    * IO.defer around the leader check: `drainFiber` binds this to a single IO value once (see its
+    * `foreverM`), so the leadership (and in-flight) branch must be re-evaluated on every run rather
+    * than baked in at construction time -- otherwise a replica that boots before winning the
+    * advisory lock latches "not leader" forever, and one that boots as leader keeps draining after
+    * demotion. Mirrors [[AutoscaleWiring.sweep]].
     */
-  def drainFiber: IO[FiberIO[Unit]] =
-    val inFlight            = new java.util.concurrent.atomic.AtomicInteger(0)
-    def drainTick: IO[Unit] =
-      if !isLeader() then IO.unit
-      else if inFlight.get() >= maintenance.maxConcurrent then IO.unit
-      else
-        IO.blocking(store.claimQueuedMaintenanceRun()).flatMap {
-          case None      => IO.unit
-          case Some(run) =>
-            inFlight.incrementAndGet()
-            poolLocks
-              .withLock(PoolKey(run.tenant, run.tenantDb, "__maint")) {
-                runner.executeRun(run)
-              }
-              .guarantee(IO.delay(inFlight.decrementAndGet()).void)
-              .handleErrorWith(t =>
-                IO.delay(
-                  logger.error(
-                    s"maintenance run ${run.id} (${run.tenant}/${run.tenantDb}) failed: ${t.getMessage}"
-                  )
+  private[boot] def drainTick: IO[Unit] = IO.defer {
+    if !isLeader() then IO.unit
+    else if inFlight.get() >= maintenance.maxConcurrent then IO.unit
+    else
+      IO.blocking(store.claimQueuedMaintenanceRun()).flatMap {
+        case None      => IO.unit
+        case Some(run) =>
+          inFlight.incrementAndGet()
+          poolLocks
+            .withLock(PoolKey(run.tenant, run.tenantDb, "__maint")) {
+              runner.executeRun(run)
+            }
+            .guarantee(IO.delay(inFlight.decrementAndGet()).void)
+            .handleErrorWith(t =>
+              IO.delay(
+                logger.error(
+                  s"maintenance run ${run.id} (${run.tenant}/${run.tenantDb}) failed: ${t.getMessage}"
                 )
               )
-              .start *> drainTick
-        }
+            )
+            .start *> drainTick
+      }
+  }
+
+  def drainFiber: IO[FiberIO[Unit]] =
     if maintenance.enabled then
       (drainTick
         .handleErrorWith(e =>

--- a/src/test/scala/ai/starlake/quack/boot/MaintenanceWiringSpec.scala
+++ b/src/test/scala/ai/starlake/quack/boot/MaintenanceWiringSpec.scala
@@ -1,0 +1,116 @@
+package ai.starlake.quack.boot
+
+import ai.starlake.quack.MaintenanceConfig
+import ai.starlake.quack.edge.adapter.{NodeLoadTracker, QuackHttpAdapter, QuackHttpClient}
+import ai.starlake.quack.model.{NodeSpec, PoolKey, RunningNode}
+import ai.starlake.quack.observability.metrics.MaintenanceMetrics
+import ai.starlake.quack.ondemand.PoolSupervisor
+import ai.starlake.quack.ondemand.ha.PoolLocker
+import ai.starlake.quack.ondemand.runtime.QuackBackend
+import ai.starlake.quack.ondemand.state.{
+  InMemoryControlPlaneStore,
+  LiquibaseRunner,
+  PostgresControlPlaneStore
+}
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import ai.starlake.quack.ondemand.telemetry.AuditRecorder
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.apache.arrow.memory.RootAllocator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+/** Regression coverage for the same construction-time leader-gate latching bug fixed in
+  * [[AutoscaleWiringSpec]]'s "re-evaluate the leader gate on every run" case: `drainFiber` used to
+  * build its forever loop from a `def drainTick` called exactly ONCE (to feed `.foreverM`), so the
+  * `if !isLeader()` head was baked in at fiber construction instead of being re-checked every tick.
+  * A replica that boots as follower and later wins leadership would never drain the maintenance
+  * queue; one that boots as leader would keep draining after demotion.
+  *
+  * Needs a real Postgres (via [[TestPostgres]]) because [[MaintenanceWiring]] takes a concrete
+  * [[PostgresControlPlaneStore]] directly (not the
+  * [[ai.starlake.quack.ondemand.state.ControlPlaneStore]] trait) for `drainTick`'s
+  * `claimQueuedMaintenanceRun` call. Every other collaborator (`PoolSupervisor`, `QuackBackend`,
+  * `QuackHttpAdapter`, `PoolLocker`) is a minimal stub: with no pool registered for the run's
+  * tenant/tenant-db, `PoolSupervisor.maintenanceNodeSpec` returns `None`, so
+  * `MaintenanceRunner.executeRun` short-circuits to "node spawn failed" without ever touching the
+  * backend/adapter/catalogReader stubs -- the test only needs the DB-level claim (queued ->
+  * running), which happens synchronously inside `drainTick` before any of that runs.
+  */
+class MaintenanceWiringSpec extends AnyFlatSpec with Matchers:
+
+  TestPostgres.dropStrayTestDatabases("qodmw")
+
+  private val stubBackend: QuackBackend = new QuackBackend:
+    def start(spec: NodeSpec): IO[RunningNode]       = IO.raiseError(new RuntimeException("unused"))
+    def stop(key: PoolKey, nodeId: String): IO[Unit] = IO.unit
+    def isAlive(nodeId: String): Boolean             = false
+    def discoverExisting(): IO[List[RunningNode]]    = IO.pure(Nil)
+    def cleanup(): IO[Unit]                          = IO.unit
+
+  /** Fresh DB + migrated schema, a fully-stubbed [[MaintenanceWiring]] wired against it. Mirrors
+    * [[ai.starlake.quack.ondemand.state.MaintenanceStoreSpec]]'s live-Postgres fixture.
+    */
+  private def withWiring(cfg: MaintenanceConfig, isLeaderFn: () => Boolean)(
+      test: (MaintenanceWiring, PostgresControlPlaneStore) => Unit
+  ): Unit =
+    if !TestPostgres.reachable then
+      cancel(
+        s"local Postgres not reachable at ${TestPostgres.pgHost}:${TestPostgres.pgPort} " +
+          "(SL_TEST_PG_* envs); skipping"
+      )
+    val dbName = s"qodmw_test_${System.nanoTime()}"
+    TestPostgres.psql("postgres", s"""CREATE DATABASE "$dbName"""")
+    try
+      val url = TestPostgres.dbUrl(dbName)
+      new LiquibaseRunner(url, TestPostgres.pgUser, TestPostgres.pgPass).run()
+      val store = new PostgresControlPlaneStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      val sup   = new PoolSupervisor(
+        backend = stubBackend,
+        tracker = new NodeLoadTracker(),
+        store = new InMemoryControlPlaneStore()
+      )
+      val adapter = new QuackHttpAdapter(
+        new QuackHttpClient(new RootAllocator(), nativeClient = false, nodeDisableSsl = true),
+        new NodeLoadTracker()
+      )
+      val wiring = new MaintenanceWiring(
+        store = store,
+        sup = sup,
+        backend = stubBackend,
+        adapter = adapter,
+        poolLocks = PoolLocker.noop,
+        catalogReader = (_, _) =>
+          throw new NotImplementedError("not exercised: no node in this fixture"),
+        maintenance = cfg,
+        isLeader = isLeaderFn,
+        audit = AuditRecorder.noop,
+        metrics = MaintenanceMetrics.noop
+      )
+      try test(wiring, store)
+      finally store.close()
+    finally Try(TestPostgres.dropDatabase(dbName))
+
+  "drainTick" should "re-evaluate the leader gate on every run, not just once when it is bound" in {
+    var leader = false
+    withWiring(MaintenanceConfig(), () => leader) { (w, store) =>
+      store.enqueueMaintenanceRun("acme", "acme_db", "tenantdb", "manual", None)
+
+      val tick = w.drainTick // bind ONCE, like AutoscaleWiringSpec's `val s = w.sweep()`
+
+      tick.unsafeRunSync() // not leader yet: must not claim
+      store
+        .listMaintenanceRuns("acme", "acme_db", 10, None)
+        .head
+        .status shouldBe "queued"
+
+      leader = true
+      tick.unsafeRunSync() // SAME bound IO, now leader: must claim fresh, not stay latched
+      store
+        .listMaintenanceRuns("acme", "acme_db", 10, None)
+        .head
+        .status should not be "queued"
+    }
+  }

--- a/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StaticMountModesSpec.scala
@@ -98,6 +98,15 @@ class StaticMountModesSpec extends AnyFlatSpec with Matchers with SecurityHttpHe
     finally harness.shutdown()
   }
 
+  "a zero-module boot (no hosted jar, no static mounts at all)" should "redirect the home page to /ui/" in {
+    val harness = bootWith(Nil)
+    try
+      val resp = get(harness.httpClient, s"${harness.baseUrl}/")
+      resp.statusCode() shouldBe 302
+      resp.headers().firstValue("Location").get() shouldBe "/ui/"
+    finally harness.shutdown()
+  }
+
   "the bare root with no root mount" should "still redirect to /ui/" in {
     val harness = bootWith(List(StaticMount("/portal", "/portal-test")))
     try


### PR DESCRIPTION
## Summary

Two small hardening changes found during the demand scale-out review:

- **`fix(manager)`: re-evaluate the maintenance drain leader gate on every tick.** `drainFiber` evaluated its tick once at fiber construction (cats-effect `*>` is by-value), latching the `isLeader()` check at the boot-time leadership value: under HA, a replica that booted as follower and later won leadership never drained maintenance runs, and one that booted as leader kept draining after demotion. Non-HA was unaffected, which is why it went unnoticed. Fix applies the same `IO.defer` shape already used by `AutoscaleWiring.sweep()`, with a regression test that binds one tick IO and runs it across a leadership flip (new `MaintenanceWiringSpec`). `schedulerFiber` was audited and is already safe: its gate lives inside an `IO.blocking` thunk that re-runs per iteration.
- **`test(manager)`: pin the zero-module home-page redirect.** A manager booted with no module and no static mounts (the core-only deployment) must 302 the bare `/` to `/ui/`. The behavior existed; the exact zero-mount case is now asserted in `StaticMountModesSpec`, keeping the "core stores no hosted pages" contract observable.

## Test plan

- `MaintenanceWiringSpec` (new): leadership-flip regression red-then-green against the latched gate; 20/20 across MaintenanceWiringSpec + MaintenanceRunnerSpec + AutoscaleWiringSpec.
- `StaticMountModesSpec`: 14/14 including the new zero-module case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
