### PR TITLE
Carry pool shapes in StructureMutation; gate setPoolResources

### DIFF
--- a/skills/quack-on-demand/SKILL.md
+++ b/skills/quack-on-demand/SKILL.md
@@ -201,6 +201,16 @@ curl -sS -X POST "http://localhost:20900/api/pool/setPodTemplate" -H "X-API-Key:
 
 The local backend ignores cpu/memory/template; use database or pool `initSql` (`SET memory_limit='...'`) for local memory control. The Helm chart's `resources` block sizes the MANAGER container, not node pods; use `setResources` for node-pod sizing.
 
+`pool/setResources` is mutation-gated as of 2026-08-13, like `pool/create` and `pool/scale`: a module gate may refuse it, and the refusal surfaces as **HTTP 429 `quota_exceeded`** with the reason in the body. Superuser sessions and static-`X-API-Key` callers bypass the gate, as everywhere. Zero-module (plain OSS) boots have no gates registered, so nothing changes there.
+
+Hosted deployments can cap a tenant's *cumulated* cores and memory across all its pools (dimensions `maxCores` / `maxMemoryGib`, `0` = unlimited). What an operator hitting a 429 needs to know:
+
+- The charge is computed from **declared** pool shapes, not live nodes: `sum over pools of (desired nodes) * cpu` and likewise for memory. **Suspended and disabled pools still count** (they keep their reservation); a stopped pool whose distribution is zeroed charges nothing.
+- Under a finite cap, a pool with an **undeclared** (empty) cpu or memory is refused rather than counted as zero. The message is `declare cpu/memory on this pool: resource caps are active for this tenant`; the fix is to `pool/setResources` a real shape on it (which is itself cap-checked). Pre-cap pools are not retroactively broken: they charge nothing until a gated mutation touches them.
+- An unparseable quantity is refused naming the offending string. Kubernetes quantity syntax: cpu `"2"` / `"1.5"` / `"500m"` (millicores are the only cpu suffix), memory `"8Gi"` / `"1024Mi"` / `Ki` / `Ti`, the decimal `k`/`M`/`G`/`T` (lowercase `k`, matching what the manager's own quantity validator admits), or a plain byte count.
+- **Shrinks always pass.** A scale-down, and any shape swap whose per-dimension delta is `<= 0`, is admitted without consulting the cap, so a tenant that is already over (caps lowered under it, shapes backfilled past them) can always shrink back into compliance.
+- Autoscale scale-outs route through the same gate, so caps bound autoscale with no extra config: a band whose ceiling exceeds the cap simply stops growing at the cap, and the refusal feeds the sweep's normal failure backoff.
+
 ## RBAC grants
 
 Grants live in the normalized `qodstate_*` tables in Postgres. The endpoints are always mounted (Postgres is the only control-plane store since 2026-06-12).

--- a/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/PoolSupervisor.scala
@@ -1332,7 +1332,8 @@ final class PoolSupervisor(
       gateBypass: Boolean = false
   ): IO[List[RunningNode]] =
     gateCheck(
-      ai.starlake.quack.spi.StructureMutation.CreatePool(key.tenant, key.tenantDb, dist.total),
+      ai.starlake.quack.spi.StructureMutation
+        .CreatePool(key.tenant, key.tenantDb, dist.total, cpu, memory),
       gateBypass
     ).flatMap {
       case Left(reason) =>
@@ -1589,28 +1590,44 @@ final class PoolSupervisor(
   def setPoolResources(
       key: PoolKey,
       cpu: String,
-      memory: String
+      memory: String,
+      gateBypass: Boolean = false
   ): IO[Either[SupervisorError, Pool]] =
-    IO.blocking {
-      withCacheRecovery("setPoolResources") {
-        pools.get(key) match
-          case None        => Left(SupervisorError.NotFound(s"pool not found: $key"))
-          case Some(state) =>
-            poolIdByKey.get(key).flatMap(poolRows.get) match
-              case None =>
-                Left(
-                  SupervisorError.Internal(
-                    s"pool entity missing for $key (control-plane out of sync)"
-                  )
-                )
-              case Some(p) =>
-                val updated = p.copy(cpu = cpu, memory = memory)
-                store.upsertPool(updated)
-                poolRows.put(updated.id, updated)
-                pools.put(key, state.copy(cpu = cpu, memory = memory))
-                publish.topologyChanged()
-                Right(updated)
-      }
+    val current  = get(key)
+    val mutation = ai.starlake.quack.spi.StructureMutation.SetPoolResources(
+      key.tenant,
+      key.tenantDb,
+      key.pool,
+      nodes = current.map(_.distribution.total).getOrElse(0),
+      fromCpu = current.map(_.cpu).getOrElse(""),
+      fromMemory = current.map(_.memory).getOrElse(""),
+      toCpu = cpu,
+      toMemory = memory
+    )
+    gateCheck(mutation, gateBypass).flatMap {
+      case Left(reason) => IO.pure(Left(SupervisorError.QuotaExceeded(reason)))
+      case Right(())    =>
+        IO.blocking {
+          withCacheRecovery("setPoolResources") {
+            pools.get(key) match
+              case None        => Left(SupervisorError.NotFound(s"pool not found: $key"))
+              case Some(state) =>
+                poolIdByKey.get(key).flatMap(poolRows.get) match
+                  case None =>
+                    Left(
+                      SupervisorError.Internal(
+                        s"pool entity missing for $key (control-plane out of sync)"
+                      )
+                    )
+                  case Some(p) =>
+                    val updated = p.copy(cpu = cpu, memory = memory)
+                    store.upsertPool(updated)
+                    poolRows.put(updated.id, updated)
+                    pools.put(key, state.copy(cpu = cpu, memory = memory))
+                    publish.topologyChanged()
+                    Right(updated)
+          }
+        }
     }
 
   def setPoolTemplate(key: PoolKey, yaml: String): IO[Either[SupervisorError, Pool]] =
@@ -1660,14 +1677,18 @@ final class PoolSupervisor(
       reason: String = "manual"
   ): IO[List[RunningNode]] =
     require(newDist.isValidFor(targetSize), "role distribution does not sum to targetSize")
-    val from = get(key).map(_.distribution.total).getOrElse(0)
+    val st    = get(key)
+    val from  = st.map(_.distribution.total).getOrElse(0)
+    val shape = st.map(s => (s.cpu, s.memory)).getOrElse(("", ""))
     gateCheck(
       ai.starlake.quack.spi.StructureMutation.ResizePool(
         key.tenant,
         key.tenantDb,
         key.pool,
         from,
-        targetSize
+        targetSize,
+        shape._1,
+        shape._2
       ),
       gateBypass
     ).flatMap {

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PoolHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PoolHandlers.scala
@@ -609,8 +609,11 @@ final class PoolHandlers(
             )
           )
         else
-          val key = PoolKey(req.tenant, req.tenantDb, req.pool)
-          sup.setPoolResources(key, req.cpu, req.memory).map {
+          val key        = PoolKey(req.tenant, req.tenantDb, req.pool)
+          val gateBypass = SuperuserCheck.reject(apiKey)(scopeOf).isEmpty
+          sup.setPoolResources(key, req.cpu, req.memory, gateBypass = gateBypass).map {
+            case Left(q: SupervisorError.QuotaExceeded) =>
+              Left((StatusCode.TooManyRequests, ErrorResponse("quota_exceeded", q.message)))
             case Left(err) =>
               Left((StatusCode.NotFound, ErrorResponse("not_found", err.message)))
             case Right(_) =>

--- a/src/main/scala/ai/starlake/quack/spi/MutationGate.scala
+++ b/src/main/scala/ai/starlake/quack/spi/MutationGate.scala
@@ -4,12 +4,31 @@ import cats.effect.IO
 
 /** A structure mutation the manager is about to perform. Consulted through [[MutationGate]] BEFORE
   * the supervisor acts, so a module can veto resource growth (quota policy lives in modules, never
-  * in core). Node counts are the requested totals (RoleDistribution.total).
+  * in core). Node counts are the requested totals; cpu/memory are the pool's declared Kubernetes
+  * quantity strings, possibly empty when undeclared.
   */
 enum StructureMutation:
   case CreateTenantDb(tenant: String)
-  case CreatePool(tenant: String, tenantDb: String, nodes: Int)
-  case ResizePool(tenant: String, tenantDb: String, pool: String, from: Int, to: Int)
+  case CreatePool(tenant: String, tenantDb: String, nodes: Int, cpu: String, memory: String)
+  case ResizePool(
+      tenant: String,
+      tenantDb: String,
+      pool: String,
+      from: Int,
+      to: Int,
+      cpu: String,
+      memory: String
+  )
+  case SetPoolResources(
+      tenant: String,
+      tenantDb: String,
+      pool: String,
+      nodes: Int,
+      fromCpu: String,
+      fromMemory: String,
+      toCpu: String,
+      toMemory: String
+  )
 
 /** Module-contributed veto hook. `Left(reason)` refuses the mutation; the reason string travels to
   * the caller as an HTTP 429 body. Gates run on the request path: keep checks cheap (a cached read

--- a/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorGateSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/PoolSupervisorGateSpec.scala
@@ -95,3 +95,59 @@ class PoolSupervisorGateSpec extends AnyFlatSpec with Matchers:
       .unsafeRunSync()
       .isRight shouldBe true
   }
+
+  "createPool" should "carry the requested cpu/memory in the gate mutation" in {
+    val sup               = setup()
+    val seen              = new java.util.concurrent.atomic.AtomicReference[StructureMutation]()
+    val spy: MutationGate = m => IO { seen.set(m); Right(()) }
+    sup.setMutationGates(List(spy)).unsafeRunSync()
+    val key = PoolKey("acme", dbName(sup), "bi")
+    sup.createPool(key, RoleDistribution(0, 1, 0), cpu = "2", memory = "8Gi").unsafeRunSync()
+    seen.get() match
+      case StructureMutation.CreatePool(_, _, 1, cpu, memory) =>
+        cpu shouldBe "2"; memory shouldBe "8Gi"
+      case other => fail(s"expected CreatePool with shape, got $other")
+  }
+
+  "scale" should "carry the pool's current declared shape in ResizePool" in {
+    val sup = setup()
+    val key = PoolKey("acme", dbName(sup), "bi")
+    sup.createPool(key, RoleDistribution(0, 1, 0), cpu = "1", memory = "4Gi").unsafeRunSync()
+    val seen              = new java.util.concurrent.atomic.AtomicReference[StructureMutation]()
+    val spy: MutationGate = m => IO { seen.set(m); Right(()) }
+    sup.setMutationGates(List(spy)).unsafeRunSync()
+    sup.scale(key, 2, RoleDistribution(0, 2, 0), force = false).unsafeRunSync()
+    seen.get() match
+      case StructureMutation.ResizePool(_, _, _, 1, 2, cpu, memory) =>
+        cpu shouldBe "1"; memory shouldBe "4Gi"
+      case other => fail(s"expected ResizePool with shape, got $other")
+  }
+
+  "setPoolResources" should "be gated and refuse with QuotaExceeded" in {
+    val sup = setup()
+    val key = PoolKey("acme", dbName(sup), "bi")
+    sup.createPool(key, RoleDistribution(0, 1, 0)).unsafeRunSync()
+    val deny: MutationGate = {
+      case _: StructureMutation.SetPoolResources => IO.pure(Left("denied"))
+      case _                                     => IO.pure(Right(()))
+    }
+    sup.setMutationGates(List(deny)).unsafeRunSync()
+    sup.setPoolResources(key, "4", "16Gi").unsafeRunSync() match
+      case Left(SupervisorError.QuotaExceeded(msg)) => msg shouldBe "denied"
+      case other                                    => fail(s"expected QuotaExceeded, got $other")
+    // gateBypass short-circuits
+    sup.setPoolResources(key, "4", "16Gi", gateBypass = true).unsafeRunSync().isRight shouldBe true
+  }
+
+  it should "carry nodes and from/to shapes in the mutation" in {
+    val sup = setup()
+    val key = PoolKey("acme", dbName(sup), "bi")
+    sup.createPool(key, RoleDistribution(0, 2, 0), cpu = "1", memory = "4Gi").unsafeRunSync()
+    val seen              = new java.util.concurrent.atomic.AtomicReference[StructureMutation]()
+    val spy: MutationGate = m => IO { seen.set(m); Right(()) }
+    sup.setMutationGates(List(spy)).unsafeRunSync()
+    sup.setPoolResources(key, "2", "8Gi").unsafeRunSync()
+    seen.get() match
+      case StructureMutation.SetPoolResources(_, _, _, 2, "1", "4Gi", "2", "8Gi") => succeed
+      case other => fail(s"expected SetPoolResources with from/to shapes, got $other")
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/api/PoolHandlersSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/PoolHandlersSpec.scala
@@ -7,6 +7,8 @@ import ai.starlake.quack.ondemand.auth.SessionScope
 import ai.starlake.quack.ondemand.runtime.QuackBackend
 import ai.starlake.quack.ondemand.runtime.testkit.StubQuackBackend
 import ai.starlake.quack.ondemand.state.InMemoryControlPlaneStore
+import ai.starlake.quack.spi.StructureMutation
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -336,6 +338,54 @@ class PoolHandlersSpec extends AnyFlatSpec with Matchers:
       .unsafeRunSync()
     out.left.toOption.map(_._1) shouldBe Some(StatusCode.BadRequest)
     out.left.toOption.map(_._2.error) shouldBe Some("invalid")
+
+  it should "map a gate refusal on setResources to 429 quota_exceeded" in:
+    val tracker = new NodeLoadTracker
+    val sup     = new PoolSupervisor(stubBackend, tracker, new InMemoryControlPlaneStore())
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    sup.createTenantDb("acme", "default", TenantDbKind.InMemory, Map.empty, "").unsafeRunSync()
+    val h = new PoolHandlers(sup, tracker)
+    h.createPool(req(size = 1, dist = RoleDistribution(0, 0, 1)), None)((_: String) => None)
+      .unsafeRunSync()
+    sup
+      .setMutationGates(List {
+        case _: StructureMutation.SetPoolResources =>
+          IO.pure(Left("cores quota is 8 (requested 16): contact support to raise it"))
+        case _ => IO.pure(Right(()))
+      })
+      .unsafeRunSync()
+    // Only a non-superuser (tenant-admin) session runs the gate; static-key /
+    // superuser callers (apiKey = None) bypass it, matching createPool.
+    val out = h
+      .setResources(
+        SetPoolResourcesRequest("acme", "acme_default", "sales", "16", "64Gi"),
+        Some("tok")
+      )(_ => Some(SessionScope(superuser = false, manageableTenants = Set("acme"))))
+      .unsafeRunSync()
+    out.left.toOption.map(_._1) shouldBe Some(StatusCode.TooManyRequests)
+    out.left.toOption.map(_._2.error) shouldBe Some("quota_exceeded")
+
+  it should "let a superuser (apiKey = None) bypass the gate on setResources" in:
+    val tracker = new NodeLoadTracker
+    val sup     = new PoolSupervisor(stubBackend, tracker, new InMemoryControlPlaneStore())
+    sup.createTenant(Tenant("acme")).unsafeRunSync()
+    sup.createTenantDb("acme", "default", TenantDbKind.InMemory, Map.empty, "").unsafeRunSync()
+    val h = new PoolHandlers(sup, tracker)
+    h.createPool(req(size = 1, dist = RoleDistribution(0, 0, 1)), None)((_: String) => None)
+      .unsafeRunSync()
+    sup
+      .setMutationGates(List {
+        case _: StructureMutation.SetPoolResources => IO.pure(Left("denied"))
+        case _                                     => IO.pure(Right(()))
+      })
+      .unsafeRunSync()
+    val out = h
+      .setResources(
+        SetPoolResourcesRequest("acme", "acme_default", "sales", "500m", "2Gi"),
+        None
+      )((_: String) => None)
+      .unsafeRunSync()
+    out shouldBe a[Right[?, ?]]
 
   // CRITICAL 1: createPool must guard podTemplateYaml
 


### PR DESCRIPTION
SPI protocol additions for module-side per-tenant cores/memory caps (hosted counterpart lands in qod-hosted): CreatePool/ResizePool carry declared cpu/memory, new gated SetPoolResources variant closes the ungated shape-change hole, handler gets gateBypass + 429 quota_exceeded. Full suite 2154/2154 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)