### PR TITLE
Managed object storage for tenant databases (QoD-provisioned data paths)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ The control plane lives in a dedicated Postgres database (`qod` by default) hold
 
 The legacy `file` mode (single JSON blob) was dropped 2026-06-12 along with the `stateStorage` and `statePath` config keys -- `PostgresControlPlaneStore` is always wired. Connections come from a HikariCP pool (size 20 on the control-plane store, 10 on `UserStore`); `close()` on the trait is called from the manager's shutdown hook.
 
+### Managed object storage (QoD-provisioned data paths)
+
+A DuckLake database can be created with `managedStorage: true` (REST `database/create`, CLI `qod database create --managed-storage`, admin UI storage mode "Managed (QoD-provisioned)") instead of a caller-supplied `dataPath`/`objectStore`. The manager then resolves `dataPath = s3://<bucket>/<tenant>_<dbname>-<id8>/` (`ManagedPrefix` in `ondemand/storage/`, `id8` = first 8 chars of the tenant-db surrogate id, so recreating a deleted name lands on a fresh empty prefix) and fills the database's `objectStore` map from the `quack-on-demand.managedObjectStore` config block (`QOD_MANAGED_STORE_ENABLED / _ENDPOINT / _REGION / _BUCKET / _ACCESS_KEY_ID / _SECRET_ACCESS_KEY / _URL_STYLE / _RETAIN_DAYS / _PURGE_SWEEP_SEC`, disabled by default), so every downstream mechanism (node `CREATE SECRET`, `SecretKeys` redaction, spawn env, manifest export) applies unchanged. `managedStorage` is exclusive with `dataPath`/`objectStore`, requires `kind=ducklake`, and 400s naming the env when the block is off; `database/update` has no `managedStorage` field, so there is no BYO-to-managed migration.
+
+Every managed create writes a tombstone row in `qodstate_managed_prefix` (Liquibase `0027`); `database/delete` stamps `deleted_at` + `purge_eligible_at` (`+retainDays`, or now with `purgeManagedData: true` / `--purge-managed-data`). `ManagedStoreWiring` (in `boot/`) sweeps due rows every `purgeSweepSec` (60s floor), HA-leader-gated inside `IO.defer`, listing and batch-deleting objects in bounded batches per prefix per tick and stamping `purged_at` when a listing comes back empty; the retained window doubles as the undrop window. The root bucket is created if missing by a boot probe that only ever WARNs. **The managed bucket must have versioning OFF**: on a versioned bucket deletes write delete markers, listings go empty, and the worker stamps a prefix purged while non-current versions keep billing.
+
 ### Pool suspend/resume (scale-to-zero)
 
 `qodstate_pool.suspended` marks a pool scaled to zero WITH its role

--- a/build.sbt
+++ b/build.sbt
@@ -179,6 +179,7 @@ lazy val root = (project in file("."))
       Dependencies.blobstoreS3,
       Dependencies.blobstoreGcs,
       Dependencies.blobstoreAzure,
+      Dependencies.awsS3,
       Dependencies.duckdbJdbc,
       Dependencies.micrometerCore,
       Dependencies.micrometerPrometheus,

--- a/cli/src/qod_cli/commands/database.py
+++ b/cli/src/qod_cli/commands/database.py
@@ -26,6 +26,7 @@ def list_(ctx: typer.Context, tenant: str = typer.Option(..., "--tenant")):
         "defaultDatabase": "--default-database",
         "defaultSchema": "--default-schema",
         "initSql": "--init-sql",
+        "managedStorage": "--managed-storage",
     },
 )
 def create(
@@ -39,6 +40,11 @@ def create(
     default_database: str = typer.Option(None, "--default-database"),
     default_schema: str = typer.Option(None, "--default-schema"),
     init_sql: str = typer.Option("", "--init-sql"),
+    managed_storage: bool = typer.Option(
+        False,
+        "--managed-storage",
+        help="Provision a managed data path (exclusive with --data-path/--object-store)",
+    ),
 ):
     body = {
         "tenant": tenant,
@@ -53,6 +59,8 @@ def create(
         body["defaultDatabase"] = default_database
     if default_schema is not None:
         body["defaultSchema"] = default_schema
+    if managed_storage:
+        body["managedStorage"] = True
     call(ctx, "POST", "/api/database/create", body=body)
 
 
@@ -95,6 +103,22 @@ def update(
 
 
 @app.command()
-@covers("POST", "/api/database/delete", {"tenant": "--tenant", "name": "--name"})
-def delete(ctx: typer.Context, tenant: str = typer.Option(..., "--tenant"), name: str = typer.Option(..., "--name")):
-    call(ctx, "POST", "/api/database/delete", body={"tenant": tenant, "name": name})
+@covers(
+    "POST",
+    "/api/database/delete",
+    {"tenant": "--tenant", "name": "--name", "purgeManagedData": "--purge-managed-data"},
+)
+def delete(
+    ctx: typer.Context,
+    tenant: str = typer.Option(..., "--tenant"),
+    name: str = typer.Option(..., "--name"),
+    purge_managed_data: bool = typer.Option(
+        False,
+        "--purge-managed-data",
+        help="Purge managed object storage immediately instead of after the retention window",
+    ),
+):
+    body = {"tenant": tenant, "name": name}
+    if purge_managed_data:
+        body["purgeManagedData"] = True
+    call(ctx, "POST", "/api/database/delete", body=body)

--- a/cli/tests/resources/openapi.yaml
+++ b/cli/tests/resources/openapi.yaml
@@ -6657,11 +6657,14 @@ components:
       required:
       - tenant
       - name
+      - purgeManagedData
       properties:
         tenant:
           type: string
         name:
           type: string
+        purgeManagedData:
+          type: boolean
     TenantDbRequest:
       title: TenantDbRequest
       type: object
@@ -6673,6 +6676,7 @@ components:
       - dataPath
       - objectStore
       - initSql
+      - managedStorage
       properties:
         tenant:
           type: string
@@ -6692,6 +6696,8 @@ components:
           type: string
         initSql:
           type: string
+        managedStorage:
+          type: boolean
     TenantDbResponse:
       title: TenantDbResponse
       type: object

--- a/cli/tests/test_commands_table.py
+++ b/cli/tests/test_commands_table.py
@@ -61,6 +61,22 @@ CASES = [
         },
     ),
     (
+        ["database", "create", "--tenant", "acme", "--name", "tpch1", "--managed-storage"],
+        "POST",
+        "/api/database/create",
+        {},
+        {
+            "tenant": "acme",
+            "name": "tpch1",
+            "kind": "ducklake",
+            "metastore": {},
+            "dataPath": "",
+            "objectStore": {},
+            "initSql": "",
+            "managedStorage": True,
+        },
+    ),
+    (
         ["database", "update", "--tenant", "acme", "--name", "tpch1", "--default-schema", "main"],
         "POST",
         "/api/database/update",
@@ -73,6 +89,13 @@ CASES = [
         "/api/database/delete",
         {},
         {"tenant": "acme", "name": "tpch1"},
+    ),
+    (
+        ["database", "delete", "--tenant", "acme", "--name", "tpch1", "--purge-managed-data"],
+        "POST",
+        "/api/database/delete",
+        {},
+        {"tenant": "acme", "name": "tpch1", "purgeManagedData": True},
     ),
     (["pool", "list"], "GET", "/api/pool/list", {}, None),
     (

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,10 @@ object Dependencies {
   val blobstoreGcs          = "com.github.fs2-blobstore" %% "gcs" % Versions.blobstore
   val blobstoreAzure        = "com.github.fs2-blobstore" %% "azure" % Versions.blobstore
 
+  // AWS SDK v2 S3 client (managed object storage) - explicit pin of the version
+  // fs2-blobstore's `s3` module already pulls in transitively.
+  val awsS3                 = "software.amazon.awssdk" % "s3" % Versions.awsSdk
+
   // DuckDB JDBC (for catalog resolver)
   val duckdbJdbc            = "org.duckdb" % "duckdb_jdbc" % Versions.duckdb
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,4 +29,5 @@ object Versions {
   val micrometer     = "1.13.6"
   val liquibase      = "4.29.2"
   val caffeine       = "3.1.8"
+  val awsSdk         = "2.42.21"
 }

--- a/skills/quack-on-demand/SKILL.md
+++ b/skills/quack-on-demand/SKILL.md
@@ -386,6 +386,109 @@ all, a separate pre-existing gap). Editing `objectStore` restarts the
 database's nodes so the new secret takes effect immediately; there is no
 in-place rotation on an already-running node.
 
+### Managed object storage (QoD provisions the bucket prefix)
+
+Instead of bringing a bucket, a `ducklake` database can ask QoD to carve its
+data path out of ONE operator-owned root bucket. Off by default; enable it on
+the manager with:
+
+```bash
+export QOD_MANAGED_STORE_ENABLED=true
+export QOD_MANAGED_STORE_ENDPOINT=http://seaweedfs:8333   # empty = AWS default resolution
+export QOD_MANAGED_STORE_REGION=us-east-1
+export QOD_MANAGED_STORE_BUCKET=qod-managed
+export QOD_MANAGED_STORE_ACCESS_KEY_ID=...
+export QOD_MANAGED_STORE_SECRET_ACCESS_KEY=...
+export QOD_MANAGED_STORE_URL_STYLE=path                   # path (S3-compatible) | vhost (AWS)
+export QOD_MANAGED_STORE_RETAIN_DAYS=7                    # retention after delete, 0 = immediate
+export QOD_MANAGED_STORE_PURGE_SWEEP_SEC=300              # purge worker cadence, 60s floor
+```
+
+**The root bucket must have versioning OFF.** On a versioned bucket a delete
+writes a delete marker instead of removing the object: the purge worker's next
+listing comes back empty, it stamps the prefix purged, and the non-current
+versions keep billing forever. Boot creates the bucket if missing; an
+unreachable store only WARNs (`managed object store unreachable`) and never
+blocks a managed create at the control plane - the create still succeeds, and
+the failure surfaces later, at node spawn/ATTACH against the missing bucket.
+In HA, replicas race that first create, so the losing ones can log one false
+"unreachable" WARN at first boot; it self-heals.
+
+```bash
+# Create a managed database. No dataPath, no objectStore: the server resolves
+# both. The response's dataPath is s3://<bucket>/<tenant>_<name>-<id8>/ where
+# id8 is the first 8 chars of the tenant-db surrogate id, so recreating a
+# deleted name always lands on a fresh empty prefix.
+curl -sS -X POST "http://localhost:20900/api/database/create" -H "X-API-Key: $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","name":"sales","kind":"ducklake","managedStorage":true}'
+
+# CLI equivalent
+qod database create --tenant acme --name sales --kind ducklake --managed-storage
+```
+
+400s, all actionable: managed storage not enabled on this deployment
+(`QOD_MANAGED_STORE_ENABLED`); `managedStorage` sent together with a
+`dataPath`/`objectStore` (one intent per call); `managedStorage` on a
+non-`ducklake` kind. `database/update` has NO `managedStorage` field: there is
+no BYO-to-managed (or managed-to-BYO) migration, recreate instead.
+
+- **Credential rotation**: a managed create snapshots the operator credential
+  (`QOD_MANAGED_STORE_SECRET_ACCESS_KEY`) into that database's own
+  `objectStore` at create time. Rotating the env var only affects *future*
+  managed creates; existing managed databases keep signing with the old key
+  and break at their next node respawn once it is revoked. Remediation today:
+  `database/update` each managed database's `objectStore` with the new
+  secret, then recycle its pools. Per-database credential minting is the
+  designed follow-up.
+
+```bash
+# Delete: tombstone now, objects purged after retainDays (7 by default).
+curl -sS -X POST "http://localhost:20900/api/database/delete" -H "X-API-Key: $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","name":"acme_sales"}'
+
+# Delete and make the storage purge-eligible immediately (the worker drains it
+# on its next sweep; the call itself still returns straight away).
+curl -sS -X POST "http://localhost:20900/api/database/delete" -H "X-API-Key: $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","name":"acme_sales","purgeManagedData":true}'
+
+qod database delete --tenant acme --name acme_sales --purge-managed-data
+```
+
+`purgeManagedData` on a BYO / default-path database is ignored with a WARN.
+Deleting the whole TENANT cascades tombstones with the normal retention window,
+never immediate.
+
+Inventory / audit the prefixes in the control-plane Postgres:
+
+```sql
+SELECT id, prefix, deleted_at, purge_eligible_at, purged_at
+FROM qodstate_managed_prefix
+ORDER BY created_at;
+```
+
+- `deleted_at IS NULL` - live database.
+- `deleted_at` set, `purged_at NULL` - retained; the objects are still there and
+  still billed. Until `purge_eligible_at`, this window doubles as the undrop
+  window (the data is recoverable by hand).
+- `purged_at` set - objects gone, row kept as the audit trail.
+
+The purge worker is HA-leader-gated, sweeps every `purgeSweepSec`, drains each
+due prefix in bounded list+delete batches (resuming across sweeps for large
+prefixes), isolates failures per prefix, and stamps `purged_at` only when a
+listing comes back empty. Grep the manager log for `managed purge:`.
+
+Two operator cautions:
+
+- **Changing `QOD_MANAGED_STORE_BUCKET` strands existing tombstones.** Rows
+  written under the old bucket no longer match the configured root, so the
+  worker logs `skipping <id>, prefix ... is not under ...` on every sweep and
+  the old bucket's objects leak. Purge or migrate before switching buckets.
+- **All managed databases share the operator credential.** Isolation between
+  tenants' managed data is prefix-by-convention, enforced by the per-db
+  `CREATE SECRET` scoped to that database's own `dataPath` plus per-pool
+  lockdown, not by store-level ACLs. Per-database credential minting is the
+  designed follow-up.
+
 ### Register a federated source
 
 ```bash

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -434,6 +434,29 @@ quack-on-demand {
     failureBackoffSweeps = 5
     failureBackoffSweeps = ${?QOD_AUTOSCALE_FAILURE_BACKOFF_SWEEPS}
   }
+
+  # Managed object storage: off by default. Managed database creates return 400
+  # until managedObjectStore.enabled is true.
+  managedObjectStore {
+    enabled = false
+    enabled = ${?QOD_MANAGED_STORE_ENABLED}
+    endpoint = ""
+    endpoint = ${?QOD_MANAGED_STORE_ENDPOINT}
+    region = "us-east-1"
+    region = ${?QOD_MANAGED_STORE_REGION}
+    bucket = "qod-managed"
+    bucket = ${?QOD_MANAGED_STORE_BUCKET}
+    accessKeyId = ""
+    accessKeyId = ${?QOD_MANAGED_STORE_ACCESS_KEY_ID}
+    secretAccessKey = ""
+    secretAccessKey = ${?QOD_MANAGED_STORE_SECRET_ACCESS_KEY}
+    urlStyle = "path"
+    urlStyle = ${?QOD_MANAGED_STORE_URL_STYLE}
+    retainDays = 7
+    retainDays = ${?QOD_MANAGED_STORE_RETAIN_DAYS}
+    purgeSweepSec = 300
+    purgeSweepSec = ${?QOD_MANAGED_STORE_PURGE_SWEEP_SEC}
+  }
 }
 
 quack-flightsql {

--- a/src/main/resources/db/changelog/0027-managed-prefix.yaml
+++ b/src/main/resources/db/changelog/0027-managed-prefix.yaml
@@ -1,0 +1,43 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0027-qodstate-managed-prefix
+      author: quack-on-demand
+      changes:
+        # Tombstone registry for managed-object-store prefixes (per spec):
+        # one row per tenant-db data-path prefix carved out of the shared
+        # bucket. deleted_at/purge_eligible_at are set together when the
+        # owning tenant-db is dropped; a sweep purges the underlying
+        # objects once purge_eligible_at elapses and stamps purged_at.
+        # Rows with deleted_at IS NULL are the live set.
+        - createTable:
+            tableName: qodstate_managed_prefix
+            columns:
+              - column:
+                  name: id
+                  type: TEXT
+                  constraints: { primaryKey: true, nullable: false }
+              - column:
+                  name: tenant
+                  type: TEXT
+                  constraints: { nullable: false }
+              - column:
+                  name: tenant_db_name
+                  type: TEXT
+                  constraints: { nullable: false }
+              - column:
+                  name: prefix
+                  type: TEXT
+                  constraints: { nullable: false }
+              - column:
+                  name: created_at
+                  type: TIMESTAMPTZ
+                  constraints: { nullable: false }
+              - column:
+                  name: deleted_at
+                  type: TIMESTAMPTZ
+              - column:
+                  name: purge_eligible_at
+                  type: TIMESTAMPTZ
+              - column:
+                  name: purged_at
+                  type: TIMESTAMPTZ

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -57,3 +57,5 @@ databaseChangeLog:
       file: db/changelog/0025-pool-autoscale-band.yaml
   - include:
       file: db/changelog/0026-pool-load.yaml
+  - include:
+      file: db/changelog/0027-managed-prefix.yaml

--- a/src/main/scala/ai/starlake/quack/Config.scala
+++ b/src/main/scala/ai/starlake/quack/Config.scala
@@ -470,6 +470,7 @@ final case class ManagerConfig(
     catalog: CatalogConfig = CatalogConfig(),
     routing: RoutingConfig = RoutingConfig(),
     autoscale: AutoscaleConfig = AutoscaleConfig(),
+    managedObjectStore: ManagedObjectStoreConfig = ManagedObjectStoreConfig(),
     @field @ConfigField(
       envVar = "QOD_SESSION_IDLE_TTL_SEC",
       description =
@@ -585,6 +586,68 @@ final case class AutoscaleConfig(
   require(hardCap >= 1, "autoscale: hardCap must be >= 1")
   def sweepInterval: scala.concurrent.duration.FiniteDuration =
     scala.concurrent.duration.DurationInt(math.max(30, sweepSeconds)).seconds
+
+/** Managed object storage: one operator root bucket, one prefix per tenant-db incarnation. Fills
+  * the database's objectStore from these credentials at managed create; a background worker purges
+  * deleted prefixes after retainDays. See
+  * docs/superpowers/specs/2026-08-13-managed-object-storage-design.md.
+  */
+final case class ManagedObjectStoreConfig(
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_ENABLED",
+      description = "Global kill switch for managed object storage. Off = managed creates 400."
+    )
+    enabled: Boolean = false,
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_ENDPOINT",
+      description = "S3-compatible endpoint URL for the operator root bucket."
+    )
+    endpoint: String = "",
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_REGION",
+      description = "Region passed to the S3-compatible client."
+    )
+    region: String = "us-east-1",
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_BUCKET",
+      description = "Operator root bucket; each tenant-db incarnation gets its own prefix."
+    )
+    bucket: String = "qod-managed",
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_ACCESS_KEY_ID",
+      description = "Access key id for the operator root bucket."
+    )
+    accessKeyId: String = "",
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_SECRET_ACCESS_KEY",
+      description = "Secret access key for the operator root bucket.",
+      sensitive = true
+    )
+    secretAccessKey: String = "",
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_URL_STYLE",
+      description = "Bucket addressing style presented to clients: 'path' or 'vhost'."
+    )
+    urlStyle: String = "path",
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_RETAIN_DAYS",
+      description =
+        "Days a deleted tenant-db prefix is retained before the purge worker removes it."
+    )
+    retainDays: Int = 7,
+    @field @ConfigField(
+      envVar = "QOD_MANAGED_STORE_PURGE_SWEEP_SEC",
+      description = "Purge worker sweep interval in seconds; clamped to a 60s floor."
+    )
+    purgeSweepSec: Int = 300
+):
+  require(retainDays >= 0, "managedObjectStore: retainDays must be >= 0")
+  require(
+    urlStyle == "path" || urlStyle == "vhost",
+    "managedObjectStore: urlStyle must be path or vhost"
+  )
+  def purgeSweepInterval: scala.concurrent.duration.FiniteDuration =
+    scala.concurrent.duration.DurationInt(math.max(60, purgeSweepSec)).seconds
 
 final case class FlightConfig(
     @field @ConfigField(envVar = "PROXY_HOST", description = "FlightSQL edge bind address.")

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -89,6 +89,7 @@ object Main extends IOApp with LazyLogging:
   given ProductHint[CatalogConfig]             = ProductHint[CatalogConfig](camelMapping)
   given ProductHint[RoutingConfig]             = ProductHint[RoutingConfig](camelMapping)
   given ProductHint[AutoscaleConfig]           = ProductHint[AutoscaleConfig](camelMapping)
+  given ProductHint[ManagedObjectStoreConfig]  = ProductHint[ManagedObjectStoreConfig](camelMapping)
   given ProductHint[ManagerConfig]             = ProductHint[ManagerConfig](camelMapping)
   given ProductHint[FlightConfig]              = ProductHint[FlightConfig](camelMapping)
   given ProductHint[DatabaseAuthConfig]        = ProductHint[DatabaseAuthConfig](camelMapping)
@@ -99,28 +100,29 @@ object Main extends IOApp with LazyLogging:
   given ProductHint[JwtAuthConfig]             = ProductHint[JwtAuthConfig](camelMapping)
   given ProductHint[AuthenticationConfig]      = ProductHint[AuthenticationConfig](camelMapping)
 
-  given ConfigReader[K8sConfig]              = deriveReader[K8sConfig]
-  given ConfigReader[AdminConfig]            = deriveReader[AdminConfig]
-  given ConfigReader[FederationConfig]       = deriveReader[FederationConfig]
-  given ConfigReader[ManagementOidcConfig]   = deriveReader[ManagementOidcConfig]
-  given ConfigReader[ManagementAuthConfig]   = deriveReader[ManagementAuthConfig]
-  given ConfigReader[ManagerAuthConfig]      = deriveReader[ManagerAuthConfig]
-  given ConfigReader[DefaultMetastoreConfig] = deriveReader[DefaultMetastoreConfig]
-  given ConfigReader[HaConfig]               = deriveReader[HaConfig]
-  given ConfigReader[TelemetryConfig]        = deriveReader[TelemetryConfig]
-  given ConfigReader[MaintenanceConfig]      = deriveReader[MaintenanceConfig]
-  given ConfigReader[CatalogConfig]          = deriveReader[CatalogConfig]
-  given ConfigReader[RoutingConfig]          = deriveReader[RoutingConfig]
-  given ConfigReader[AutoscaleConfig]        = deriveReader[AutoscaleConfig]
-  given ConfigReader[ManagerConfig]          = deriveReader[ManagerConfig]
-  given ConfigReader[FlightConfig]           = deriveReader[FlightConfig]
-  given ConfigReader[DatabaseAuthConfig]     = deriveReader[DatabaseAuthConfig]
-  given ConfigReader[KeycloakAuthConfig]     = deriveReader[KeycloakAuthConfig]
-  given ConfigReader[GoogleAuthConfig]       = deriveReader[GoogleAuthConfig]
-  given ConfigReader[AzureAuthConfig]        = deriveReader[AzureAuthConfig]
-  given ConfigReader[AwsAuthConfig]          = deriveReader[AwsAuthConfig]
-  given ConfigReader[JwtAuthConfig]          = deriveReader[JwtAuthConfig]
-  given ConfigReader[AuthenticationConfig]   = deriveReader[AuthenticationConfig]
+  given ConfigReader[K8sConfig]                = deriveReader[K8sConfig]
+  given ConfigReader[AdminConfig]              = deriveReader[AdminConfig]
+  given ConfigReader[FederationConfig]         = deriveReader[FederationConfig]
+  given ConfigReader[ManagementOidcConfig]     = deriveReader[ManagementOidcConfig]
+  given ConfigReader[ManagementAuthConfig]     = deriveReader[ManagementAuthConfig]
+  given ConfigReader[ManagerAuthConfig]        = deriveReader[ManagerAuthConfig]
+  given ConfigReader[DefaultMetastoreConfig]   = deriveReader[DefaultMetastoreConfig]
+  given ConfigReader[HaConfig]                 = deriveReader[HaConfig]
+  given ConfigReader[TelemetryConfig]          = deriveReader[TelemetryConfig]
+  given ConfigReader[MaintenanceConfig]        = deriveReader[MaintenanceConfig]
+  given ConfigReader[CatalogConfig]            = deriveReader[CatalogConfig]
+  given ConfigReader[RoutingConfig]            = deriveReader[RoutingConfig]
+  given ConfigReader[AutoscaleConfig]          = deriveReader[AutoscaleConfig]
+  given ConfigReader[ManagedObjectStoreConfig] = deriveReader[ManagedObjectStoreConfig]
+  given ConfigReader[ManagerConfig]            = deriveReader[ManagerConfig]
+  given ConfigReader[FlightConfig]             = deriveReader[FlightConfig]
+  given ConfigReader[DatabaseAuthConfig]       = deriveReader[DatabaseAuthConfig]
+  given ConfigReader[KeycloakAuthConfig]       = deriveReader[KeycloakAuthConfig]
+  given ConfigReader[GoogleAuthConfig]         = deriveReader[GoogleAuthConfig]
+  given ConfigReader[AzureAuthConfig]          = deriveReader[AzureAuthConfig]
+  given ConfigReader[AwsAuthConfig]            = deriveReader[AwsAuthConfig]
+  given ConfigReader[JwtAuthConfig]            = deriveReader[JwtAuthConfig]
+  given ConfigReader[AuthenticationConfig]     = deriveReader[AuthenticationConfig]
   import MetricsConfigCodec.given
 
   private val DevSessionJwtSecret = "qod-dev-session-secret-rotate-in-production-x9k2v7p3m8q1"
@@ -298,7 +300,8 @@ object Main extends IOApp with LazyLogging:
       locks = poolLocks,
       publish = publisher,
       events = moduleEventBus.sink,
-      lockdownEnabled = lockdownCfg.enabled
+      lockdownEnabled = lockdownCfg.enabled,
+      managedStore = Option.when(mgrCfg.managedObjectStore.enabled)(mgrCfg.managedObjectStore)
     )
     supRef.set(sup)
 
@@ -429,7 +432,8 @@ object Main extends IOApp with LazyLogging:
       sup,
       manifestFedStore,
       catalog = catalogHandlers,
-      audit = auditRecorder
+      audit = auditRecorder,
+      managedEnabled = mgrCfg.managedObjectStore.enabled
     )
 
     // REST surface only; the scheduler + drain-loop fibers start later with the duty fibers.
@@ -893,6 +897,12 @@ object Main extends IOApp with LazyLogging:
         modulePublicPrefixes = modules.flatMap(_.publicPathPrefixes).toSet,
         moduleStaticMounts = modules.flatMap(_.staticMounts)
       )
+      // One managed-object-store client for both the boot probe below and the purge
+      // worker further down. Constructed unconditionally: the SDK client it wraps is
+      // lazy, so nothing is touched while managed storage is off.
+      val managedStoreClient =
+        new ai.starlake.quack.ondemand.storage.S3ManagedStoreClient(mgrCfg.managedObjectStore)
+
       // Leader-only boot duties. Ordering: the bootstrap hook runs BEFORE restore()
       // so the supervisor cache reflects imported state and reconcile() can spawn
       // those pools; inverting leaves the REST/UI on an empty cache after boot.
@@ -947,6 +957,32 @@ object Main extends IOApp with LazyLogging:
         // One-shot purge at boot: single-manager mode never runs the HA leader's
         // periodic purge of expired denylist rows.
         IO.delay(store.purgeExpiredRevokedJti(java.time.Instant.now())) *>
+        // Managed object store reachability probe. Advisory only: an unreachable or
+        // mis-credentialed bucket must never stop the manager from booting. It does
+        // not gate managed tenant-db creates either - those still succeed at the
+        // control plane; the failure only surfaces later, when a node tries to
+        // ATTACH against the missing bucket.
+        (if !mgrCfg.managedObjectStore.enabled then IO.unit
+         else
+           IO.blocking(managedStoreClient.ensureBucket()).attempt.map {
+             case Right(Right(())) =>
+               logger.info(
+                 s"managed object store ready: bucket '${mgrCfg.managedObjectStore.bucket}'"
+               )
+             case Right(Left(err)) =>
+               logger.warn(
+                 s"managed object store unreachable: managed creates still succeed " +
+                   s"at the control plane, but their nodes will fail to ATTACH until " +
+                   s"the store recovers: $err"
+               )
+             case Left(t) =>
+               logger.warn(
+                 s"managed object store unreachable: managed creates still succeed " +
+                   s"at the control plane, but their nodes will fail to ATTACH until " +
+                   s"the store recovers: " +
+                   Option(t.getMessage).getOrElse(t.toString)
+               )
+           }) *>
         moduleStart *>
         // Modules may build their MutationGates only inside start(), so this reads
         // them strictly after moduleStart and before the server binds.
@@ -1060,6 +1096,17 @@ object Main extends IOApp with LazyLogging:
                 )
                 val autoscaleFiber = autoscaleWiring.fiber
 
+                // Managed-object-store purge worker: deletes the objects under a
+                // tombstoned tenant-db prefix once its retention window has passed.
+                val managedStoreWiring = new ai.starlake.quack.boot.ManagedStoreWiring(
+                  cfg = mgrCfg.managedObjectStore,
+                  client = managedStoreClient,
+                  due = store.dueManagedPrefixes,
+                  markPurged = store.markManagedPrefixPurged,
+                  isLeader = () => coordinator.forall(_.isLeader)
+                )
+                val managedPurgeFiber = managedStoreWiring.fiber
+
                 // Leader elector + LISTEN dispatch loop. No-op fiber when HA off.
                 val coordinatorFiber = coordinator match
                   case Some(c) => c.loop.start
@@ -1128,18 +1175,21 @@ object Main extends IOApp with LazyLogging:
                               maintenanceSchedulerFiber.flatMap { msFiber =>
                                 maintenanceDrainFiber.flatMap { mdFiber =>
                                   autoscaleFiber.flatMap { asFiber =>
-                                    moduleDispatcherFibers.flatMap { modDispFibers =>
-                                      moduleSingletonFibers.flatMap { modSingFibers =>
-                                        IO.never[Unit]
-                                          .guarantee(
-                                            fiber.cancel *> rcFiber.cancel *> coFiber.cancel *>
-                                              hrFiber.cancel *> jFiber.cancel *> pFiber.cancel *>
-                                              rlFiber.cancel *> msFiber.cancel *> mdFiber.cancel *>
-                                              asFiber.cancel *>
-                                              modDispFibers.traverse_(_.cancel) *>
-                                              modSingFibers.traverse_(_.cancel) *>
-                                              gracefulShutdown
-                                          )
+                                    managedPurgeFiber.flatMap { mpFiber =>
+                                      moduleDispatcherFibers.flatMap { modDispFibers =>
+                                        moduleSingletonFibers.flatMap { modSingFibers =>
+                                          IO.never[Unit]
+                                            .guarantee(
+                                              fiber.cancel *> rcFiber.cancel *> coFiber.cancel *>
+                                                hrFiber.cancel *> jFiber.cancel *> pFiber.cancel *>
+                                                rlFiber.cancel *> msFiber.cancel *>
+                                                mdFiber.cancel *> asFiber.cancel *>
+                                                mpFiber.cancel *>
+                                                modDispFibers.traverse_(_.cancel) *>
+                                                modSingFibers.traverse_(_.cancel) *>
+                                                gracefulShutdown
+                                            )
+                                        }
                                       }
                                     }
                                   }

--- a/src/main/scala/ai/starlake/quack/boot/ManagedStoreWiring.scala
+++ b/src/main/scala/ai/starlake/quack/boot/ManagedStoreWiring.scala
@@ -1,0 +1,105 @@
+package ai.starlake.quack.boot
+
+import ai.starlake.quack.ManagedObjectStoreConfig
+import ai.starlake.quack.ondemand.state.ManagedPrefixRow
+import ai.starlake.quack.ondemand.storage.ManagedStoreClient
+import cats.effect.{FiberIO, IO}
+import com.typesafe.scalalogging.LazyLogging
+
+/** The managed-object-store purge worker. Tenant-db drop only tombstones the prefix
+  * (`markManagedPrefixDeleted`); the objects survive the retention window so an operator can still
+  * recover them. Once `purgeEligibleAt` is past, this loop deletes the objects under the prefix and
+  * stamps `purgedAt`.
+  *
+  * Work is bounded per tick on purpose: at most `maxBatchesPerPrefixPerTick` list+delete rounds per
+  * prefix, so a huge prefix drains across several sweeps instead of holding the fiber (and the S3
+  * connection) for minutes. That makes the worker resumable by construction: the tombstone row
+  * keeps coming back as due until a listing comes back empty.
+  *
+  * Failures are isolated per prefix: a `Left` from list or delete logs a warn and moves to the NEXT
+  * row, and the failed row is simply retried on the next sweep (`purgedAt` stays NULL).
+  */
+final class ManagedStoreWiring(
+    cfg: ManagedObjectStoreConfig,
+    client: ManagedStoreClient,
+    due: java.time.Instant => List[ManagedPrefixRow],
+    markPurged: (String, java.time.Instant) => Unit,
+    isLeader: () => Boolean,
+    batchSize: Int = 1000,
+    maxBatchesPerPrefixPerTick: Int = 10,
+    now: () => java.time.Instant = () => java.time.Instant.now()
+) extends LazyLogging:
+
+  private val bucketRoot = s"s3://${cfg.bucket}/"
+
+  /** `ManagedPrefixRow.prefix` holds the full `s3://bucket/...` URL (it doubles as the tenant-db
+    * dataPath); `listPrefix` wants the key prefix inside the bucket. A row that does not live under
+    * the configured bucket is skipped rather than listed: passing the un-stripped URL through would
+    * match nothing at best, and an empty prefix would enumerate the WHOLE bucket at worst.
+    */
+  private def keyPrefixOf(row: ManagedPrefixRow): Option[String] =
+    val stripped = row.prefix.stripPrefix(bucketRoot)
+    if stripped == row.prefix || stripped.isEmpty then
+      logger.warn(
+        s"managed purge: skipping ${row.id}, prefix '${row.prefix}' is not under '$bucketRoot'"
+      )
+      None
+    else Some(stripped)
+
+  @annotation.tailrec
+  private def drain(row: ManagedPrefixRow, keyPrefix: String, batchesLeft: Int): Unit =
+    if batchesLeft <= 0 then
+      logger.info(
+        s"managed purge: ${row.prefix} still has objects after " +
+          s"$maxBatchesPerPrefixPerTick batches, resuming next sweep"
+      )
+    else
+      client.listPrefix(keyPrefix, batchSize) match
+        case Left(err) =>
+          logger.warn(s"managed purge: list failed for ${row.prefix}, retrying next sweep: $err")
+        case Right(Nil) =>
+          markPurged(row.id, now())
+          logger.info(
+            s"managed purge: purged ${row.prefix} (${row.tenant}/${row.tenantDbName})"
+          )
+        case Right(keys) =>
+          client.deleteBatch(keys) match
+            case Left(err) =>
+              logger.warn(
+                s"managed purge: delete failed for ${row.prefix}, retrying next sweep: $err"
+              )
+            case Right(()) => drain(row, keyPrefix, batchesLeft - 1)
+
+  private def drainRow(row: ManagedPrefixRow): Unit =
+    keyPrefixOf(row).foreach(kp => drain(row, kp, maxBatchesPerPrefixPerTick))
+
+  /** One purge pass over every due tombstone. Leader-only.
+    *
+    * IO.defer around the leader check: `fiber` binds this to a single IO value once (see its
+    * `foreverM`), so the leadership branch must be re-evaluated on every run rather than baked in
+    * at construction time. Otherwise a replica that boots before winning the advisory lock latches
+    * "not leader" forever.
+    *
+    * One `IO.blocking` PER ROW rather than one wrapping the whole loop: `IO.blocking` is
+    * uncancelable while running, so a single blocking block around every due row would make a
+    * shutdown landing mid-sweep stall until every row (bounded per row, but unbounded in row count)
+    * has drained. Folding the rows into the IO chain gives cancellation a checkpoint between rows,
+    * same shape as `AutoscaleWiring.sweep`'s per-action fold.
+    */
+  def tick(): IO[Unit] = IO.defer {
+    if !isLeader() then IO.unit
+    else
+      IO.blocking(due(now())).flatMap { rows =>
+        rows.foldLeft(IO.unit)((acc, row) => acc *> IO.blocking(drainRow(row)))
+      }
+  }
+
+  /** One sweep every `cfg.purgeSweepInterval` (60s floor). `enabled = false` starts no loop at all:
+    * with managed storage off nothing ever writes a tombstone row.
+    */
+  def fiber: IO[FiberIO[Unit]] =
+    if !cfg.enabled then IO.unit.start
+    else
+      (tick().handleErrorWith(t =>
+        IO.delay(logger.warn(s"managed purge: pass failed, continuing: ${t.getMessage}"))
+      ) *> IO.sleep(cfg.purgeSweepInterval)).foreverM.void.start

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -27,6 +27,7 @@ import ai.starlake.quack.ondemand.state.{
   RbacUser,
   RolePermission
 }
+import ai.starlake.quack.ondemand.storage.ManagedPrefix
 import ai.starlake.quack.route.PoolSnapshot
 import ai.starlake.quack.spi.ManagerEvent
 import cats.effect.IO
@@ -104,7 +105,14 @@ final class PoolSupervisor(
       * global default the per-pool tri-state inherits, so the query path and the maintenance path
       * can never drift.
       */
-    lockdownEnabled: Boolean = false
+    lockdownEnabled: Boolean = false,
+    /** Managed object storage (QOD_MANAGED_STORE_*), from Main; `None` when the config block is
+      * disabled. Present-and-enabled is the precondition for `createTenantDb(managedStorage =
+      * true)`: it supplies the bucket the per-incarnation prefix is carved from, the credentials
+      * the tenant-db's objectStore is filled with, and the `retainDays` window [[deleteTenantDb]]
+      * stamps on the tombstone row.
+      */
+    managedStore: Option[ai.starlake.quack.ManagedObjectStoreConfig] = None
 ):
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -998,7 +1006,11 @@ final class PoolSupervisor(
             )
           else
             tdbs.foreach { td =>
-              store.deleteTenantDb(td.id); tenantDbs.remove(td.id)
+              store.deleteTenantDb(td.id)
+              // Same tombstone stamp as deleteTenantDb: a cascaded delete must not strand a
+              // managed prefix un-eligible, or its objects would be billed forever.
+              stampManagedPrefixDeleted(td.id, td.name, purgeManagedData = false)
+              tenantDbs.remove(td.id)
               try onTenantDbDeleted(name.toLowerCase, td.name)
               catch case _: Throwable => ()
               dbAdmin.dropDatabase(td.name) match
@@ -1029,6 +1041,13 @@ final class PoolSupervisor(
       defaultDatabase: Option[String] = None,
       defaultSchema: Option[String] = None,
       initSql: String = "",
+      /** Carve this database's storage out of the operator-managed bucket: the caller supplies
+        * neither `dataPath` nor `objectStore`, and both are resolved here from [[managedStore]]
+        * (prefix keyed by the freshly minted surrogate id, credentials from the config block).
+        * Refused when managed storage is not configured. The REST layer additionally refuses it
+        * together with a caller-supplied dataPath/objectStore and on non-DuckLake kinds.
+        */
+      managedStorage: Boolean = false,
       gateBypass: Boolean = false
   ): IO[Either[SupervisorError, TenantDb]] =
     gateCheck(
@@ -1045,6 +1064,13 @@ final class PoolSupervisor(
                 val tn = tenantName.toLowerCase
                 getTenant(tn) match
                   case None => Left(SupervisorError.NotFound(s"tenant not found: $tn"))
+                  case Some(_) if managedStorage && managedStore.forall(!_.enabled) =>
+                    Left(
+                      SupervisorError.InvalidArgument(
+                        "managed storage is not configured: set QOD_MANAGED_STORE_ENABLED " +
+                          "and its credentials"
+                      )
+                    )
                   case Some(t)
                       if tenantDbs.values.exists(td => td.tenantId == t.id && td.name == full) =>
                     Left(
@@ -1060,14 +1086,44 @@ final class PoolSupervisor(
                       case TenantDbKind.DuckDbFile => metastore
                       case TenantDbKind.InMemory   => metastore
 
+                    // Minted up front: a managed prefix is keyed by this id, so a recreated
+                    // database of the same name never lands on its predecessor's data.
+                    val id         = newId("td")
+                    val managedCfg =
+                      if managedStorage then managedStore.filter(_.enabled) else None
+                    // `full` is `<tenant>_<suffix>` and ManagedPrefix.dataPath re-joins its
+                    // (tenant, dbName) arguments with an underscore, so the db-name piece fed
+                    // here is `full` minus its tenant prefix. Result: the spec's shape
+                    // `s3://<bucket>/<tenant>_<dbname>-<id8>/`.
+                    val effectiveDataPath = managedCfg.fold(dataPath) { cfg =>
+                      ManagedPrefix.dataPath(cfg.bucket, tn, full.stripPrefix(s"${tn}_"), id)
+                    }
+                    val effectiveObjectStore =
+                      managedCfg.fold(objectStore)(ManagedPrefix.objectStoreFor)
+
+                    /** Tombstone row for the managed prefix, written with the tenant-db row so no
+                      * managed create can leave storage carved out with nothing to purge it. No-op
+                      * for BYO / default-path databases.
+                      */
+                    def recordManagedPrefix(): Unit =
+                      managedCfg.foreach { _ =>
+                        store.insertManagedPrefix(
+                          id,
+                          tn,
+                          full,
+                          effectiveDataPath,
+                          java.time.Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MICROS)
+                        )
+                      }
+
                     val td = TenantDb(
-                      id = newId("td"),
+                      id = id,
                       tenantId = t.id,
                       name = full,
                       kind = kind,
                       metastore = effectiveMeta,
-                      dataPath = dataPath,
-                      objectStore = objectStore,
+                      dataPath = effectiveDataPath,
+                      objectStore = effectiveObjectStore,
                       defaultDatabase = defaultDatabase,
                       defaultSchema = defaultSchema,
                       initSql = initSql
@@ -1093,9 +1149,10 @@ final class PoolSupervisor(
                                 // don't race on `CREATE TABLE __ducklake_metadata`.
                                 try
                                   DuckLakeInitializer.initBlocking(
-                                    effectiveMeta.updated("dataPath", dataPath)
+                                    effectiveMeta.updated("dataPath", effectiveDataPath)
                                   )
                                   store.upsertTenantDb(td)
+                                  recordManagedPrefix()
                                   tenantDbs.put(td.id, td)
                                   publish.topologyChanged()
                                   events.emit(ManagerEvent.TenantDbCreated(tenantName, td.name))
@@ -1116,12 +1173,14 @@ final class PoolSupervisor(
                                         s"first pool spawn will retry the ATTACH. Cause: ${t.getMessage}"
                                     )
                                     store.upsertTenantDb(td)
+                                    recordManagedPrefix()
                                     tenantDbs.put(td.id, td)
                                     publish.topologyChanged()
                                     events.emit(ManagerEvent.TenantDbCreated(tenantName, td.name))
                                     Right(td)
                           case TenantDbKind.DuckDbFile | TenantDbKind.InMemory =>
                             store.upsertTenantDb(td)
+                            recordManagedPrefix()
                             tenantDbs.put(td.id, td)
                             publish.topologyChanged()
                             events.emit(ManagerEvent.TenantDbCreated(tenantName, td.name))
@@ -1130,7 +1189,41 @@ final class PoolSupervisor(
         }
     }
 
-  def deleteTenantDb(tenantName: String, tenantDbName: String): IO[Either[SupervisorError, Unit]] =
+  /** Stamp the deleted tenant-db's managed-prefix tombstone: `deletedAt` now, `purgeEligibleAt`
+    * `retainDays` later (or now when the caller asked for an immediate purge). The retention window
+    * falls back to the config default when managed storage is not wired on this replica, so a row
+    * written by another replica is never stranded permanently un-eligible. Already-stamped rows are
+    * left alone: re-stamping would silently extend or shorten a window the purge worker may already
+    * be acting on.
+    */
+  private def stampManagedPrefixDeleted(
+      tenantDbId: String,
+      tenantDbName: String,
+      purgeManagedData: Boolean
+  ): Unit =
+    store.managedPrefix(tenantDbId) match
+      case Some(row) if row.deletedAt.isEmpty =>
+        val now        = java.time.Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MICROS)
+        val retainDays = managedStore.map(_.retainDays).getOrElse(7)
+        val eligible   =
+          if purgeManagedData then now
+          else now.plus(retainDays.toLong, java.time.temporal.ChronoUnit.DAYS)
+        store.markManagedPrefixDeleted(tenantDbId, now, eligible)
+      case Some(_) => ()
+      case None    =>
+        if purgeManagedData then
+          logger.warn(s"purgeManagedData ignored: '$tenantDbName' has no managed prefix")
+
+  /** `purgeManagedData` makes a managed database's storage eligible for the purge worker
+    * immediately instead of after `managedStore.retainDays`; the objects themselves are removed
+    * asynchronously, so the call still returns as fast as a plain delete. Ignored with a WARN on a
+    * BYO / default-path database, which has no managed prefix to purge.
+    */
+  def deleteTenantDb(
+      tenantName: String,
+      tenantDbName: String,
+      purgeManagedData: Boolean = false
+  ): IO[Either[SupervisorError, Unit]] =
     IO.blocking {
       withCacheRecovery("deleteTenantDb") {
         val tn = tenantName.toLowerCase
@@ -1162,6 +1255,7 @@ final class PoolSupervisor(
                   )
                 else
                   store.deleteTenantDb(td.id)
+                  stampManagedPrefixDeleted(td.id, tenantDbName, purgeManagedData)
                   tenantDbs.remove(td.id)
                   dataPathBlocked.remove(td.id)
                   try onTenantDbDeleted(tn, tenantDbName)

--- a/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
@@ -333,7 +333,12 @@ final case class TenantDbRequest(
     objectStore: Map[String, String] = Map.empty,
     defaultDatabase: Option[String] = None,
     defaultSchema: Option[String] = None,
-    initSql: String = ""
+    initSql: String = "",
+    // Carve the storage out of the operator-managed bucket instead of
+    // supplying it: exclusive with `dataPath` / `objectStore`, requires
+    // kind=ducklake and an enabled managed-store config. The resolved
+    // location comes back on the response's `dataPath`.
+    managedStorage: Boolean = false
 )
 final case class TenantDbResponse(
     id: String,
@@ -356,7 +361,15 @@ final case class TenantDbResponse(
     tableCount: Option[Int] = None
 )
 final case class TenantDbListResponse(tenantDbs: List[TenantDbResponse])
-final case class TenantDbOpRequest(tenant: String, name: String)
+final case class TenantDbOpRequest(
+    tenant: String,
+    name: String,
+    // Delete-only: makes a managed database's storage eligible for the purge
+    // worker immediately instead of after retainDays. Ignored (with a WARN)
+    // for a BYO / default-path database, and meaningless on any other
+    // endpoint that reuses this request shape.
+    purgeManagedData: Boolean = false
+)
 
 final case class UpdateTenantDbRequest(
     tenant: String,
@@ -1085,10 +1098,11 @@ object Dtos:
   given Codec[ConfigListResponse]       = deriveCodec
   given Codec[ManifestImportSummary]    = deriveCodec
 
-  given Codec[TenantDbRequest]        = ConfiguredCodec.derived
-  given Codec[TenantDbResponse]       = deriveCodec
-  given Codec[TenantDbListResponse]   = deriveCodec
-  given Codec[TenantDbOpRequest]      = deriveCodec
+  given Codec[TenantDbRequest]      = ConfiguredCodec.derived
+  given Codec[TenantDbResponse]     = deriveCodec
+  given Codec[TenantDbListResponse] = deriveCodec
+  // ConfiguredCodec so an old body without `purgeManagedData` still decodes.
+  given Codec[TenantDbOpRequest]      = ConfiguredCodec.derived
   given Codec[UpdateTenantDbRequest]  = deriveCodec
   given Codec[FailedRestart]          = deriveCodec
   given Codec[UpdateTenantDbResponse] = deriveCodec

--- a/src/main/scala/ai/starlake/quack/ondemand/api/TenantDbHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/TenantDbHandlers.scala
@@ -18,7 +18,11 @@ final class TenantDbHandlers(
     sup: PoolSupervisor,
     federatedStore: Option[FederatedSourceStore] = None,
     catalog: Option[CatalogHandlers] = None,
-    audit: AuditRecorder = AuditRecorder.noop
+    audit: AuditRecorder = AuditRecorder.noop,
+    /** Mirrors `manager.managedObjectStore.enabled`: gates `managedStorage` requests here so the
+      * caller gets a 400 naming the env var instead of a supervisor-level refusal.
+      */
+    managedEnabled: Boolean = false
 ):
 
   type Out[A] = IO[Either[(StatusCode, ErrorResponse), A]]
@@ -33,6 +37,21 @@ final class TenantDbHandlers(
     */
   private def validateObjectStore(objectStore: Map[String, String]): Option[String] =
     TenantDb.objectStoreError(objectStore)
+
+  /** The three `managedStorage` refusals, all 400 `invalid`: the deployment has managed storage
+    * switched off, the caller mixed managed with a BYO location, or the kind cannot hold one. An
+    * unparseable `kind` yields None here so the existing `invalid_kind` arm below still owns that
+    * message.
+    */
+  private def validateManagedStorage(req: TenantDbRequest): Option[String] =
+    if !req.managedStorage then None
+    else if !managedEnabled then
+      Some("managed storage is not enabled on this deployment (QOD_MANAGED_STORE_ENABLED)")
+    else if req.dataPath.nonEmpty || req.objectStore.nonEmpty then
+      Some("managedStorage is exclusive with dataPath/objectStore: one intent per call")
+    else if TenantDbKind.fromWire(req.kind).toOption.exists(_ != TenantDbKind.DuckLake) then
+      Some("managedStorage requires kind=ducklake")
+    else None
 
   private def federatedCount(tenantDbId: String): Int =
     federatedStore.fold(0)(_.listSources(tenantDbId).size)
@@ -88,7 +107,7 @@ final class TenantDbHandlers(
             )
           )
         else
-          validateObjectStore(req.objectStore) match
+          validateObjectStore(req.objectStore).orElse(validateManagedStorage(req)) match
             case Some(msg) =>
               IO.pure(Left((StatusCode.BadRequest, ErrorResponse("invalid", msg))))
             case None =>
@@ -108,6 +127,7 @@ final class TenantDbHandlers(
                       defaultDatabase = req.defaultDatabase,
                       defaultSchema = req.defaultSchema,
                       initSql = req.initSql,
+                      managedStorage = req.managedStorage,
                       gateBypass = gateBypass
                     )
                     .flatMap {
@@ -187,7 +207,7 @@ final class TenantDbHandlers(
         )
         IO.pure(Left(err))
       case None =>
-        sup.deleteTenantDb(req.tenant, req.name).map {
+        sup.deleteTenantDb(req.tenant, req.name, purgeManagedData = req.purgeManagedData).map {
           case Right(_) =>
             audit.rest(
               apiKey,

--- a/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneStore.scala
@@ -63,6 +63,43 @@ trait ControlPlaneStore:
   /** Delete every bucket older than `olderThan`. Returns the number of rows removed. */
   def purgePoolLoad(olderThan: java.time.Instant): Int
 
+  // ---------------- Managed prefix (tombstone registry) ------------------
+  // Tombstones a data-path prefix carved out of the shared managed object
+  // store for a tenant-db. `insertManagedPrefix` runs at tenant-db create
+  // time; `markManagedPrefixDeleted` at tenant-db drop time (sets both
+  // deletedAt and the retention-window purgeEligibleAt together); the purge
+  // sweep polls `dueManagedPrefixes` and stamps `markManagedPrefixPurged`
+  // once the underlying objects are gone.
+
+  /** Insert a new tombstone row in the live (not-yet-deleted) state. */
+  def insertManagedPrefix(
+      id: String,
+      tenant: String,
+      tenantDbName: String,
+      prefix: String,
+      createdAt: java.time.Instant
+  ): Unit
+
+  /** Stamp `deletedAt` and `purgeEligibleAt` on an existing row. No-op when `id` is unknown. */
+  def markManagedPrefixDeleted(
+      id: String,
+      deletedAt: java.time.Instant,
+      purgeEligibleAt: java.time.Instant
+  ): Unit
+
+  /** Rows past their retention window and not yet purged, ordered by `purgeEligibleAt` ascending.
+    * Feeds the purge sweep.
+    */
+  def dueManagedPrefixes(now: java.time.Instant): List[ManagedPrefixRow]
+
+  /** Stamp `purgedAt` once the sweep has removed the underlying objects. No-op when `id` is
+    * unknown.
+    */
+  def markManagedPrefixPurged(id: String, purgedAt: java.time.Instant): Unit
+
+  /** Look up a single tombstone row by id. */
+  def managedPrefix(id: String): Option[ManagedPrefixRow]
+
   /** Insert/update a running node under the given pool surrogate id. `RunningNode.poolKey` is a
     * natural key (tenant/pool) carried by the runtime and does not always match a single Postgres
     * row, so the FK to `qodstate_pool.id` is supplied explicitly by the caller.
@@ -349,3 +386,18 @@ trait ControlPlaneStore:
 
   /** Cheap liveness probe for readiness checks. */
   def ping(): Boolean = true
+
+/** A tombstone row for a managed-object-store prefix carved out for one tenant-db. `deletedAt` /
+  * `purgeEligibleAt` are `None` while the tenant-db is live; both get set together when it is
+  * dropped, and `purgedAt` is set once the purge sweep has removed the underlying objects.
+  */
+final case class ManagedPrefixRow(
+    id: String,
+    tenant: String,
+    tenantDbName: String,
+    prefix: String,
+    createdAt: java.time.Instant,
+    deletedAt: Option[java.time.Instant],
+    purgeEligibleAt: Option[java.time.Instant],
+    purgedAt: Option[java.time.Instant]
+)

--- a/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStore.scala
@@ -1932,6 +1932,102 @@ final class PostgresControlPlaneStore(
     finally ps.close()
   }
 
+  // ---------------- Managed prefix (tombstone registry) ------------------
+
+  def insertManagedPrefix(
+      id: String,
+      tenant: String,
+      tenantDbName: String,
+      prefix: String,
+      createdAt: Instant
+  ): Unit = withConn { c =>
+    val ps = c.prepareStatement(
+      """INSERT INTO qodstate_managed_prefix (id, tenant, tenant_db_name, prefix, created_at)
+        |VALUES (?, ?, ?, ?, ?)
+        |ON CONFLICT (id) DO NOTHING""".stripMargin
+    )
+    try
+      ps.setString(1, id)
+      ps.setString(2, tenant)
+      ps.setString(3, tenantDbName)
+      ps.setString(4, prefix)
+      ps.setTimestamp(5, Timestamp.from(createdAt))
+      ps.executeUpdate()
+      ()
+    finally ps.close()
+  }
+
+  def markManagedPrefixDeleted(
+      id: String,
+      deletedAt: Instant,
+      purgeEligibleAt: Instant
+  ): Unit = withConn { c =>
+    val ps = c.prepareStatement(
+      """UPDATE qodstate_managed_prefix
+        |SET deleted_at = ?, purge_eligible_at = ?
+        |WHERE id = ?""".stripMargin
+    )
+    try
+      ps.setTimestamp(1, Timestamp.from(deletedAt))
+      ps.setTimestamp(2, Timestamp.from(purgeEligibleAt))
+      ps.setString(3, id)
+      ps.executeUpdate()
+      ()
+    finally ps.close()
+  }
+
+  def dueManagedPrefixes(now: Instant): List[ManagedPrefixRow] = withConn { c =>
+    val ps = c.prepareStatement(
+      """SELECT id, tenant, tenant_db_name, prefix, created_at, deleted_at, purge_eligible_at, purged_at
+        |FROM qodstate_managed_prefix
+        |WHERE purge_eligible_at <= ? AND purged_at IS NULL
+        |ORDER BY purge_eligible_at ASC""".stripMargin
+    )
+    try
+      ps.setTimestamp(1, Timestamp.from(now))
+      val rs = ps.executeQuery()
+      try drain(rs)(readManagedPrefixRow)
+      finally rs.close()
+    finally ps.close()
+  }
+
+  def markManagedPrefixPurged(id: String, purgedAt: Instant): Unit = withConn { c =>
+    val ps = c.prepareStatement(
+      "UPDATE qodstate_managed_prefix SET purged_at = ? WHERE id = ?"
+    )
+    try
+      ps.setTimestamp(1, Timestamp.from(purgedAt))
+      ps.setString(2, id)
+      ps.executeUpdate()
+      ()
+    finally ps.close()
+  }
+
+  def managedPrefix(id: String): Option[ManagedPrefixRow] = withConn { c =>
+    val ps = c.prepareStatement(
+      """SELECT id, tenant, tenant_db_name, prefix, created_at, deleted_at, purge_eligible_at, purged_at
+        |FROM qodstate_managed_prefix WHERE id = ?""".stripMargin
+    )
+    try
+      ps.setString(1, id)
+      val rs = ps.executeQuery()
+      try if rs.next() then Some(readManagedPrefixRow(rs)) else None
+      finally rs.close()
+    finally ps.close()
+  }
+
+  private def readManagedPrefixRow(rs: ResultSet): ManagedPrefixRow =
+    ManagedPrefixRow(
+      id = rs.getString("id"),
+      tenant = rs.getString("tenant"),
+      tenantDbName = rs.getString("tenant_db_name"),
+      prefix = rs.getString("prefix"),
+      createdAt = rs.getTimestamp("created_at").toInstant,
+      deletedAt = Option(rs.getTimestamp("deleted_at")).map(_.toInstant),
+      purgeEligibleAt = Option(rs.getTimestamp("purge_eligible_at")).map(_.toInstant),
+      purgedAt = Option(rs.getTimestamp("purged_at")).map(_.toInstant)
+    )
+
   private def drain[A](rs: ResultSet)(read: ResultSet => A): List[A] =
     val buf = ListBuffer.empty[A]
     while rs.next() do buf += read(rs)

--- a/src/main/scala/ai/starlake/quack/ondemand/storage/ManagedStoreClient.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/storage/ManagedStoreClient.scala
@@ -1,0 +1,27 @@
+package ai.starlake.quack.ondemand.storage
+
+/** Thin seam over the operator object store. No SDK types leak past here. */
+trait ManagedStoreClient:
+  def ensureBucket(): Either[String, Unit] // idempotent create-if-missing
+  def listPrefix(
+      prefix: String,
+      max: Int
+  ): Either[String, List[String]]                           // object KEYS under prefix, up to max
+  def deleteBatch(keys: List[String]): Either[String, Unit] // <= 1000 keys per call
+
+object ManagedPrefix:
+  def id8(tenantDbId: String): String = tenantDbId.stripPrefix("td-").take(8)
+  def dataPath(bucket: String, tenant: String, dbName: String, tenantDbId: String): String =
+    s"s3://$bucket/${tenant}_$dbName-${id8(tenantDbId)}/"
+
+  /** The object-key prefix inside the bucket (dataPath minus scheme+bucket). */
+  def keyPrefix(tenant: String, dbName: String, tenantDbId: String): String =
+    s"${tenant}_$dbName-${id8(tenantDbId)}/"
+  def objectStoreFor(cfg: ai.starlake.quack.ManagedObjectStoreConfig): Map[String, String] =
+    val base = Map(
+      "s3_region"            -> cfg.region,
+      "s3_url_style"         -> cfg.urlStyle,
+      "s3_access_key_id"     -> cfg.accessKeyId,
+      "s3_secret_access_key" -> cfg.secretAccessKey
+    )
+    if cfg.endpoint.nonEmpty then base.updated("s3_endpoint", cfg.endpoint) else base

--- a/src/main/scala/ai/starlake/quack/ondemand/storage/S3ManagedStoreClient.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/storage/S3ManagedStoreClient.scala
@@ -1,0 +1,92 @@
+package ai.starlake.quack.ondemand.storage
+
+import ai.starlake.quack.ManagedObjectStoreConfig
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{
+  CreateBucketRequest,
+  Delete,
+  DeleteObjectsRequest,
+  HeadBucketRequest,
+  ListObjectsV2Request,
+  NoSuchBucketException,
+  ObjectIdentifier,
+  S3Error
+}
+
+import java.net.URI
+import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
+
+/** AWS SDK v2 [[S3Client]] impl of [[ManagedStoreClient]] for the operator root bucket. The client
+  * is built lazily so wiring this up with `enabled=false` never touches the SDK.
+  */
+final class S3ManagedStoreClient(cfg: ManagedObjectStoreConfig) extends ManagedStoreClient:
+
+  private lazy val client: S3Client =
+    val builder = S3Client
+      .builder()
+      .region(Region.of(cfg.region))
+      .credentialsProvider(
+        StaticCredentialsProvider.create(
+          AwsBasicCredentials.create(cfg.accessKeyId, cfg.secretAccessKey)
+        )
+      )
+      .forcePathStyle(cfg.urlStyle == "path")
+    if cfg.endpoint.nonEmpty then builder.endpointOverride(URI.create(cfg.endpoint)).build()
+    else builder.build()
+
+  def ensureBucket(): Either[String, Unit] =
+    try
+      client.headBucket(HeadBucketRequest.builder().bucket(cfg.bucket).build())
+      Right(())
+    catch
+      case _: NoSuchBucketException =>
+        try
+          client.createBucket(CreateBucketRequest.builder().bucket(cfg.bucket).build())
+          Right(())
+        catch case NonFatal(e) => Left(s"ensureBucket: createBucket failed: ${e.getMessage}")
+      case NonFatal(e) => Left(s"ensureBucket: headBucket failed: ${e.getMessage}")
+
+  def listPrefix(prefix: String, max: Int): Either[String, List[String]] =
+    try
+      val req = ListObjectsV2Request
+        .builder()
+        .bucket(cfg.bucket)
+        .prefix(prefix)
+        .maxKeys(max)
+        .build()
+      val resp = client.listObjectsV2(req)
+      Right(resp.contents().asScala.map(_.key()).toList)
+    catch case NonFatal(e) => Left(s"listPrefix: ${e.getMessage}")
+
+  def deleteBatch(keys: List[String]): Either[String, Unit] =
+    if keys.isEmpty then Right(())
+    else
+      try
+        val objectIds = keys.map(k => ObjectIdentifier.builder().key(k).build()).asJava
+        val req       = DeleteObjectsRequest
+          .builder()
+          .bucket(cfg.bucket)
+          .delete(Delete.builder().objects(objectIds).build())
+          .build()
+        val resp = client.deleteObjects(req)
+        S3ManagedStoreClient.deleteOutcome(resp.errors().asScala.toList)
+      catch case NonFatal(e) => Left(s"deleteBatch: ${e.getMessage}")
+
+object S3ManagedStoreClient:
+
+  /** DeleteObjects answers 200 with a per-key error list when some keys could not be removed (ACL,
+    * object lock, transient server error). Reporting that as success would make the purge worker a
+    * silent non-progress loop: the listing never empties, so the prefix is re-listed forever and no
+    * `Left` ever reaches the sweep's warn path. Named errors are surfaced instead.
+    */
+  private[storage] def deleteOutcome(errors: List[S3Error]): Either[String, Unit] =
+    errors match
+      case Nil        => Right(())
+      case first :: _ =>
+        Left(
+          s"deleteBatch: ${errors.size} key(s) failed, " +
+            s"first: ${first.key()} (${first.code()})"
+        )

--- a/src/test/scala/ai/starlake/quack/ManagedObjectStoreConfigSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ManagedObjectStoreConfigSpec.scala
@@ -1,0 +1,34 @@
+package ai.starlake.quack
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import pureconfig.ConfigSource
+
+class ManagedObjectStoreConfigSpec extends AnyFlatSpec with Matchers:
+  import Main.given
+
+  "ManagedObjectStoreConfig" should "load defaults from application.conf" in:
+    val cfg = ConfigSource.default.at("quack-on-demand").loadOrThrow[ManagerConfig]
+    cfg.managedObjectStore.enabled shouldBe false
+    cfg.managedObjectStore.endpoint shouldBe ""
+    cfg.managedObjectStore.region shouldBe "us-east-1"
+    cfg.managedObjectStore.bucket shouldBe "qod-managed"
+    cfg.managedObjectStore.urlStyle shouldBe "path"
+    cfg.managedObjectStore.retainDays shouldBe 7
+    cfg.managedObjectStore.purgeSweepSec shouldBe 300
+
+  it should "honor camelCase overlays" in:
+    val cfg = ConfigSource
+      .string("""quack-on-demand { managedObjectStore { retainDays = 30, urlStyle = "vhost" } }""")
+      .withFallback(ConfigSource.default)
+      .at("quack-on-demand")
+      .loadOrThrow[ManagerConfig]
+    cfg.managedObjectStore.retainDays shouldBe 30
+    cfg.managedObjectStore.urlStyle shouldBe "vhost"
+
+  it should "clamp the purge sweep to the 60s floor" in:
+    ManagedObjectStoreConfig(purgeSweepSec = 5).purgeSweepInterval.toSeconds shouldBe 60L
+
+  it should "refuse invalid bounds" in:
+    an[IllegalArgumentException] should be thrownBy ManagedObjectStoreConfig(retainDays = -1)
+    an[IllegalArgumentException] should be thrownBy ManagedObjectStoreConfig(urlStyle = "weird")

--- a/src/test/scala/ai/starlake/quack/boot/ManagedStoreWiringSpec.scala
+++ b/src/test/scala/ai/starlake/quack/boot/ManagedStoreWiringSpec.scala
@@ -1,0 +1,167 @@
+package ai.starlake.quack.boot
+
+import ai.starlake.quack.ManagedObjectStoreConfig
+import ai.starlake.quack.ondemand.state.ManagedPrefixRow
+import ai.starlake.quack.ondemand.storage.testkit.StubManagedStoreClient
+import cats.effect.unsafe.implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+class ManagedStoreWiringSpec extends AnyFlatSpec with Matchers:
+
+  private val cfg = ManagedObjectStoreConfig(enabled = true, bucket = "qod-managed")
+
+  private val keyPrefix = "acme_sales-aabbccdd/"
+
+  private def row(id: String, kp: String): ManagedPrefixRow =
+    ManagedPrefixRow(
+      id = id,
+      tenant = "acme",
+      tenantDbName = "sales",
+      prefix = s"s3://${cfg.bucket}/$kp",
+      createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+      deletedAt = Some(Instant.parse("2026-01-02T00:00:00Z")),
+      purgeEligibleAt = Some(Instant.parse("2026-01-09T00:00:00Z")),
+      purgedAt = None
+    )
+
+  "tick" should "do nothing as follower and drain as leader with one bound IO" in:
+    val stub = new StubManagedStoreClient
+    stub.seed(keyPrefix, 3)
+    var leader = false
+    var purged = List.empty[(String, Instant)]
+    val w      = new ManagedStoreWiring(
+      cfg = cfg,
+      client = stub,
+      due = _ => List(row("mp-1", keyPrefix)),
+      markPurged = (id, at) => purged = purged :+ (id, at),
+      isLeader = () => leader
+    )
+    // ONE bound IO, run twice across a leadership flip: the gate must be
+    // re-evaluated per run, not latched at construction.
+    val t = w.tick()
+    t.unsafeRunSync()
+    stub.listPrefixCalls shouldBe 0
+    stub.deleteBatchCalls shouldBe 0
+    stub.allKeys.size shouldBe 3
+    purged shouldBe empty
+
+    leader = true
+    t.unsafeRunSync()
+    stub.allKeys shouldBe empty
+    purged.map(_._1) shouldBe List("mp-1")
+
+  it should "resume a large prefix across ticks and stamp purged only when empty" in:
+    val stub = new StubManagedStoreClient
+    stub.seed(keyPrefix, 2500)
+    var purged = List.empty[String]
+    val w      = new ManagedStoreWiring(
+      cfg = cfg,
+      client = stub,
+      due = _ => List(row("mp-1", keyPrefix)),
+      markPurged = (id, _) => purged = purged :+ id,
+      isLeader = () => true,
+      batchSize = 1000,
+      maxBatchesPerPrefixPerTick = 2
+    )
+    val t = w.tick()
+    t.unsafeRunSync()
+    stub.allKeys.size shouldBe 500
+    purged shouldBe empty
+
+    t.unsafeRunSync()
+    stub.allKeys shouldBe empty
+    purged shouldBe List("mp-1")
+
+  it should "isolate a failing prefix from the rest" in:
+    val stub      = new StubManagedStoreClient
+    val otherKeys = "globex_ops-11223344/"
+    stub.seed(keyPrefix, 2)
+    stub.seed(otherKeys, 2)
+    stub.failNextDelete = Some("boom")
+    var purged = List.empty[String]
+    // `dueManagedPrefixes` only returns rows with a NULL purgedAt, so the fixture
+    // drops a row once it has been stamped.
+    val w = new ManagedStoreWiring(
+      cfg = cfg,
+      client = stub,
+      due = _ =>
+        List(row("mp-1", keyPrefix), row("mp-2", otherKeys)).filterNot(r => purged.contains(r.id)),
+      markPurged = (id, _) => purged = purged :+ id,
+      isLeader = () => true
+    )
+    val t = w.tick()
+    t.unsafeRunSync()
+    // First row's delete failed and it moved on; the second row drained fully.
+    stub.allKeys.sorted shouldBe List(s"${keyPrefix}0", s"${keyPrefix}1")
+    purged shouldBe List("mp-2")
+
+    // The failed prefix is retried on the next tick.
+    t.unsafeRunSync()
+    stub.allKeys shouldBe empty
+    purged shouldBe List("mp-2", "mp-1")
+
+  it should "isolate a failing listPrefix from the rest" in:
+    val stub      = new StubManagedStoreClient
+    val otherKeys = "globex_ops-11223344/"
+    stub.seed(keyPrefix, 2)
+    stub.seed(otherKeys, 2)
+    stub.failNextList = Some("boom")
+    var purged = List.empty[String]
+    // `dueManagedPrefixes` only returns rows with a NULL purgedAt, so the fixture
+    // drops a row once it has been stamped.
+    val w = new ManagedStoreWiring(
+      cfg = cfg,
+      client = stub,
+      due = _ =>
+        List(row("mp-1", keyPrefix), row("mp-2", otherKeys)).filterNot(r => purged.contains(r.id)),
+      markPurged = (id, _) => purged = purged :+ id,
+      isLeader = () => true
+    )
+    val t = w.tick()
+    t.unsafeRunSync()
+    // First row's list failed and it moved on; the second row drained fully.
+    stub.allKeys.sorted shouldBe List(s"${keyPrefix}0", s"${keyPrefix}1")
+    purged shouldBe List("mp-2")
+
+    // The failed prefix is retried on the next tick.
+    t.unsafeRunSync()
+    stub.allKeys shouldBe empty
+    purged shouldBe List("mp-2", "mp-1")
+
+  it should "skip a row whose prefix does not live under the configured bucket" in:
+    val stub = new StubManagedStoreClient
+    stub.seed(keyPrefix, 2)
+    var purged = List.empty[String]
+    val bogus  = row("mp-1", keyPrefix).copy(prefix = "s3://someone-elses-bucket/acme_sales/")
+    val w      = new ManagedStoreWiring(
+      cfg = cfg,
+      client = stub,
+      due = _ => List(bogus),
+      markPurged = (id, _) => purged = purged :+ id,
+      isLeader = () => true
+    )
+    w.tick().unsafeRunSync()
+    stub.listPrefixCalls shouldBe 0
+    stub.allKeys.size shouldBe 2
+    purged shouldBe empty
+
+  "fiber" should "be inert when disabled" in:
+    val stub = new StubManagedStoreClient
+    stub.seed(keyPrefix, 2)
+    var dueCalls = 0
+    var purged   = List.empty[String]
+    val w        = new ManagedStoreWiring(
+      cfg = cfg.copy(enabled = false),
+      client = stub,
+      due = _ => { dueCalls += 1; List(row("mp-1", keyPrefix)) },
+      markPurged = (id, _) => purged = purged :+ id,
+      isLeader = () => true
+    )
+    w.fiber.flatMap(_.join).unsafeRunSync().isSuccess shouldBe true
+    dueCalls shouldBe 0
+    stub.listPrefixCalls shouldBe 0
+    stub.allKeys.size shouldBe 2
+    purged shouldBe empty

--- a/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorSpec.scala
@@ -853,6 +853,146 @@ class PoolSupervisorSpec extends AnyFlatSpec with Matchers:
     td.metastore("dbName")     shouldBe "tpch_prod"
     td.metastore("schemaName") shouldBe "main"
 
+  // ---------- Managed object storage (createTenantDb / deleteTenantDb) ----------
+
+  private def managedCfg(): ai.starlake.quack.ManagedObjectStoreConfig =
+    ai.starlake.quack.ManagedObjectStoreConfig(
+      enabled         = true,
+      bucket          = "qod-managed",
+      accessKeyId     = "AK",
+      secretAccessKey = "SK"
+    )
+
+  /** Managed creates go through the DuckLake arm, so they need the RecordingDbAdmin stub the
+    * other DuckLake create tests use; the DuckLake pre-init itself fails against the fake
+    * metastore and falls through to the swallow-and-retry arm, exactly as in those tests. */
+  private def supManaged(
+      cfg: Option[ai.starlake.quack.ManagedObjectStoreConfig]
+  ): (PoolSupervisor, InMemoryControlPlaneStore) =
+    val st  = new InMemoryControlPlaneStore()
+    val sup = new PoolSupervisor(
+      fakeBackend(), new NodeLoadTracker, st,
+      defaultMetastore = Map.empty, dbAdmin = new RecordingDbAdmin, managedStore = cfg
+    )
+    (sup, st)
+
+  private val managedMeta = Map(
+    "pgHost" -> "h", "pgPort" -> "0", "pgUser" -> "u",
+    "pgPassword" -> "s", "dbName" -> "ignored", "schemaName" -> "main"
+  )
+
+  "PoolSupervisor.createTenantDb (managed)" should
+    "resolve an id-keyed managed dataPath and fill objectStore from config" in:
+    val (sup, st) = supManaged(Some(managedCfg()))
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val td = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync().toOption.get
+    td.dataPath should fullyMatch regex "s3://qod-managed/acme_sales-[0-9a-f]{8}/"
+    td.dataPath shouldBe s"s3://qod-managed/acme_sales-${td.id.stripPrefix("td-").take(8)}/"
+    td.objectStore("s3_access_key_id")     shouldBe "AK"
+    td.objectStore("s3_secret_access_key") shouldBe "SK"
+    td.objectStore("s3_region")            shouldBe "us-east-1"
+    td.objectStore("s3_url_style")         shouldBe "path"
+    td.objectStore.contains("s3_endpoint") shouldBe false
+    val row = st.managedPrefix(td.id)
+    row shouldBe defined
+    row.get.tenant       shouldBe "acme"
+    row.get.tenantDbName shouldBe "acme_sales"
+    row.get.prefix       shouldBe td.dataPath
+    row.get.deletedAt    shouldBe None
+
+  it should "refuse managed create when unconfigured" in:
+    val (sup, st) = supManaged(None)
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val out = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync()
+    out.swap.toOption.get shouldBe a[SupervisorError.InvalidArgument]
+    out.swap.toOption.get.message should include("QOD_MANAGED_STORE_ENABLED")
+    sup.listTenantDbsByTenant("acme") shouldBe empty
+
+  it should "refuse managed create when the config block is disabled" in:
+    val (sup, _) = supManaged(Some(managedCfg().copy(enabled = false)))
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val out = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync()
+    out.swap.toOption.get shouldBe a[SupervisorError.InvalidArgument]
+
+  it should "give a recreated database a fresh prefix" in:
+    val (sup, st) = supManaged(Some(managedCfg()))
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val first = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync().toOption.get
+    sup.deleteTenantDb("acme", "acme_sales").unsafeRunSync() shouldBe Right(())
+    val second = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync().toOption.get
+    second.id       should not be first.id
+    second.dataPath should not be first.dataPath
+    st.managedPrefix(first.id).get.deletedAt  shouldBe defined
+    st.managedPrefix(second.id).get.deletedAt shouldBe None
+
+  "PoolSupervisor.deleteTenantDb (managed)" should
+    "stamp eligibility per retainDays and immediately with the purge flag" in:
+    val (sup, st) = supManaged(Some(managedCfg()))
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val first = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync().toOption.get
+    sup.deleteTenantDb("acme", "acme_sales").unsafeRunSync() shouldBe Right(())
+    val retained = st.managedPrefix(first.id).get
+    val deleted  = retained.deletedAt.get
+    retained.purgeEligibleAt.get shouldBe deleted.plus(7, java.time.temporal.ChronoUnit.DAYS)
+    retained.purgedAt shouldBe None
+
+    val second = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync().toOption.get
+    sup.deleteTenantDb("acme", "acme_sales", purgeManagedData = true)
+      .unsafeRunSync() shouldBe Right(())
+    val purged = st.managedPrefix(second.id).get
+    purged.purgeEligibleAt.get shouldBe purged.deletedAt.get
+    // The first incarnation's window is untouched by the second's immediate purge.
+    st.managedPrefix(first.id).get.purgeEligibleAt.get shouldBe
+      deleted.plus(7, java.time.temporal.ChronoUnit.DAYS)
+
+  it should "leave a BYO database alone when purgeManagedData is set" in:
+    val (sup, st) = supManaged(Some(managedCfg()))
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val td = sup.createTenantDb(
+      "acme", "byo", TenantDbKind.DuckLake, managedMeta, dataPath = "/data/acme_byo"
+    ).unsafeRunSync().toOption.get
+    st.managedPrefix(td.id) shouldBe None
+    sup.deleteTenantDb("acme", "acme_byo", purgeManagedData = true)
+      .unsafeRunSync() shouldBe Right(())
+    st.managedPrefix(td.id) shouldBe None
+
+  "PoolSupervisor.deleteTenant (managed)" should
+    "stamp deletedAt and purgeEligibleAt on the managed prefix row during the cascade delete" in:
+    // deleteTenant's per-tenant-db loop calls stampManagedPrefixDeleted itself (it does not
+    // route through deleteTenantDb) -- pin that the cascade leaves the same tombstone behind
+    // so a managed prefix is never stranded un-eligible for purge.
+    val (sup, st) = supManaged(Some(managedCfg()))
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    val td = sup.createTenantDb(
+      "acme", "sales", TenantDbKind.DuckLake, managedMeta, dataPath = "",
+      managedStorage = true
+    ).unsafeRunSync().toOption.get
+    sup.deleteTenant("acme").unsafeRunSync() shouldBe Right(())
+    val row = st.managedPrefix(td.id).get
+    val deleted = row.deletedAt.get
+    row.purgeEligibleAt.get shouldBe deleted.plus(7, java.time.temporal.ChronoUnit.DAYS)
+
   "PoolSupervisor.deleteTenantDb" should "invoke DbAdmin.dropDatabase after the row is gone" in:
     val (sup, admin) = supWithAdmin()
     sup.createTenant(Tenant("tpch")).unsafeRunSync()

--- a/src/test/scala/ai/starlake/quack/ondemand/api/DtosWireContractSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/DtosWireContractSpec.scala
@@ -155,6 +155,29 @@ class DtosWireContractSpec extends AnyFlatSpec with Matchers:
   "TenantDbRequest" should "default every optional field when absent" in:
     decode[TenantDbRequest]("""{"tenant":"acme","name":"acme_x"}""") shouldBe
       Right(TenantDbRequest("acme", "acme_x"))
+    decode[TenantDbRequest]("""{"tenant":"acme","name":"acme_x"}""").map(_.managedStorage) shouldBe
+      Right(false)
+
+  it should "round-trip managedStorage through the wire" in:
+    val req = TenantDbRequest("acme", "sales", managedStorage = true)
+    req.asJson.hcursor.get[Boolean]("managedStorage") shouldBe Right(true)
+    decode[TenantDbRequest](req.asJson.noSpaces) shouldBe Right(req)
+    decode[TenantDbRequest](
+      """{"tenant":"acme","name":"sales","managedStorage":true}"""
+    ).map(_.managedStorage) shouldBe Right(true)
+
+  "TenantDbOpRequest" should "decode a body written before purgeManagedData existed" in:
+    // Pins the deriveCodec -> ConfiguredCodec swap: without it the added field makes
+    // every existing database/delete body fail to decode.
+    decode[TenantDbOpRequest]("""{"tenant":"t","name":"n"}""") shouldBe
+      Right(TenantDbOpRequest("t", "n"))
+    decode[TenantDbOpRequest]("""{"tenant":"t","name":"n"}""").map(_.purgeManagedData) shouldBe
+      Right(false)
+
+  it should "round-trip purgeManagedData through the wire" in:
+    val req = TenantDbOpRequest("t", "n", purgeManagedData = true)
+    req.asJson.hcursor.get[Boolean]("purgeManagedData") shouldBe Right(true)
+    decode[TenantDbOpRequest](req.asJson.noSpaces) shouldBe Right(req)
 
   // ----- Auth --------------------------------------------------------------
 

--- a/src/test/scala/ai/starlake/quack/ondemand/api/TenantDbHandlersSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/TenantDbHandlersSpec.scala
@@ -34,6 +34,17 @@ class TenantDbHandlersSpec extends AnyFlatSpec with Matchers:
     sup.createTenant(Tenant("acme")).unsafeRunSync()
     (sup, new TenantDbHandlers(sup))
 
+  /** Same fixture as [[freshHandlers]] but with `managedEnabled = true`, for the arms of
+    * `validateManagedStorage` that only fire once the deployment-level gate is open. */
+  private def freshHandlersManaged(): TenantDbHandlers =
+    val sup = new PoolSupervisor(
+      new StubQuackBackend(),
+      new NodeLoadTracker,
+      new InMemoryControlPlaneStore()
+    )
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    new TenantDbHandlers(sup, managedEnabled = true)
+
   private val denyingGate = new ai.starlake.quack.spi.MutationGate:
     def check(
         m: ai.starlake.quack.spi.StructureMutation
@@ -343,3 +354,76 @@ class TenantDbHandlersSpec extends AnyFlatSpec with Matchers:
       Some("root-key")
     )(superuserScopeOf).unsafeRunSync()
     out.isRight shouldBe true
+
+  "TenantDbHandlers.createTenantDb (managedStorage validation)" should
+    "reject managedStorage=true when managed storage is disabled on this deployment (400 invalid)" in:
+    val h = freshHandlers()
+    val out = h.createTenantDb(
+      TenantDbRequest(tenant = "acme", name = "mgd1", kind = "ducklake", managedStorage = true),
+      None
+    )((_: String) => None).unsafeRunSync()
+    out.isLeft shouldBe true
+    val (code, err) = out.swap.toOption.get
+    code shouldBe StatusCode.BadRequest
+    err.error shouldBe "invalid"
+    err.message should include("QOD_MANAGED_STORE_ENABLED")
+
+  it should "reject managedStorage=true combined with a non-empty dataPath (400 invalid, one intent per call)" in:
+    val h = freshHandlersManaged()
+    val out = h.createTenantDb(
+      TenantDbRequest(
+        tenant         = "acme",
+        name           = "mgd2",
+        kind           = "ducklake",
+        managedStorage = true,
+        dataPath       = "/data/acme_mgd2"
+      ),
+      None
+    )((_: String) => None).unsafeRunSync()
+    out.isLeft shouldBe true
+    val (code, err) = out.swap.toOption.get
+    code shouldBe StatusCode.BadRequest
+    err.error shouldBe "invalid"
+    err.message should include("one intent per call")
+
+  it should "reject managedStorage=true combined with a non-empty objectStore (400 invalid)" in:
+    val h = freshHandlersManaged()
+    val out = h.createTenantDb(
+      TenantDbRequest(
+        tenant         = "acme",
+        name           = "mgd3",
+        kind           = "ducklake",
+        managedStorage = true,
+        objectStore    = Map("s3_access_key_id" -> "k")
+      ),
+      None
+    )((_: String) => None).unsafeRunSync()
+    out.isLeft shouldBe true
+    val (code, err) = out.swap.toOption.get
+    code shouldBe StatusCode.BadRequest
+    err.error shouldBe "invalid"
+    err.message should include("one intent per call")
+
+  it should "reject managedStorage=true with kind=memory (400 invalid, names ducklake)" in:
+    val h = freshHandlersManaged()
+    val out = h.createTenantDb(
+      TenantDbRequest(tenant = "acme", name = "mgd4", kind = "memory", managedStorage = true),
+      None
+    )((_: String) => None).unsafeRunSync()
+    out.isLeft shouldBe true
+    val (code, err) = out.swap.toOption.get
+    code shouldBe StatusCode.BadRequest
+    err.error shouldBe "invalid"
+    err.message should include("ducklake")
+
+  it should "reject an unparseable kind with invalid_kind, even with managedStorage=true " +
+    "(the managed arm must not swallow the kind check)" in:
+    val h = freshHandlersManaged()
+    val out = h.createTenantDb(
+      TenantDbRequest(tenant = "acme", name = "mgd5", kind = "garbage", managedStorage = true),
+      None
+    )((_: String) => None).unsafeRunSync()
+    out.isLeft shouldBe true
+    val (code, err) = out.swap.toOption.get
+    code shouldBe StatusCode.BadRequest
+    err.error shouldBe "invalid_kind"

--- a/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryControlPlaneStore.scala
@@ -530,6 +530,52 @@ final class InMemoryControlPlaneStore extends ControlPlaneStore:
     }
     stale.size
 
+  // ---------------- Managed prefix (tombstone registry) ----------------
+  private val managedPrefixes = TrieMap.empty[String, ManagedPrefixRow]
+
+  def insertManagedPrefix(
+      id: String,
+      tenant: String,
+      tenantDbName: String,
+      prefix: String,
+      createdAt: Instant
+  ): Unit =
+    managedPrefixes.putIfAbsent(
+      id,
+      ManagedPrefixRow(
+        id = id,
+        tenant = tenant,
+        tenantDbName = tenantDbName,
+        prefix = prefix,
+        createdAt = createdAt,
+        deletedAt = None,
+        purgeEligibleAt = None,
+        purgedAt = None
+      )
+    )
+    ()
+
+  def markManagedPrefixDeleted(id: String, deletedAt: Instant, purgeEligibleAt: Instant): Unit =
+    managedPrefixes.get(id).foreach { row =>
+      managedPrefixes.put(
+        id,
+        row.copy(deletedAt = Some(deletedAt), purgeEligibleAt = Some(purgeEligibleAt))
+      )
+    }
+
+  def dueManagedPrefixes(now: Instant): List[ManagedPrefixRow] =
+    managedPrefixes.values
+      .filter(r => r.purgeEligibleAt.exists(!_.isAfter(now)) && r.purgedAt.isEmpty)
+      .toList
+      .sortBy(_.purgeEligibleAt.get)
+
+  def markManagedPrefixPurged(id: String, purgedAt: Instant): Unit =
+    managedPrefixes
+      .get(id)
+      .foreach(row => managedPrefixes.put(id, row.copy(purgedAt = Some(purgedAt))))
+
+  def managedPrefix(id: String): Option[ManagedPrefixRow] = managedPrefixes.get(id)
+
   def snapshot(): ControlPlaneSnapshot = ControlPlaneSnapshot(
     tenants = listTenants(),
     tenantDbs = tenantDbs.values.toList.sortBy(_.name),

--- a/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryManagedPrefixSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/InMemoryManagedPrefixSpec.scala
@@ -1,0 +1,119 @@
+package ai.starlake.quack.ondemand.state
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+/** Direct coverage for the managed-prefix (tombstone registry) methods on
+  * [[InMemoryControlPlaneStore]]. Mirrors the two Postgres-backed cases in
+  * [[PostgresControlPlaneStoreSpec]] so later purge-worker work can rely on both backends agreeing
+  * on: the inclusive `purgeEligibleAt <= now` boundary, ordering by `purgeEligibleAt` ascending,
+  * unknown-id marks being no-ops, and purged rows being excluded from `dueManagedPrefixes`. Plain
+  * unit test -- no Postgres dependency.
+  */
+class InMemoryManagedPrefixSpec extends AnyFlatSpec with Matchers:
+
+  private val tenant       = "tenant-1"
+  private val tenantDbName = "acme_default"
+
+  it should "walk the managed-prefix lifecycle" in {
+    val store     = new InMemoryControlPlaneStore()
+    val createdAt = Instant.parse("2026-08-12T10:00:00Z")
+    store.insertManagedPrefix(
+      "mp-1",
+      tenant,
+      tenantDbName,
+      "acme/acme_default/td-abc/",
+      createdAt
+    )
+    store.managedPrefix("mp-1") shouldBe Some(
+      ManagedPrefixRow(
+        id = "mp-1",
+        tenant = tenant,
+        tenantDbName = tenantDbName,
+        prefix = "acme/acme_default/td-abc/",
+        createdAt = createdAt,
+        deletedAt = None,
+        purgeEligibleAt = None,
+        purgedAt = None
+      )
+    )
+
+    val deletedAt       = createdAt.plusSeconds(3600)
+    val purgeEligibleAt = deletedAt.plusSeconds(604800)
+    store.markManagedPrefixDeleted("mp-1", deletedAt, purgeEligibleAt)
+    val afterDelete = store.managedPrefix("mp-1").get
+    afterDelete.deletedAt shouldBe Some(deletedAt)
+    afterDelete.purgeEligibleAt shouldBe Some(purgeEligibleAt)
+    afterDelete.purgedAt shouldBe None
+
+    store.dueManagedPrefixes(purgeEligibleAt.minusSeconds(1)) shouldBe Nil
+    // purge_eligible_at <= now is inclusive, so the boundary itself is due.
+    val due = store.dueManagedPrefixes(purgeEligibleAt)
+    due.map(_.id) shouldBe List("mp-1")
+
+    val purgedAt = purgeEligibleAt.plusSeconds(60)
+    store.markManagedPrefixPurged("mp-1", purgedAt)
+    store.dueManagedPrefixes(purgedAt) shouldBe Nil
+    val afterPurge = store.managedPrefix("mp-1").get
+    afterPurge.purgedAt shouldBe Some(purgedAt)
+  }
+
+  it should "order due prefixes by eligibility and skip unknown-id marks" in {
+    val store           = new InMemoryControlPlaneStore()
+    val createdAt       = Instant.parse("2026-08-12T10:00:00Z")
+    val laterEligible   = createdAt.plusSeconds(700000)
+    val earlierEligible = createdAt.plusSeconds(600000)
+    store.insertManagedPrefix(
+      "mp-later",
+      tenant,
+      tenantDbName,
+      "acme/acme_default/td-a/",
+      createdAt
+    )
+    store.insertManagedPrefix(
+      "mp-earlier",
+      tenant,
+      tenantDbName,
+      "acme/acme_default/td-b/",
+      createdAt
+    )
+    store.markManagedPrefixDeleted("mp-later", createdAt, laterEligible)
+    store.markManagedPrefixDeleted("mp-earlier", createdAt, earlierEligible)
+
+    val due = store.dueManagedPrefixes(laterEligible.plusSeconds(1))
+    due.map(_.id) shouldBe List("mp-earlier", "mp-later")
+
+    noException should be thrownBy store.markManagedPrefixDeleted(
+      "no-such-id",
+      createdAt,
+      createdAt.plusSeconds(1)
+    )
+    noException should be thrownBy store.markManagedPrefixPurged("no-such-id", createdAt)
+    store.managedPrefix("no-such-id") shouldBe None
+  }
+
+  it should "keep the first insert's createdAt on a duplicate id" in {
+    val store         = new InMemoryControlPlaneStore()
+    val firstCreated  = Instant.parse("2026-08-12T10:00:00Z")
+    val secondCreated = firstCreated.plusSeconds(3600)
+    store.insertManagedPrefix(
+      "mp-dup",
+      tenant,
+      tenantDbName,
+      "acme/acme_default/td-dup/",
+      firstCreated
+    )
+    store.insertManagedPrefix(
+      "mp-dup",
+      tenant,
+      tenantDbName,
+      "acme/acme_default/td-dup-2/",
+      secondCreated
+    )
+
+    val row = store.managedPrefix("mp-dup").get
+    row.createdAt shouldBe firstCreated
+    row.prefix shouldBe "acme/acme_default/td-dup/"
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/state/LiquibaseRunnerSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/LiquibaseRunnerSpec.scala
@@ -57,6 +57,7 @@ class LiquibaseRunnerSpec extends AnyFlatSpec with Matchers:
           "qodstate_group_role",
           "qodstate_maintenance_policy",
           "qodstate_maintenance_run",
+          "qodstate_managed_prefix",
           "qodstate_node",
           "qodstate_pool",
           "qodstate_pool_load",
@@ -104,8 +105,9 @@ class LiquibaseRunnerSpec extends AnyFlatSpec with Matchers:
       // rollup_watermark, Liquibase 0019) +
       // 1 snapshot-tag table (snapshot_tag, Liquibase 0020) +
       // 2 maintenance tables (policy + run, Liquibase 0021) +
-      // 1 autoscale-demand table (pool_load, Liquibase 0026).
+      // 1 autoscale-demand table (pool_load, Liquibase 0026) +
+      // 1 tombstone-registry table (managed_prefix, Liquibase 0027).
       // qodstate_tenant_identity is gone -- auth provider is a tenant attribute now.
-      rs.getInt(1) shouldBe 25
+      rs.getInt(1) shouldBe 26
     finally c.close()
   }

--- a/src/test/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStoreSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/PostgresControlPlaneStoreSpec.scala
@@ -234,6 +234,108 @@ class PostgresControlPlaneStoreSpec extends AnyFlatSpec with Matchers:
     store.poolLoadWindow(b0) shouldBe Map(pool.id -> (1L, 200L))
   }
 
+  it should "walk the managed-prefix lifecycle" in withStore { store =>
+    store.upsertTenant(tenant)
+    store.upsertTenantDb(tenantDb)
+    val createdAt = Instant.parse("2026-08-12T10:00:00Z")
+    store.insertManagedPrefix(
+      "mp-1",
+      tenant.id,
+      tenantDb.name,
+      "acme/acme_default/td-abc/",
+      createdAt
+    )
+    store.managedPrefix("mp-1") shouldBe Some(
+      ManagedPrefixRow(
+        id = "mp-1",
+        tenant = tenant.id,
+        tenantDbName = tenantDb.name,
+        prefix = "acme/acme_default/td-abc/",
+        createdAt = createdAt,
+        deletedAt = None,
+        purgeEligibleAt = None,
+        purgedAt = None
+      )
+    )
+
+    val deletedAt       = createdAt.plusSeconds(3600)
+    val purgeEligibleAt = deletedAt.plusSeconds(604800)
+    store.markManagedPrefixDeleted("mp-1", deletedAt, purgeEligibleAt)
+    val afterDelete = store.managedPrefix("mp-1").get
+    afterDelete.deletedAt shouldBe Some(deletedAt)
+    afterDelete.purgeEligibleAt shouldBe Some(purgeEligibleAt)
+    afterDelete.purgedAt shouldBe None
+
+    store.dueManagedPrefixes(purgeEligibleAt.minusSeconds(1)) shouldBe Nil
+    // purge_eligible_at <= now is inclusive, so the boundary itself is due.
+    val due = store.dueManagedPrefixes(purgeEligibleAt)
+    due.map(_.id) shouldBe List("mp-1")
+
+    val purgedAt = purgeEligibleAt.plusSeconds(60)
+    store.markManagedPrefixPurged("mp-1", purgedAt)
+    store.dueManagedPrefixes(purgedAt) shouldBe Nil
+    val afterPurge = store.managedPrefix("mp-1").get
+    afterPurge.purgedAt shouldBe Some(purgedAt)
+  }
+
+  it should "order due prefixes by eligibility and skip unknown-id marks" in withStore { store =>
+    store.upsertTenant(tenant)
+    store.upsertTenantDb(tenantDb)
+    val createdAt       = Instant.parse("2026-08-12T10:00:00Z")
+    val laterEligible   = createdAt.plusSeconds(700000)
+    val earlierEligible = createdAt.plusSeconds(600000)
+    store.insertManagedPrefix(
+      "mp-later",
+      tenant.id,
+      tenantDb.name,
+      "acme/acme_default/td-a/",
+      createdAt
+    )
+    store.insertManagedPrefix(
+      "mp-earlier",
+      tenant.id,
+      tenantDb.name,
+      "acme/acme_default/td-b/",
+      createdAt
+    )
+    store.markManagedPrefixDeleted("mp-later", createdAt, laterEligible)
+    store.markManagedPrefixDeleted("mp-earlier", createdAt, earlierEligible)
+
+    val due = store.dueManagedPrefixes(laterEligible.plusSeconds(1))
+    due.map(_.id) shouldBe List("mp-earlier", "mp-later")
+
+    noException should be thrownBy store.markManagedPrefixDeleted(
+      "no-such-id",
+      createdAt,
+      createdAt.plusSeconds(1)
+    )
+  }
+
+  it should "keep the first insert's createdAt on a duplicate id" in withStore { store =>
+    store.upsertTenant(tenant)
+    store.upsertTenantDb(tenantDb)
+    val firstCreated  = Instant.parse("2026-08-12T10:00:00Z")
+    val secondCreated = firstCreated.plusSeconds(3600)
+    store.insertManagedPrefix(
+      "mp-dup",
+      tenant.id,
+      tenantDb.name,
+      "acme/acme_default/td-dup/",
+      firstCreated
+    )
+    store.insertManagedPrefix(
+      "mp-dup",
+      tenant.id,
+      tenantDb.name,
+      "acme/acme_default/td-dup-2/",
+      secondCreated
+    )
+
+    val row = store.managedPrefix("mp-dup").get
+    row.createdAt shouldBe firstCreated
+    row.prefix shouldBe "acme/acme_default/td-dup/"
+  }
+
   it should "preserve idleTimeoutSec as a populated Option" in withStore { store =>
     store.upsertTenant(tenant)
     store.upsertTenantDb(tenantDb)

--- a/src/test/scala/ai/starlake/quack/ondemand/storage/ManagedPrefixSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/storage/ManagedPrefixSpec.scala
@@ -1,0 +1,52 @@
+package ai.starlake.quack.ondemand.storage
+
+import ai.starlake.quack.ManagedObjectStoreConfig
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.s3.model.S3Error
+
+class ManagedPrefixSpec extends AnyFlatSpec with Matchers:
+  "id8" should "strip the td- prefix before taking 8 chars" in:
+    ManagedPrefix.id8("td-0123456789abcdef0123456789abcdef") shouldBe "01234567"
+
+  "dataPath" should "build the spec's prefix shape" in:
+    ManagedPrefix.dataPath("qod-managed", "acme", "sales", "td-aabbccddeeff00112233") shouldBe
+      "s3://qod-managed/acme_sales-aabbccdd/"
+
+  "keyPrefix" should "match dataPath minus scheme and bucket" in:
+    ManagedPrefix.keyPrefix("acme", "sales", "td-aabbccddeeff00112233") shouldBe
+      "acme_sales-aabbccdd/"
+
+  "objectStoreFor" should "fill the BYO key vocabulary and omit empty endpoint" in:
+    val cfg = ManagedObjectStoreConfig(
+      enabled = true,
+      region = "eu-west-1",
+      accessKeyId = "AK",
+      secretAccessKey = "SK"
+    )
+    val m = ManagedPrefix.objectStoreFor(cfg)
+    m("s3_region") shouldBe "eu-west-1"
+    m("s3_url_style") shouldBe "path"
+    m("s3_access_key_id") shouldBe "AK"
+    m("s3_secret_access_key") shouldBe "SK"
+    m.contains("s3_endpoint") shouldBe false
+    ManagedPrefix
+      .objectStoreFor(cfg.copy(endpoint = "http://minio:9000"))("s3_endpoint") shouldBe
+      "http://minio:9000"
+
+  // S3 answers DeleteObjects with 200 even when individual keys failed; swallowing
+  // that turns the purge worker into a silent non-progress loop (the listing never
+  // empties and no Left ever reaches the sweep's warn path).
+  "deleteOutcome" should "be Right when the response carries no per-key errors" in:
+    S3ManagedStoreClient.deleteOutcome(Nil) shouldBe Right(())
+
+  it should "be Left naming the first failing key and its code" in:
+    val errs = List(
+      S3Error.builder().key("acme_sales-aabbccdd/data/f1.parquet").code("AccessDenied").build(),
+      S3Error.builder().key("acme_sales-aabbccdd/data/f2.parquet").code("InternalError").build()
+    )
+    S3ManagedStoreClient.deleteOutcome(errs) shouldBe
+      Left(
+        "deleteBatch: 2 key(s) failed, first: " +
+          "acme_sales-aabbccdd/data/f1.parquet (AccessDenied)"
+      )

--- a/src/test/scala/ai/starlake/quack/ondemand/storage/testkit/StubManagedStoreClient.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/storage/testkit/StubManagedStoreClient.scala
@@ -1,0 +1,55 @@
+package ai.starlake.quack.ondemand.storage.testkit
+
+import ai.starlake.quack.ondemand.storage.ManagedStoreClient
+
+import scala.collection.concurrent.TrieMap
+
+/** In-memory [[ManagedStoreClient]] test double. No network, no AWS SDK. Consumed by the specs that
+  * drive prefix listing / batch deletion (Tasks 3-5).
+  */
+final class StubManagedStoreClient extends ManagedStoreClient:
+  private val keys = TrieMap.empty[String, Unit]
+
+  /** When set, the NEXT `deleteBatch` call returns `Left(msg)` instead of deleting, then the flag
+    * resets to `None` so later calls succeed again (single-shot failure injection).
+    */
+  var failNextDelete: Option[String] = None
+
+  /** When set, the NEXT `listPrefix` call returns `Left(msg)` instead of listing, then the flag
+    * resets to `None` so later calls succeed again (single-shot failure injection).
+    */
+  var failNextList: Option[String] = None
+
+  var listPrefixCalls: Int  = 0
+  var deleteBatchCalls: Int = 0
+
+  /** Seed `count` synthetic keys under `prefix` (e.g. `prefix0`, `prefix1`, ...). */
+  def seed(prefix: String, count: Int): Unit =
+    (0 until count).foreach(i => keys.put(s"$prefix$i", ()))
+
+  /** Insert a single key. */
+  def insert(key: String): Unit = keys.put(key, ())
+
+  /** Snapshot of every key currently held, for assertions. */
+  def allKeys: List[String] = keys.keys.toList
+
+  def ensureBucket(): Either[String, Unit] = Right(())
+
+  def listPrefix(prefix: String, max: Int): Either[String, List[String]] =
+    listPrefixCalls += 1
+    failNextList match
+      case Some(msg) =>
+        failNextList = None
+        Left(msg)
+      case None =>
+        Right(keys.keys.filter(_.startsWith(prefix)).toList.sorted.take(max))
+
+  def deleteBatch(ks: List[String]): Either[String, Unit] =
+    deleteBatchCalls += 1
+    failNextDelete match
+      case Some(msg) =>
+        failNextDelete = None
+        Left(msg)
+      case None =>
+        ks.foreach(keys.remove)
+        Right(())

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -298,6 +298,9 @@ export interface TenantDbRequest {
   defaultDatabase?: string;
   defaultSchema?: string;
   initSql?: string;
+  // DuckLake only; exclusive with dataPath/objectStore. When true the
+  // server provisions and resolves the dataPath itself.
+  managedStorage?: boolean;
 }
 
 export interface TenantDbResponse {
@@ -330,6 +333,9 @@ export interface TenantDbListResponse {
 export interface TenantDbOpRequest {
   tenant: string;
   name: string;
+  // Immediate purge eligibility for managed object storage vs. the
+  // retention window. Ignored (server WARNs) for non-managed databases.
+  purgeManagedData?: boolean;
 }
 
 export interface UpdateTenantDbRequest {

--- a/ui/src/components/DataPathEditor.tsx
+++ b/ui/src/components/DataPathEditor.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 // human strings shown in the dropdown; the keys are the values
 // persisted on the tenant-db row's `objectStore` map and used by the
 // Quack node to attach the right cloud filesystem.
-export type StoreType = 'none' | 's3' | 'r2' | 'azure' | 'gcs';
+export type StoreType = 'none' | 's3' | 'r2' | 'azure' | 'gcs' | 'managed';
 
 interface KeySpec {
   name:        string;
@@ -22,6 +22,10 @@ interface StoreSpec {
 const STORE_SPECS: Record<StoreType, StoreSpec> = {
   none: {
     label: 'Local filesystem',
+    keys:  []
+  },
+  managed: {
+    label: 'Managed (QoD-provisioned)',
     keys:  []
   },
   s3: {
@@ -95,7 +99,7 @@ export function buildObjectStore(
   storeKeys:   Record<string, string>,
   storeExtras: string,
 ): Record<string, string> {
-  if (storeType === 'none') return {};
+  if (storeType === 'none' || storeType === 'managed') return {};
   const spec   = STORE_SPECS[storeType];
   const forbid = new Set(spec.keys.map(k => k.name));
   const extras = parseExtras(storeExtras, forbid);
@@ -150,7 +154,14 @@ export default function DataPathEditor(p: Props) {
           <span>Backend</span>
           <select
             value={p.storeType}
-            onChange={ev => p.onStoreTypeChange(ev.target.value as StoreType)}
+            onChange={ev => {
+              const next = ev.target.value as StoreType;
+              // Managed storage has no path for the user to set; clear any
+              // path typed under a previous backend selection so the
+              // disabled field doesn't show stale, unsent text.
+              if (next === 'managed' && p.dataPath !== '') p.onDataPathChange('');
+              p.onStoreTypeChange(next);
+            }}
           >
             {(Object.keys(STORE_SPECS) as StoreType[]).map(t => (
               <option key={t} value={t}>{STORE_SPECS[t].label}</option>
@@ -162,11 +173,19 @@ export default function DataPathEditor(p: Props) {
           <input
             value={p.dataPath}
             onChange={ev => p.onDataPathChange(ev.target.value)}
-            placeholder="/data/prod or s3://bucket/path"
+            placeholder={p.storeType === 'managed' ? 'resolved by the server at create' : '/data/prod or s3://bucket/path'}
+            disabled={p.storeType === 'managed'}
             style={{ width: '100%' }}
           />
         </label>
       </div>
+
+      {p.storeType === 'managed' && (
+        <p className="subtle" style={{ marginTop: '0.5rem' }}>
+          The server provisions object storage for this database and resolves its data path
+          automatically; no credentials to fill in.
+        </p>
+      )}
 
       {spec.keys.length > 0 && (
         <div style={{ marginTop: '0.75rem' }}>

--- a/ui/src/components/DatabaseSection.tsx
+++ b/ui/src/components/DatabaseSection.tsx
@@ -130,7 +130,12 @@ export default function DatabaseSection({ tenant }: { tenant: string }) {
         name,  // server is idempotent on already-prefixed input
         kind,
       };
-      if (kind === 'ducklake') {
+      if (kind === 'ducklake' && storeType === 'managed') {
+        reqBody.metastore      = collectMetastore();
+        reqBody.managedStorage = true;
+        // dataPath / objectStore intentionally omitted -- the server
+        // provisions and resolves the data path itself.
+      } else if (kind === 'ducklake') {
         reqBody.metastore   = collectMetastore();
         reqBody.dataPath    = dataPath.trim();
         reqBody.objectStore = buildObjectStore(storeType, storeKeys, storeExtras);
@@ -151,12 +156,16 @@ export default function DatabaseSection({ tenant }: { tenant: string }) {
     }
   }
 
-  async function handleDelete(dbName: string): Promise<boolean> {
+  async function handleDelete(dbName: string, kind: TenantDbKind): Promise<boolean> {
     if (!confirm(`Delete database '${dbName}' from tenant '${tenant}'?\n\n` +
                  `This drops the Postgres database '${dbName}' and any DuckLake catalog in it.`)) return false;
+    // Only a ducklake database can hold managed object storage; the second
+    // confirm is meaningless (and confusing) for duckdb-file / memory kinds.
+    const purge = kind === 'ducklake' && confirm('Also purge managed object storage now? ' +
+      'OK = purge immediately, Cancel = retain for the configured window.');
     setError(null);
     try {
-      await api.deleteTenantDb({ tenant, name: dbName });
+      await api.deleteTenantDb({ tenant, name: dbName, purgeManagedData: purge });
       await reload();
       return true;
     } catch (e) {
@@ -372,7 +381,7 @@ export default function DatabaseSection({ tenant }: { tenant: string }) {
             </label>
             <div className="row" style={{ gap: 8, marginTop: '0.75rem', justifyContent: 'space-between' }}>
               <button type="button" className="danger"
-                onClick={() => void (async () => { const ok = await handleDelete(editingDb.name); if (ok) setEditingDb(null); })()}>
+                onClick={() => void (async () => { const ok = await handleDelete(editingDb.name, editingDb.kind); if (ok) setEditingDb(null); })()}>
                 Delete database
               </button>
               <div className="row" style={{ gap: 8 }}>

--- a/website/docs/operating/managed-storage.md
+++ b/website/docs/operating/managed-storage.md
@@ -1,0 +1,129 @@
+---
+id: managed-storage
+title: Managed object storage
+---
+
+A DuckLake database normally points at a `dataPath` you choose, authenticated either by the manager-wide object-store credentials or by that database's own `objectStore` keys (see [Tenants and databases](/operating/tenants-databases#per-database-object-store-credentials)). Managed object storage is the other option: the operator configures **one** root bucket once, and each database created with `managedStorage` gets its own prefix carved out of it, provisioned and reclaimed by the manager.
+
+It is off by default. Nothing in this page applies until `QOD_MANAGED_STORE_ENABLED=true`.
+
+## Configuration
+
+The `quack-on-demand.managedObjectStore` block. As always, prefer the environment variables over editing the bundled `application.conf`.
+
+| Key | Env var | Default | Meaning |
+|---|---|---|---|
+| `enabled` | `QOD_MANAGED_STORE_ENABLED` | `false` | Master switch. While off, a managed create is refused with `400`. |
+| `endpoint` | `QOD_MANAGED_STORE_ENDPOINT` | _(empty)_ | S3-compatible endpoint URL. Empty means AWS default endpoint resolution. |
+| `region` | `QOD_MANAGED_STORE_REGION` | `us-east-1` | Region passed to the S3 client. |
+| `bucket` | `QOD_MANAGED_STORE_BUCKET` | `qod-managed` | The operator root bucket every managed prefix lives in. |
+| `accessKeyId` | `QOD_MANAGED_STORE_ACCESS_KEY_ID` | _(empty)_ | Operator access key id. |
+| `secretAccessKey` | `QOD_MANAGED_STORE_SECRET_ACCESS_KEY` | _(empty)_ | Operator secret access key. Redacted in config output. |
+| `urlStyle` | `QOD_MANAGED_STORE_URL_STYLE` | `path` | `path` for S3-compatible stores, `vhost` for AWS. Any other value is refused at config load. |
+| `retainDays` | `QOD_MANAGED_STORE_RETAIN_DAYS` | `7` | Days a deleted database's objects are retained before the purge worker removes them. `0` makes every delete immediately eligible. |
+| `purgeSweepSec` | `QOD_MANAGED_STORE_PURGE_SWEEP_SEC` | `300` | Purge worker cadence, clamped to a 60 second floor. |
+
+The manager creates the root bucket at boot if it does not exist and logs `managed object store ready: bucket '<name>'`. The probe is advisory: an unreachable or mis-credentialed store logs `managed object store unreachable: managed creates still succeed at the control plane, but their nodes will fail to ATTACH until the store recovers` and never blocks boot. It does not gate managed creates either - a `database/create` with `managedStorage: true` succeeds at the control plane regardless of store reachability; the failure only surfaces later, when a node tries to ATTACH against the missing bucket.
+
+:::warning Versioning must be OFF on the managed bucket
+On a versioned bucket a delete does not remove the object, it writes a delete marker. The purge worker's next listing then comes back empty, so it stamps the prefix as purged while every non-current version survives and keeps costing money, invisible to the inventory query below. Create the root bucket with versioning disabled, and do not enable it later.
+:::
+
+## Creating a managed database
+
+Send `managedStorage: true` and no location of your own:
+
+```bash
+qod database create --tenant acme --name sales --kind ducklake --managed-storage
+```
+
+```bash
+curl -sS -X POST "$MGR/api/database/create" \
+  -H "X-API-Key: $QOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","name":"sales","kind":"ducklake","managedStorage":true}'
+```
+
+In the admin UI, pick the storage mode **Managed (QoD-provisioned)** in the database form; it takes no fields, and the resolved path shows up on the database after create.
+
+The manager resolves:
+
+```
+dataPath = s3://<bucket>/<tenant>_<dbname>-<id8>/
+```
+
+where `id8` is the first 8 characters of the database's surrogate id. Prefixes are keyed by the incarnation, not by the name: delete `acme_sales` and create it again and the new database gets a fresh, empty prefix instead of inheriting its predecessor's files. The response carries the effective `dataPath`.
+
+The database's `objectStore` map is filled from the config block (`s3_endpoint`, `s3_region`, `s3_url_style`, `s3_access_key_id`, `s3_secret_access_key`), so everything downstream behaves exactly as it does for a bring-your-own bucket: the path-scoped `CREATE SECRET` at node spawn, secret redaction on GET/list, the Kubernetes per-node Secret, and manifest export redaction.
+
+Three refusals, all `400` with an actionable message:
+
+- managed storage is not enabled on this deployment (the message names `QOD_MANAGED_STORE_ENABLED`);
+- `managedStorage` sent together with a `dataPath` or an `objectStore` (one intent per call);
+- `managedStorage` on a kind other than `ducklake`.
+
+:::note No migration between the two models
+`database/update` does not accept `managedStorage`. The field does not exist on the update request at all, so there is no bring-your-own-to-managed conversion and no managed-to-bring-your-own conversion. Moving a database between storage models means creating a new database and reloading the data.
+:::
+
+## Lifecycle: create, tombstone, retain, purge
+
+1. **Create.** The prefix is resolved and a row is written to the control-plane table `qodstate_managed_prefix` (id, tenant, database name, prefix, `created_at`).
+2. **Delete.** `database/delete` stamps `deleted_at` and `purge_eligible_at` on that row and returns immediately. `purge_eligible_at` is `deleted_at + retainDays`, or `deleted_at` itself when the caller asked for an immediate purge. The objects are untouched at this point. Deleting the owning tenant cascades the same stamp with the normal retention window, never immediate.
+3. **Retain.** Until `purge_eligible_at`, the data is still in the bucket and still billed. That window doubles as the undrop window: the files are recoverable by hand while it lasts.
+4. **Purge.** A background worker sweeps every `purgeSweepSec`, picks up every row whose `purge_eligible_at` has passed and whose `purged_at` is null, lists and batch-deletes the objects under the prefix, and stamps `purged_at` once a listing comes back empty. It logs one `managed purge:` line per outcome.
+
+The worker is gated on HA leadership, so exactly one replica purges. It bounds the number of list-and-delete rounds per prefix per sweep, so a very large prefix drains over several sweeps instead of holding the sweep open; the tombstone row simply stays due until it is empty. A failure on one prefix logs a warning and moves on to the next row, and is retried on the following sweep.
+
+### Purging immediately
+
+```bash
+qod database delete --tenant acme --name acme_sales --purge-managed-data
+```
+
+```bash
+curl -sS -X POST "$MGR/api/database/delete" \
+  -H "X-API-Key: $QOD_API_KEY" -H 'Content-Type: application/json' \
+  -d '{"tenant":"acme","name":"acme_sales","purgeManagedData":true}'
+```
+
+The admin UI asks a second time on a `ducklake` delete ("Also purge managed object storage now?"); confirming sets the same flag. "Immediately" means immediately *eligible*: the delete call still returns as fast as a plain delete, and the worker removes the objects on its next sweep. The flag is ignored, with a warning in the log, on a database that has no managed prefix.
+
+### Inventory
+
+```sql
+SELECT id, prefix, deleted_at, purge_eligible_at, purged_at
+FROM qodstate_managed_prefix
+ORDER BY created_at;
+```
+
+- `deleted_at IS NULL` - a live database.
+- `deleted_at` set, `purged_at` null - retained. The objects still exist and still cost money; `purge_eligible_at` tells you when the worker will take them.
+- `purged_at` set - the objects are gone. The row is kept as an audit trail, one row per database incarnation.
+
+## Operational notes
+
+### Changing the bucket strands existing tombstones
+
+`QOD_MANAGED_STORE_BUCKET` is not a value you can swap in place. Tombstone rows hold the full `s3://bucket/...` prefix they were written with; after a bucket change those rows no longer sit under the configured root, so the purge worker refuses to list them (it will not risk enumerating a whole bucket from a mismatched prefix), warns `skipping <id>, prefix ... is not under ...` on every sweep, and the old bucket's objects leak indefinitely. Before switching buckets, purge the outstanding prefixes or migrate them, and confirm the sweep log is quiet afterwards.
+
+### First-boot warning in HA
+
+With several manager replicas starting together, they all probe the store and race to create the root bucket. The replicas that lose the race can log one `managed object store unreachable` warning at first boot. It is a false alarm, it self-heals on the next probe, and the store is fine. A warning that repeats on a settled cluster is real.
+
+### Isolation posture: shared credential, prefix by convention
+
+All managed databases share the operator credential. Isolation between tenants' managed data is prefix-by-convention, enforced by QoD's node configuration (the per-database `CREATE SECRET` scoped to that database's own `dataPath`) plus [per-pool lockdown](/operating/hardening), not by store-level ACLs. A principal who can run arbitrary configuration statements on a node with those credentials is not confined by the bucket itself. Keep node lockdown on for managed deployments, and treat the operator credential as a manager-level secret.
+
+Per-database credential minting (per-database keys issued by the store's admin API or by IAM) is the designed follow-up; it would change only which credentials land in a database's `objectStore`, not the prefix layout or the lifecycle above.
+
+### Credential rotation
+
+A managed create snapshots the operator credential (`QOD_MANAGED_STORE_ACCESS_KEY_ID` / `QOD_MANAGED_STORE_SECRET_ACCESS_KEY`) into that database's own `objectStore` at create time; it is a copy, not a live reference to the config block. Rotating `QOD_MANAGED_STORE_SECRET_ACCESS_KEY` on the manager therefore only affects *future* managed creates - every managed database that already exists keeps signing requests with the old key until something rewrites its `objectStore`, and it breaks at its next node respawn once the old key is revoked at the store.
+
+Today's remediation is manual, per database: `database/update` with a fresh `objectStore` pointing at the new secret, then recycle that database's pools so nodes pick it up on their next spawn. Per-database credential minting (above) is the designed follow-up that would make rotation blast-radius-free by construction.
+
+## See also
+
+- [Tenants and databases](/operating/tenants-databases) - the bring-your-own-bucket alternative and the rest of the database fields.
+- [Configuration reference](/reference/configuration) - the generated table for every `managedObjectStore` key.
+- [Managed DuckLake maintenance](/operating/maintenance) - compaction and snapshot expiry, which bound what a managed prefix actually stores.

--- a/website/docs/operating/tenants-databases.md
+++ b/website/docs/operating/tenants-databases.md
@@ -100,6 +100,10 @@ This per-db secret is authored only for `kind=ducklake` databases (both spawn sc
 
 Editing `objectStore` (create or update) restarts the database's nodes so the new secret takes effect immediately; edits do not rotate a secret on an already-running node without a respawn. For object storage on S3-compatible backends and the manager-wide `QOD_S3_*` keys, see the Docker deployment page and the [Configuration reference](/reference/configuration).
 
+### Managed object storage
+
+The alternative to bringing your own bucket: with `quack-on-demand.managedObjectStore` enabled, `qod database create --managed-storage` (or `managedStorage: true`, or the storage mode "Managed (QoD-provisioned)" in the admin UI) lets the manager carve this database's `dataPath` out of one operator root bucket and fill its `objectStore` for you. `managedStorage` is exclusive with `dataPath` and `objectStore`, requires `kind=ducklake`, and is refused while the config block is off. Deleting such a database tombstones its prefix and a background worker purges the objects after a retention window. See [Managed object storage](/operating/managed-storage).
+
 ### List and delete
 
 ```bash
@@ -110,7 +114,7 @@ qod database list --tenant acme
 qod database delete --tenant acme --name sales
 ```
 
-Deleting a database removes the `qodstate_tenant_db` row. The underlying Postgres database and any object-store Parquet are not erased by the API; reclaim them separately if you no longer need the data.
+Deleting a database removes the `qodstate_tenant_db` row. The underlying Postgres database and any object-store Parquet are not erased by the API; reclaim them separately if you no longer need the data. The exception is a database on [managed object storage](/operating/managed-storage), whose data QoD does reclaim: delete tombstones the prefix and a background worker purges the objects once the retention window elapses, or right away with `--purge-managed-data`.
 
 ## Next step
 

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -194,6 +194,20 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | `quack-on-demand.maintenance.runTimeoutMin` | `QOD_MAINT_RUN_TIMEOUT_MIN` | `60` |  | Minutes without a heartbeat before a running maintenance run is swept as failed. |
 | `quack-on-demand.maintenance.nodeReadyTimeoutSec` | `QOD_MAINT_NODE_READY_TIMEOUT_SEC` | `180` |  | Seconds to wait for the ephemeral maintenance node to accept connections after spawn before the run is failed as 'node spawn failed'. Covers cold-start extension installs. |
 
+## `quack-on-demand.managedObjectStore`
+
+| Key | Env var | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `quack-on-demand.managedObjectStore.enabled` | `QOD_MANAGED_STORE_ENABLED` | `false` |  | Global kill switch for managed object storage. Off = managed creates 400. |
+| `quack-on-demand.managedObjectStore.endpoint` | `QOD_MANAGED_STORE_ENDPOINT` | _(unset)_ |  | S3-compatible endpoint URL for the operator root bucket. |
+| `quack-on-demand.managedObjectStore.region` | `QOD_MANAGED_STORE_REGION` | `us-east-1` |  | Region passed to the S3-compatible client. |
+| `quack-on-demand.managedObjectStore.bucket` | `QOD_MANAGED_STORE_BUCKET` | `qod-managed` |  | Operator root bucket; each tenant-db incarnation gets its own prefix. |
+| `quack-on-demand.managedObjectStore.accessKeyId` | `QOD_MANAGED_STORE_ACCESS_KEY_ID` | _(unset)_ |  | Access key id for the operator root bucket. |
+| `quack-on-demand.managedObjectStore.secretAccessKey` | `QOD_MANAGED_STORE_SECRET_ACCESS_KEY` | `***` | yes | Secret access key for the operator root bucket. |
+| `quack-on-demand.managedObjectStore.urlStyle` | `QOD_MANAGED_STORE_URL_STYLE` | `path` |  | Bucket addressing style presented to clients: 'path' or 'vhost'. |
+| `quack-on-demand.managedObjectStore.retainDays` | `QOD_MANAGED_STORE_RETAIN_DAYS` | `7` |  | Days a deleted tenant-db prefix is retained before the purge worker removes it. |
+| `quack-on-demand.managedObjectStore.purgeSweepSec` | `QOD_MANAGED_STORE_PURGE_SWEEP_SEC` | `300` |  | Purge worker sweep interval in seconds; clamped to a 60s floor. |
+
 ## `quack-on-demand.metrics`
 
 | Key | Env var | Default | Sensitive | Description |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -55,6 +55,7 @@ const sidebars: SidebarsConfig = {
           label: 'Provisioning',
           items: [
             'operating/tenants-databases',
+            'operating/managed-storage',
             'operating/pools-cohorts',
             'operating/autoscaling',
             'operating/federation',


### PR DESCRIPTION
## Summary

Managed object storage for tenant databases: instead of bringing a bucket, a `ducklake` database can ask QoD to carve its data path out of ONE operator-owned root bucket (`database/create` + `managedStorage: true`, exclusive with `dataPath`/`objectStore`). First implemented slice of the hosted enrollment journey (slice D), built in core so it works on every deployment shape.

- **Prefix resolution**: `s3://<bucket>/<tenant>_<name>-<id8>/`, keyed by the tenant-db surrogate id, so recreating a deleted name always gets a fresh empty prefix (no incarnation mixing, safely purgeable). The database's `objectStore` is filled from the new `quack-on-demand.managedObjectStore` config block (9 keys, `QOD_MANAGED_STORE_*`, disabled by default), riding all existing per-db mechanisms unchanged: node `CREATE SECRET` scoping, `SecretKeys` redaction, spawn env, manifest export.
- **Lifecycle**: deletion stamps a tombstone in the new `qodstate_managed_prefix` registry (changeset 0027: orphan inventory + purge queue + undrop window). Objects purge automatically and asynchronously after `retainDays` (default 7); `purgeManagedData: true` on delete makes the prefix immediately eligible. Tenant deletion cascades tombstones. Rows survive as an audit trail.
- **Purge worker** (`ManagedStoreWiring`): HA-leader-gated per tick inside `IO.defer` (the latched-gate pattern), bounded list+delete batches resuming across sweeps, per-prefix failure isolation, per-row cancellation checkpoints so shutdown never stalls behind a sweep, defensive prefix-strip guard (a bucket-mismatched row is skipped, never a whole-bucket listing), and S3 `DeleteObjects` per-key errors surface as failures instead of silent non-progress.
- **Boot probe**: creates the root bucket if missing; advisory only, WARN on unreachable, never blocks boot or creates (the failure surfaces at node ATTACH, and the docs say exactly that).
- **Surfaces**: admin UI storage mode "Managed (QoD-provisioned)" + kind-gated purge confirm on delete; CLI `qod database create --managed-storage` / `delete --purge-managed-data`; OpenAPI contract regenerated, parity gates green. AWS SDK v2 `s3` pinned explicitly at 2.42.21 (previously transitive via fs2-blobstore).
- **Operator docs** (new `website/docs/operating/managed-storage.md`, runbook recipe, CLAUDE.md): the versioning-OFF bucket requirement (delete markers would fake a successful purge), credential-rotation snapshot semantics, the HA first-boot create race, bucket-change tombstone stranding, and the shared-credential prefix-by-convention isolation posture.

Design spec: `docs/superpowers/specs/2026-08-13-managed-object-storage-design.md`.

## Test plan

- Full suite: 2186 tests, 2184 green; both failures environmental on the dev machine (`EndToEndSmokeSpec` ran against a live user-started 0.6.2 manager squatting :20900; `DemoDifferentiatorSpec` known machine-broken). All feature suites green: config (11), ManagedPrefixSpec (6), store lifecycle incl. InMemory mirror + keep-first idempotency (48-run batch), supervisor + handler validation matrix (145-222 runs), ManagedStoreWiringSpec (6, incl. leadership-flip on one bound IO, 2500-key multi-tick resume, per-prefix and per-list failure isolation), UI `tsc`+vite clean, CLI 249 passed / 1 skipped with REST-parity and `OpenApiFreshnessSpec` green, website build clean.
- **Live SeaweedFS smoke passed end to end**: boot auto-created the bucket; managed create resolved the id-keyed prefix with the secret redacted from responses; a pool node came up healthy (DuckLake ATTACH via the per-db secret against SeaweedFS); FlightSQL `CREATE TABLE ... range(5000)` landed parquet under the prefix; delete with `--purge-managed-data` had the worker drain the prefix to zero objects and stamp `purged_at` within one sweep.

## Known follow-ups (non-blocking, tracked in the SDD ledger)

- `updateTenantDb` still accepts `objectStore` patches on managed databases (operator-credential clobber; `mergeSecretKeys` preserve-direction nuance noted).
- `ManifestImporter` bypasses the tombstone registry in both directions (superuser-only path).
- `TenantDbResponse` has no `managed` indicator: the UI purge confirm shows for every ducklake delete and the managed option shows even when the deployment has it disabled.
- Managed gates are REST-level; direct supervisor/SPI callers are unguarded.
- `ensureBucket` may need a LocationConstraint for non-us-east-1 AWS (SeaweedFS-verified only).
- Boot-probe and purge log lines are INFO, invisible at the default ERROR log level the docs quote them under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
