### PR TITLE
MCP server + personal access tokens; strict /api auth posture (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **MCP server for AI agents.** The manager now serves an MCP (Model Context Protocol)
+  endpoint at `POST /mcp` on the REST port (stateless Streamable HTTP, `QOD_MCP_ENABLED`
+  default on), so agents like Claude Code can discover schemas, run SQL with full
+  RBAC/RLS/CLS enforcement, use DuckLake time travel, and (with an admin credential)
+  operate pools and nodes. Data tier: `run_sql` (row-capped via `QOD_MCP_MAX_ROWS`,
+  default 500), `list_databases`, `list_tables`, `describe_table`, `table_history`,
+  `list_snapshots`, `my_usage`. Admin tier: pool status/scale/suspend/resume, node
+  restart/quarantine, active statements + kill, maintenance, tag create/protect
+  (protect-only), audit search. Destructive and credential operations are deny-listed
+  with no code path from `/mcp`. Auth is a personal access token or the static API key;
+  session JWTs are refused.
+- **Personal access tokens (PATs).** Long-lived bearer credentials for agents and
+  scripts, minted from the profile page (UI), `qod auth pat create|list|revoke` (CLI),
+  or `POST /api/auth/pat/*` (REST). Only a SHA-256 hash is stored; the token is shown
+  once at mint. A PAT is accepted wherever a session token is, on both `/api` and
+  `/mcp`, with exactly its owner's scope (admin PATs manage; `role=user` PATs are
+  profile-only). PAT management itself is session-only: a PAT can never mint,
+  enumerate, or revoke tokens.
 - **BREAKING: an unset or empty `QOD_API_KEY` no longer leaves `/api` open.** Every
   non-public `/api` call now requires a session, a personal access token, or the static key;
   a keyless call answers 401 regardless of configuration. Keyless dev scripts must log in via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **BREAKING: an unset or empty `QOD_API_KEY` no longer leaves `/api` open.** Every
+  non-public `/api` call now requires a session, a personal access token, or the static key;
+  a keyless call answers 401 regardless of configuration. Keyless dev scripts must log in via
+  `/api/auth/login` (or set `QOD_API_KEY`). Public endpoints (login, password reset, client
+  config) are unaffected.
+
 ## 0.6.5
 
 _Released 2026-08-17._

--- a/cli/src/qod_cli/commands/auth.py
+++ b/cli/src/qod_cli/commands/auth.py
@@ -113,6 +113,35 @@ def reset_password(ctx: typer.Context):
     call(ctx, "POST", "/api/auth/reset-password", body={"token": token, "newPassword": new})
 
 
+pat_app = typer.Typer(help="Personal access tokens for agents and scripts (MCP auth).")
+app.add_typer(pat_app, name="pat")
+
+
+@pat_app.command()
+@covers("POST", "/api/auth/pat/create", {"name": "--name", "expiresAt": "--expires-at"})
+def create(
+    ctx: typer.Context,
+    name: str = typer.Option(..., "--name", help="Label shown in listings."),
+    expires_at: str = typer.Option(None, "--expires-at", help="Optional ISO-8601 expiry."),
+):
+    """Create a PAT. The token is printed ONCE; store it now."""
+    call(ctx, "POST", "/api/auth/pat/create", body={"name": name, "expiresAt": expires_at})
+
+
+@pat_app.command("list")
+@covers("POST", "/api/auth/pat/list")
+def list_(ctx: typer.Context):
+    """List your PATs (never shows token values)."""
+    call(ctx, "POST", "/api/auth/pat/list")
+
+
+@pat_app.command()
+@covers("POST", "/api/auth/pat/revoke", {"id": "--id"})
+def revoke(ctx: typer.Context, id: str = typer.Option(..., "--id")):
+    """Revoke a PAT immediately."""
+    call(ctx, "POST", "/api/auth/pat/revoke", body={"id": id})
+
+
 @covers("POST", "/api/auth/logout")
 def logout(ctx: typer.Context):
     """Revoke the current session token."""

--- a/cli/tests/resources/openapi.yaml
+++ b/cli/tests/resources/openapi.yaml
@@ -2562,6 +2562,116 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/auth/pat/create:
+    post:
+      operationId: postApiAuthPatCreate
+      parameters:
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          type: string
+      - name: qod_session
+        in: cookie
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatCreateResponse'
+        '400':
+          description: 'Invalid value for: header X-API-Key, Invalid value for: cookie
+            qod_session, Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/auth/pat/list:
+    post:
+      operationId: postApiAuthPatList
+      parameters:
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          type: string
+      - name: qod_session
+        in: cookie
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatListResponse'
+        '400':
+          description: 'Invalid value for: header X-API-Key, Invalid value for: cookie
+            qod_session'
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/auth/pat/revoke:
+    post:
+      operationId: postApiAuthPatRevoke
+      parameters:
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          type: string
+      - name: qod_session
+        in: cookie
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatRevokeRequest'
+        required: true
+      responses:
+        '200':
+          description: ''
+        '400':
+          description: 'Invalid value for: header X-API-Key, Invalid value for: cookie
+            qod_session, Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/auth/reset-password:
     post:
       operationId: postApiAuthReset-password
@@ -6017,6 +6127,74 @@ components:
         value:
           type: string
         effect:
+          type: string
+    PatCreateRequest:
+      title: PatCreateRequest
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+    PatCreateResponse:
+      title: PatCreateResponse
+      type: object
+      required:
+      - id
+      - name
+      - token
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        token:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+    PatEntry:
+      title: PatEntry
+      type: object
+      required:
+      - id
+      - name
+      - createdAt
+      - revoked
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        lastUsedAt:
+          type: string
+          format: date-time
+        revoked:
+          type: boolean
+    PatListResponse:
+      title: PatListResponse
+      type: object
+      properties:
+        tokens:
+          type: array
+          items:
+            $ref: '#/components/schemas/PatEntry'
+    PatRevokeRequest:
+      title: PatRevokeRequest
+      type: object
+      required:
+      - id
+      properties:
+        id:
           type: string
     PoolCohortDto:
       title: PoolCohortDto

--- a/cli/tests/test_auth.py
+++ b/cli/tests/test_auth.py
@@ -190,3 +190,66 @@ def test_reset_password_prompts_and_sends_token(runner, respx_mock):
 
     sent = json.loads(route.calls.last.request.content)
     assert sent == {"token": "tok-123", "newPassword": "newpw"}
+
+
+def test_pat_create_sends_name_and_prints_token(runner, respx_mock):
+    route = respx_mock.post(f"{BASE}/api/auth/pat/create").mock(
+        return_value=httpx.Response(
+            200,
+            json={"id": "pat-1", "name": "claude", "token": "qod_pat_abc123", "expiresAt": None},
+        )
+    )
+    result = runner.invoke(app, ["auth", "pat", "create", "--name", "claude"])
+    assert result.exit_code == 0
+    assert route.called
+    import json
+
+    sent = json.loads(route.calls.last.request.content)
+    assert sent == {"name": "claude", "expiresAt": None}
+    assert "qod_pat_abc123" in result.output
+
+
+def test_pat_create_sends_expiry(runner, respx_mock):
+    route = respx_mock.post(f"{BASE}/api/auth/pat/create").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "pat-2",
+                "name": "ci",
+                "token": "qod_pat_xyz",
+                "expiresAt": "2027-01-01T00:00:00Z",
+            },
+        )
+    )
+    result = runner.invoke(
+        app,
+        ["auth", "pat", "create", "--name", "ci", "--expires-at", "2027-01-01T00:00:00Z"],
+    )
+    assert result.exit_code == 0
+    assert route.called
+    import json
+
+    sent = json.loads(route.calls.last.request.content)
+    assert sent == {"name": "ci", "expiresAt": "2027-01-01T00:00:00Z"}
+
+
+def test_pat_list_hits_the_list_route(runner, respx_mock):
+    route = respx_mock.post(f"{BASE}/api/auth/pat/list").mock(
+        return_value=httpx.Response(200, json={"tokens": []})
+    )
+    result = runner.invoke(app, ["auth", "pat", "list"])
+    assert result.exit_code == 0
+    assert route.called
+
+
+def test_pat_revoke_sends_id(runner, respx_mock):
+    route = respx_mock.post(f"{BASE}/api/auth/pat/revoke").mock(
+        return_value=httpx.Response(200, json={})
+    )
+    result = runner.invoke(app, ["auth", "pat", "revoke", "--id", "pat-1"])
+    assert result.exit_code == 0
+    assert route.called
+    import json
+
+    sent = json.loads(route.calls.last.request.content)
+    assert sent == {"id": "pat-1"}

--- a/skills/quack-on-demand/SKILL.md
+++ b/skills/quack-on-demand/SKILL.md
@@ -76,9 +76,11 @@ this profile).
 
 ## Auth flow (REST + UI)
 
-The REST API has two acceptable credentials:
+The REST API has three acceptable credentials:
 1. **Static** `X-API-Key` header matching `QOD_API_KEY` (if set; not set by default)
 2. **UI session token** minted via `POST /api/auth/login`
+3. **Personal access token** (`qod_pat_...`), sent the same way as a session token
+   (see "Personal access tokens and the MCP server" below)
 
 ```bash
 # Get a session token (admin role required)
@@ -91,7 +93,7 @@ TOKEN=$(curl -sS -X POST http://localhost:20900/api/auth/login \
 curl -H "X-API-Key: $TOKEN" http://localhost:20900/api/pool/list
 ```
 
-If `QOD_API_KEY` is unset, the manager logs a loud warning at startup and `/api/...` accepts anonymous traffic - fine for local dev, never for prod.
+If `QOD_API_KEY` is unset (or empty), only the static-key arm is disabled: every non-public `/api/...` call still requires a session or PAT, and a keyless call answers 401. There is no open mode; keyless dev scripts must log in first.
 
 ### Regular-user login (profile only)
 
@@ -113,6 +115,50 @@ qod auth login --username alice --tenant acme
 qod profile usage --days 7
 qod profile statements --limit 20
 ```
+
+### Personal access tokens and the MCP server
+
+PATs are long-lived bearer credentials for agents and scripts. A PAT acts with exactly
+its owner's permissions (admin PATs reach the admin surface, `role=user` PATs are
+demoted to the profile allowlist) and is accepted wherever a session token is, on both
+`/api/*` and the MCP endpoint. Management is session-only: a PAT can never mint, list,
+or revoke PATs (`403 session_required`).
+
+```bash
+# Mint (session required; the token is printed ONCE - store it now)
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/auth/pat/create \
+  -H 'Content-Type: application/json' -d '{"name":"claude-code"}'
+# {"id":"pat-...","name":"claude-code","token":"qod_pat_..."}
+
+# List (metadata only; the raw token is unrecoverable after mint)
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/auth/pat/list
+# Revoke
+curl -sS -H "X-API-Key: $TOKEN" -X POST http://localhost:20900/api/auth/pat/revoke \
+  -H 'Content-Type: application/json' -d '{"id":"pat-..."}'
+
+# CLI equivalents
+qod auth pat create --name claude-code [--expires-at 2027-01-01T00:00:00Z]
+qod auth pat list
+qod auth pat revoke --id pat-...
+```
+
+The MCP server lives at `POST /mcp` on the manager port (`QOD_MCP_ENABLED`, default
+true). Auth is `Authorization: Bearer <PAT or QOD_API_KEY>`; session JWTs are refused
+there. Point Claude Code at it with:
+
+```bash
+claude mcp add --transport http qod http://localhost:20900/mcp \
+  --header "Authorization: Bearer qod_pat_..."
+```
+
+MCP troubleshooting:
+- **401 on every call**: the bearer is a session JWT (refused by design) or a dead PAT
+  (revoked, expired, owner disabled). Mint a fresh PAT.
+- **Tool missing from tools/list**: wrong tier - admin tools need an admin-owned PAT or
+  the static key.
+- **run_sql denied**: the ACL message names the table and missing verb; fix the grant.
+- **"pool is resuming"**: the suspended pool is waking; retry in a few seconds.
+- Row caps: `run_sql` is truncated server-side at `QOD_MCP_MAX_ROWS` (default 500).
 
 ### Account lockout and self-service password reset
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -493,6 +493,15 @@ quack-on-demand {
     starttls    = ${?QOD_SMTP_STARTTLS}
   }
 
+  # MCP server for AI agents at POST /mcp. Auth: PAT or the static API key;
+  # session JWTs and passwords are never accepted here.
+  mcp {
+    enabled = true
+    enabled = ${?QOD_MCP_ENABLED}
+    maxRows = 500
+    maxRows = ${?QOD_MCP_MAX_ROWS}
+  }
+
   # Externally visible base URL used to build the password-reset links mailed to
   # users. Empty (default) makes the link host-relative (/ui/reset-password?...)
   # and Main logs a boot warning; set it to the browser-visible manager origin.

--- a/src/main/resources/db/changelog/0032-pat.yaml
+++ b/src/main/resources/db/changelog/0032-pat.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0032-pat
+      author: qod
+      changes:
+        # Personal access tokens: long-lived bearer credentials for agents (MCP)
+        # and scripts. Only the SHA-256 hash of the token is stored; the raw
+        # value is shown once at mint time. Revocation and expiry are checked
+        # on every use via the unique token_hash index.
+        - createTable:
+            tableName: qodstate_pat
+            columns:
+              - column: { name: id,           type: TEXT, constraints: { primaryKey: true, nullable: false } }
+              - column: { name: user_id,      type: TEXT, constraints: { nullable: false } }
+              - column: { name: name,         type: TEXT, constraints: { nullable: false } }
+              - column: { name: token_hash,   type: TEXT, constraints: { nullable: false, unique: true } }
+              - column: { name: created_at,   type: TIMESTAMP WITH TIME ZONE, constraints: { nullable: false } }
+              - column: { name: expires_at,   type: TIMESTAMP WITH TIME ZONE }
+              - column: { name: last_used_at, type: TIMESTAMP WITH TIME ZONE }
+              - column: { name: revoked_at,   type: TIMESTAMP WITH TIME ZONE }
+        - addForeignKeyConstraint:
+            constraintName: fk_qodstate_pat_user
+            baseTableName: qodstate_pat
+            baseColumnNames: user_id
+            referencedTableName: qodstate_user
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - createIndex:
+            indexName: idx_qodstate_pat_user
+            tableName: qodstate_pat
+            columns:
+              - column: { name: user_id }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -67,3 +67,5 @@ databaseChangeLog:
       file: db/changelog/0030-user-lockout.yaml
   - include:
       file: db/changelog/0031-user-email-from-username.yaml
+  - include:
+      file: db/changelog/0032-pat.yaml

--- a/src/main/scala/ai/starlake/quack/Config.scala
+++ b/src/main/scala/ai/starlake/quack/Config.scala
@@ -341,6 +341,22 @@ final case class CatalogConfig(
     restoreTimeoutSec: Int = 300
 )
 
+/** MCP server for AI agents at POST /mcp. Auth: PAT or the static API key; session JWTs and
+  * passwords are never accepted there.
+  */
+final case class McpConfig(
+    @field @ConfigField(
+      envVar = "QOD_MCP_ENABLED",
+      description = "Serve the MCP endpoint at POST /mcp."
+    )
+    enabled: Boolean = true,
+    @field @ConfigField(
+      envVar = "QOD_MCP_MAX_ROWS",
+      description = "Hard cap on rows returned by the run_sql MCP tool."
+    )
+    maxRows: Int = 500
+)
+
 final case class TelemetryConfig(
     @field
     @ConfigField(
@@ -415,7 +431,9 @@ final case class ManagerConfig(
     port: Int,
     @field @ConfigField(
       envVar = "QOD_API_KEY",
-      description = "Static admin API key sent as X-API-Key. Unset = REST namespace is open.",
+      description =
+        "Static admin API key sent as X-API-Key. Unset or empty disables the static-key arm; " +
+          "/api then accepts only session and PAT credentials (never open).",
       sensitive = true
     )
     apiKey: Option[String],
@@ -495,6 +513,7 @@ final case class ManagerConfig(
     autoscale: AutoscaleConfig = AutoscaleConfig(),
     managedObjectStore: ManagedObjectStoreConfig = ManagedObjectStoreConfig(),
     smtp: SmtpConfig = SmtpConfig(),
+    mcp: McpConfig = McpConfig(),
     @field @ConfigField(
       envVar = "QOD_PUBLIC_BASE_URL",
       description =

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -250,6 +250,11 @@ object Main extends IOApp with LazyLogging:
       UserStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap, mgrCfg.auth.lockout)
     BootPreflight.seedAdminUsers(userStore, mgrCfg.admin)
 
+    // Personal access tokens live next to the user rows they reference (qodstate_pat
+    // FKs qodstate_user); its own small Hikari pool, closed in the shutdown hook.
+    val patStore =
+      ai.starlake.quack.ondemand.state.PatStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
+
     val backend: QuackBackend = BootFactories.quackBackend(mgrCfg)
 
     val secretResolver: SecretResolver =
@@ -570,6 +575,15 @@ object Main extends IOApp with LazyLogging:
       // Same tenant resolution as login: id or display name -> surrogate id.
       resolveTenant = (raw: String) => sup.getTenantById(raw).orElse(sup.getTenant(raw)).map(_.id),
       publicBaseUrl = mgrCfg.publicBaseUrl.trim
+    )
+    // Self-service personal access tokens. Identity comes from the session JWT and
+    // is resolved to the owning qodstate_user row id, which is what qodstate_pat
+    // keys (and FKs) on.
+    val patHandlers = new ai.starlake.quack.ondemand.api.PatHandlers(
+      pats = patStore,
+      sessions = sessionTokens,
+      userIdOf = (tenant, username) => userStore.userIdOf(tenant, username),
+      audit = auditRecorder
     )
     val historyHandlers    = new StatementHistoryHandlers(stmtHistory, sup)
     val auditHandlers      = new ai.starlake.quack.ondemand.api.AuditHandlers(telemetryStore)
@@ -982,7 +996,8 @@ object Main extends IOApp with LazyLogging:
         moduleEndpoints = modules.flatMap(_.endpoints),
         modulePublicPrefixes = modules.flatMap(_.publicPathPrefixes).toSet,
         moduleStaticMounts = modules.flatMap(_.staticMounts),
-        passwordReset = Some(passwordResetHandlers)
+        passwordReset = Some(passwordResetHandlers),
+        pat = Some(patHandlers)
       )
       // One managed-object-store client for both the boot probe below and the purge
       // worker further down. Constructed unconditionally: the SDK client it wraps is
@@ -1106,6 +1121,7 @@ object Main extends IOApp with LazyLogging:
                   telemetryStore = telemetryStore,
                   store = store,
                   userStore = userStore,
+                  patStore = patStore,
                   catalogReaders = catalogReaders,
                   tracker = tracker,
                   modules = modules,

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -254,6 +254,15 @@ object Main extends IOApp with LazyLogging:
     // Personal access tokens live next to the user rows they reference (qodstate_pat
     // FKs qodstate_user); its own small Hikari pool, closed in the shutdown hook.
     val patStore = PatStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
+    // Resolves a PAT bearer to its owner's principal for /api admission. Grants are
+    // row-only BY CONTRACT (PatAuthenticator's scaladoc): a PAT is bound to one
+    // qodstate_user row, and an identity-keyed lookup would fold in the grants of a
+    // same-named user in another tenant.
+    val patAuthenticator = new ai.starlake.quack.ondemand.auth.PatAuthenticator(
+      patStore,
+      userById = userStore.userById,
+      grantsFor = u => List(ai.starlake.quack.ondemand.state.UserGrant(u.tenant, u.role))
+    )
 
     val backend: QuackBackend = BootFactories.quackBackend(mgrCfg)
 
@@ -594,7 +603,9 @@ object Main extends IOApp with LazyLogging:
     // Self-service surface for non-admin sessions; scopes strictly to the
     // session's own (tenant, username), so it takes no tenant/user input.
     val profileHandlers = new ai.starlake.quack.ondemand.api.ProfileHandlers(
-      sessionTokens,
+      // Composed bearer lookup, session JWT first then PAT: a PAT owner sees the
+      // same self-scoped profile a login session would.
+      t => sessionTokens.get(t).orElse(patAuthenticator.sessionOf(t)),
       telemetryStore,
       stmtHistory,
       id => sup.getTenantById(id)
@@ -999,7 +1010,8 @@ object Main extends IOApp with LazyLogging:
         modulePublicPrefixes = modules.flatMap(_.publicPathPrefixes).toSet,
         moduleStaticMounts = modules.flatMap(_.staticMounts),
         passwordReset = Some(passwordResetHandlers),
-        pat = Some(patHandlers)
+        pat = Some(patHandlers),
+        patAuth = Some(patAuthenticator)
       )
       // One managed-object-store client for both the boot probe below and the purge
       // worker further down. Constructed unconditionally: the SDK client it wraps is

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -94,6 +94,7 @@ object Main extends IOApp with LazyLogging:
   given ProductHint[AutoscaleConfig]           = ProductHint[AutoscaleConfig](camelMapping)
   given ProductHint[ManagedObjectStoreConfig]  = ProductHint[ManagedObjectStoreConfig](camelMapping)
   given ProductHint[SmtpConfig]                = ProductHint[SmtpConfig](camelMapping)
+  given ProductHint[McpConfig]                 = ProductHint[McpConfig](camelMapping)
   given ProductHint[ManagerConfig]             = ProductHint[ManagerConfig](camelMapping)
   given ProductHint[FlightConfig]              = ProductHint[FlightConfig](camelMapping)
   given ProductHint[DatabaseAuthConfig]        = ProductHint[DatabaseAuthConfig](camelMapping)
@@ -120,6 +121,7 @@ object Main extends IOApp with LazyLogging:
   given ConfigReader[AutoscaleConfig]          = deriveReader[AutoscaleConfig]
   given ConfigReader[ManagedObjectStoreConfig] = deriveReader[ManagedObjectStoreConfig]
   given ConfigReader[SmtpConfig]               = deriveReader[SmtpConfig]
+  given ConfigReader[McpConfig]                = deriveReader[McpConfig]
   given ConfigReader[ManagerConfig]            = deriveReader[ManagerConfig]
   given ConfigReader[FlightConfig]             = deriveReader[FlightConfig]
   given ConfigReader[DatabaseAuthConfig]       = deriveReader[DatabaseAuthConfig]
@@ -967,6 +969,54 @@ object Main extends IOApp with LazyLogging:
         )
       )
 
+      // MCP endpoint (POST /mcp): the agent-facing tool surface over the SAME handler
+      // instances REST uses. Auth is PAT or the static key only; the run_sql path goes
+      // through routedExecutor(recordExecution = true) so DuckLake snapshots carry the
+      // acting user's author stamp exactly like FlightSQL writes.
+      val mcpRoutes: Option[org.http4s.HttpRoutes[IO]] =
+        if !mgrCfg.mcp.enabled then None
+        else
+          val mcpScopeOf: String => Option[ai.starlake.quack.ondemand.auth.SessionScope] =
+            t => sessionTokens.scopeOf(t).orElse(patAuthenticator.scopeOf(t))
+          for
+            cat   <- catalogHandlers
+            hist  <- catalogHistoryHandlers
+            tagH  <- tagHandlers
+            maint <- maintenanceHandlers
+          yield
+            val dataTools = new ai.starlake.quack.mcp.McpDataTools(
+              mgrCfg.mcp,
+              routedExecutor(recordExecution = true),
+              sup,
+              cat,
+              hist,
+              tagH,
+              tenantDbs,
+              profileHandlers,
+              mcpScopeOf
+            )
+            val adminTools = new ai.starlake.quack.mcp.McpAdminTools(
+              pools,
+              nodes,
+              activeStmtHandlers,
+              maint,
+              tagH,
+              auditHandlers,
+              mcpScopeOf
+            )
+            new ai.starlake.quack.mcp.McpRoutes(
+              mgrCfg.mcp,
+              mgrCfg.apiKey.filter(_.nonEmpty),
+              patAuthenticator.resolve,
+              dataTools.tools ++ adminTools.tools,
+              serverVersion = "dev"
+            ).routes
+      if mgrCfg.mcp.enabled && mcpRoutes.isEmpty then
+        logger.warn("mcp: enabled but a required handler is unwired; POST /mcp not mounted")
+      else if mgrCfg.mcp.enabled then
+        logger.info("mcp: serving POST /mcp (bearer auth: PAT or static API key)")
+      else logger.info("mcp: disabled (QOD_MCP_ENABLED=false); POST /mcp not mounted")
+
       // Reads the module surfaces (endpoints / publicPathPrefixes / staticMounts),
       // so it MUST run after moduleStart; called from the IO chain below.
       def buildManagerServer(): ManagerServer = new ManagerServer(
@@ -1011,7 +1061,8 @@ object Main extends IOApp with LazyLogging:
         moduleStaticMounts = modules.flatMap(_.staticMounts),
         passwordReset = Some(passwordResetHandlers),
         pat = Some(patHandlers),
-        patAuth = Some(patAuthenticator)
+        patAuth = Some(patAuthenticator),
+        mcpRoutes = mcpRoutes
       )
       // One managed-object-store client for both the boot probe below and the purge
       // worker further down. Constructed unconditionally: the SDK client it wraps is

--- a/src/main/scala/ai/starlake/quack/Main.scala
+++ b/src/main/scala/ai/starlake/quack/Main.scala
@@ -59,6 +59,7 @@ import ai.starlake.quack.ondemand.runtime._
 import ai.starlake.quack.ondemand.state.{
   ControlPlaneStore,
   LiquibaseRunner,
+  PatStore,
   PostgresControlPlaneStore,
   PostgresDbAdmin,
   UserStore
@@ -252,8 +253,7 @@ object Main extends IOApp with LazyLogging:
 
     // Personal access tokens live next to the user rows they reference (qodstate_pat
     // FKs qodstate_user); its own small Hikari pool, closed in the shutdown hook.
-    val patStore =
-      ai.starlake.quack.ondemand.state.PatStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
+    val patStore = PatStore.fromDefaultMetastore(mgrCfg.defaultMetastore.asMap)
 
     val backend: QuackBackend = BootFactories.quackBackend(mgrCfg)
 
@@ -582,7 +582,9 @@ object Main extends IOApp with LazyLogging:
     val patHandlers = new ai.starlake.quack.ondemand.api.PatHandlers(
       pats = patStore,
       sessions = sessionTokens,
-      userIdOf = (tenant, username) => userStore.userIdOf(tenant, username),
+      // The whole row, not just its id: a disabled owner must be refused at MINT
+      // time too, not only when the resulting token is used.
+      userOf = (tenant, username) => store.findUser(tenant, username),
       audit = auditRecorder
     )
     val historyHandlers    = new StatementHistoryHandlers(stmtHistory, sup)

--- a/src/main/scala/ai/starlake/quack/boot/ShutdownCoordinator.scala
+++ b/src/main/scala/ai/starlake/quack/boot/ShutdownCoordinator.scala
@@ -5,7 +5,7 @@ import ai.starlake.quack.edge.adapter.NodeLoadTracker
 import ai.starlake.quack.ondemand.ha.HaCoordinator
 import ai.starlake.quack.ondemand.module.ModuleEventBus
 import ai.starlake.quack.ondemand.runtime.QuackBackend
-import ai.starlake.quack.ondemand.state.{PostgresControlPlaneStore, UserStore}
+import ai.starlake.quack.ondemand.state.{PatStore, PostgresControlPlaneStore, UserStore}
 import ai.starlake.quack.ondemand.telemetry.{EventJournal, TelemetryStore}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
@@ -33,6 +33,7 @@ final class ShutdownCoordinator(
     telemetryStore: TelemetryStore,
     store: PostgresControlPlaneStore,
     userStore: UserStore,
+    patStore: PatStore,
     catalogReaders: CatalogReaders,
     tracker: NodeLoadTracker,
     modules: List[ai.starlake.quack.spi.ManagerModule],
@@ -75,6 +76,8 @@ final class ShutdownCoordinator(
         try store.close()
         catch case _: Throwable => ()
         try userStore.close()
+        catch case _: Throwable => ()
+        try patStore.close()
         catch case _: Throwable => ()
           // Stop the idle-eviction sweeper, then close every cached
           // catalog reader's Hikari pool.

--- a/src/main/scala/ai/starlake/quack/mcp/McpAdminTools.scala
+++ b/src/main/scala/ai/starlake/quack/mcp/McpAdminTools.scala
@@ -1,0 +1,421 @@
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.model.RoleDistribution
+import ai.starlake.quack.ondemand.api.{
+  ActiveStatementHandlers,
+  AuditHandlers,
+  KillStatementRequest,
+  MaintenanceHandlers,
+  MaintenanceRunRequest,
+  NodeHandlers,
+  NodeOpRequest,
+  PoolHandlers,
+  ResumePoolRequest,
+  ScalePoolRequest,
+  SuspendPoolRequest,
+  TagCreateRequest,
+  TagHandlers,
+  TagProtectRequest
+}
+import ai.starlake.quack.ondemand.api.Dtos.given
+import ai.starlake.quack.ondemand.auth.SessionScope
+import cats.effect.IO
+import io.circe.{Json, JsonObject}
+import io.circe.syntax._
+
+/** The MCP admin tier: pool/node operations, statement kill, maintenance, tags, and audit search.
+  * Every tool is `adminOnly = true` (the route re-checks at call time) and delegates to the SAME
+  * REST handlers the admin UI uses, with the principal's raw bearer as `apiKey`, so the
+  * `TenantScopeCheck` gates and audit trail behave identically to REST.
+  *
+  * Deny-list (spec 2026-08-18, "Decisions" item 2): nothing here can weaken protection or destroy
+  * irreversibly. In particular `protect_tag` has NO unprotect argument and there is no tag-delete
+  * tool; the only direction this surface can move a guardrail is ON.
+  */
+final class McpAdminTools(
+    pools: PoolHandlers,
+    nodes: NodeHandlers,
+    statements: ActiveStatementHandlers,
+    maintenance: MaintenanceHandlers,
+    tags: TagHandlers,
+    auditH: AuditHandlers,
+    scopeOf: String => Option[SessionScope]
+):
+
+  import McpToolArgs._
+
+  def tools: List[McpToolDef] = List(
+    listPoolsTool,
+    getPoolStatusTool,
+    scalePoolTool,
+    suspendPoolTool,
+    resumePoolTool,
+    restartNodeTool,
+    quarantineNodeTool,
+    unquarantineNodeTool,
+    activeStatementsTool,
+    killStatementTool,
+    runMaintenanceTool,
+    maintenanceRunsTool,
+    createTagTool,
+    protectTagTool,
+    auditSearchTool
+  )
+
+  private def keyOf(principal: McpPrincipal): Option[String] = principal.rawToken
+
+  // ---------- pools ----------
+
+  private val listPoolsTool = McpToolDef(
+    name = "list_pools",
+    description =
+      "List every pool you can manage, with nodes, health, served counts, suspended flag and " +
+        "autoscale band.",
+    inputSchema = objectSchema(required = Nil),
+    adminOnly = true,
+    run = (principal, _) =>
+      pools.listPools(keyOf(principal))(scopeOf).map(res => bridge(res).map(_.asJson))
+  )
+
+  private val getPoolStatusTool = McpToolDef(
+    name = "get_pool_status",
+    description = "Detailed status of one pool: nodes, health, served counts, roles.",
+    inputSchema = objectSchema(
+      required = List("database", "pool"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "pool" -> strProp("Pool name."),
+      tenantProp
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- required(args, "database")
+        pool     <- required(args, "pool")
+      yield (tenant, database, pool)) match
+        case Left(err)                       => IO.pure(Left(err))
+        case Right((tenant, database, pool)) =>
+          pools.poolStatus(tenant, database, pool).map(res => bridge(res).map(_.asJson))
+  )
+
+  private val scalePoolTool = McpToolDef(
+    name = "scale_pool",
+    description =
+      "Scale a pool to an explicit role distribution (writers/readers/dual node counts). A pool " +
+        "with a declared autoscale band refuses targets outside it (outside_band): adjust the " +
+        "band first, or stay inside it.",
+    inputSchema = objectSchema(
+      required = List("database", "pool"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "pool"    -> strProp("Pool name."),
+      "writers" -> intProp("Write-only node count (default 0)."),
+      "readers" -> intProp("Read-only node count (default 0)."),
+      "dual"    -> intProp("Dual (read+write) node count (default 0)."),
+      "force"   -> boolProp("Force-shrink past drain protection."),
+      tenantProp
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- required(args, "database")
+        pool     <- required(args, "pool")
+      yield (tenant, database, pool)) match
+        case Left(err)                       => IO.pure(Left(err))
+        case Right((tenant, database, pool)) =>
+          val dist =
+            RoleDistribution(
+              writeonly = int(args, "writers").getOrElse(0),
+              readonly = int(args, "readers").getOrElse(0),
+              dual = int(args, "dual").getOrElse(0)
+            )
+          pools
+            .scalePool(
+              ScalePoolRequest(
+                tenant,
+                database,
+                pool,
+                targetSize = dist.writeonly + dist.readonly + dist.dual,
+                roleDistribution = dist,
+                force = bool(args, "force").getOrElse(false)
+              ),
+              keyOf(principal)
+            )(scopeOf)
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  private def poolLifecycleTool(
+      name: String,
+      description: String,
+      act: (McpPrincipal, String, String, String) => IO[Either[String, Json]]
+  ): McpToolDef =
+    McpToolDef(
+      name = name,
+      description = description,
+      inputSchema = objectSchema(
+        required = List("database", "pool"),
+        props = "database" -> strProp("Database (tenant-db) name."),
+        "pool" -> strProp("Pool name."),
+        tenantProp
+      ),
+      adminOnly = true,
+      run = (principal, args) =>
+        (for
+          tenant   <- tenantOf(principal, args)
+          database <- required(args, "database")
+          pool     <- required(args, "pool")
+        yield (tenant, database, pool)) match
+          case Left(err)                       => IO.pure(Left(err))
+          case Right((tenant, database, pool)) => act(principal, tenant, database, pool)
+    )
+
+  private val suspendPoolTool = poolLifecycleTool(
+    "suspend_pool",
+    "Suspend a pool to zero nodes, keeping its role distribution. It wakes automatically on the " +
+      "next statement, or explicitly via resume_pool.",
+    (principal, tenant, database, pool) =>
+      pools
+        .suspendPool(SuspendPoolRequest(tenant, database, pool), keyOf(principal))(scopeOf)
+        .map(res => bridge(res).map(_.asJson))
+  )
+
+  private val resumePoolTool = poolLifecycleTool(
+    "resume_pool",
+    "Wake a suspended pool back to its kept role distribution.",
+    (principal, tenant, database, pool) =>
+      pools
+        .resumePool(ResumePoolRequest(tenant, database, pool), keyOf(principal))(scopeOf)
+        .map(res => bridge(res).map(_.asJson))
+  )
+
+  // ---------- nodes ----------
+
+  private def nodeOpTool(
+      name: String,
+      description: String,
+      act: (NodeOpRequest, Option[String]) => IO[Either[String, Json]]
+  ): McpToolDef =
+    McpToolDef(
+      name = name,
+      description = description,
+      inputSchema = objectSchema(
+        required = List("database", "pool", "node_id"),
+        props = "database" -> strProp("Database (tenant-db) name."),
+        "pool"    -> strProp("Pool name."),
+        "node_id" -> strProp("Node id (see get_pool_status)."),
+        tenantProp
+      ),
+      adminOnly = true,
+      run = (principal, args) =>
+        (for
+          tenant   <- tenantOf(principal, args)
+          database <- required(args, "database")
+          pool     <- required(args, "pool")
+          nodeId   <- required(args, "node_id")
+        yield NodeOpRequest(tenant, database, pool, nodeId)) match
+          case Left(err)  => IO.pure(Left(err))
+          case Right(req) => act(req, principal.rawToken)
+    )
+
+  private val restartNodeTool = nodeOpTool(
+    "restart_node",
+    "Stop and respawn one node (fresh port and process). Use for a node that is unhealthy or " +
+      "stuck on an occupied port.",
+    (req, key) => nodes.restartNode(req, key)(scopeOf).map(res => bridge(res).map(_.asJson))
+  )
+
+  private val quarantineNodeTool = nodeOpTool(
+    "quarantine_node",
+    "Take a node out of routing without stopping it, so it can be inspected.",
+    (req, key) => nodes.quarantineNode(req, key)(scopeOf).map(res => bridge(res).map(_.asJson))
+  )
+
+  private val unquarantineNodeTool = nodeOpTool(
+    "unquarantine_node",
+    "Return a quarantined node to routing.",
+    (req, key) => nodes.unquarantineNode(req, key)(scopeOf).map(res => bridge(res).map(_.asJson))
+  )
+
+  // ---------- statements ----------
+
+  private val activeStatementsTool = McpToolDef(
+    name = "active_statements",
+    description = "Statements currently executing, with user, pool, node and a SQL preview.",
+    inputSchema = objectSchema(required = Nil),
+    adminOnly = true,
+    run = (principal, _) =>
+      statements.list(keyOf(principal))(scopeOf).map(res => bridge(res).map(_.asJson))
+  )
+
+  private val killStatementTool = McpToolDef(
+    name = "kill_statement",
+    description =
+      "Kill one running statement by id (from active_statements). An id that is no longer " +
+        "running answers status already-completed, not an error.",
+    inputSchema = objectSchema(
+      required = List("id"),
+      props = "id" -> strProp("Statement id from active_statements.")
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      required(args, "id") match
+        case Left(err) => IO.pure(Left(err))
+        case Right(id) =>
+          statements
+            .kill(KillStatementRequest(id), keyOf(principal))(scopeOf)
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  // ---------- maintenance ----------
+
+  private val runMaintenanceTool = McpToolDef(
+    name = "run_maintenance",
+    description =
+      "Trigger a maintenance run (flush, expire, compaction chain) on a database now; returns " +
+        "the run id to watch via maintenance_runs.",
+    inputSchema = objectSchema(
+      required = List("database"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "scope"      -> strProp("Optional scope (e.g. one schema.table)."),
+      "operations" -> strProp("Optional comma-separated operations subset."),
+      tenantProp
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- required(args, "database")
+      yield (tenant, database)) match
+        case Left(err)                 => IO.pure(Left(err))
+        case Right((tenant, database)) =>
+          maintenance
+            .triggerRun(
+              MaintenanceRunRequest(tenant, database, str(args, "scope"), str(args, "operations")),
+              keyOf(principal)
+            )(scopeOf)
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  private val maintenanceRunsTool = McpToolDef(
+    name = "maintenance_runs",
+    description = "Recent maintenance runs of a database, newest first.",
+    inputSchema = objectSchema(
+      required = List("database"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "limit" -> intProp("Max runs (default 50)."),
+      tenantProp
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- required(args, "database")
+      yield (tenant, database)) match
+        case Left(err)                 => IO.pure(Left(err))
+        case Right((tenant, database)) =>
+          maintenance
+            .listRuns(tenant, database, int(args, "limit"), None, keyOf(principal))(scopeOf)
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  // ---------- tags ----------
+
+  private val createTagTool = McpToolDef(
+    name = "create_tag",
+    description =
+      "Name a snapshot (from list_snapshots) so it can be referenced and protected. Tags are " +
+        "created unprotected; protect_tag pins them.",
+    inputSchema = objectSchema(
+      required = List("database", "name", "snapshot_id"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "name"        -> strProp("Tag name."),
+      "snapshot_id" -> intProp("Snapshot id to tag."),
+      tenantProp
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- required(args, "database")
+        name     <- required(args, "name")
+        snapshot <- long(args, "snapshot_id").toRight("the 'snapshot_id' argument is required")
+      yield (tenant, database, name, snapshot)) match
+        case Left(err)                                 => IO.pure(Left(err))
+        case Right((tenant, database, name, snapshot)) =>
+          tags
+            .create(
+              TagCreateRequest(tenant, database, name, snapshot, isProtected = false),
+              keyOf(principal)
+            )(scopeOf)
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  private val protectTagTool = McpToolDef(
+    name = "protect_tag",
+    description =
+      "Protect a tag so its snapshot survives retention and cannot be expired. There is no " +
+        "unprotect from here: protection can only be removed by a human through the UI or CLI.",
+    inputSchema = objectSchema(
+      required = List("database", "name"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "name" -> strProp("Tag name."),
+      tenantProp
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- required(args, "database")
+        name     <- required(args, "name")
+      yield (tenant, database, name)) match
+        case Left(err)                       => IO.pure(Left(err))
+        case Right((tenant, database, name)) =>
+          tags
+            // isProtected is pinned true: the deny-list (spec, Decisions item 2) forbids any
+            // protection-weakening operation from /mcp, so this tool has no boolean and the
+            // request is hardcoded to the protecting direction.
+            .protect(
+              TagProtectRequest(tenant, database, name, isProtected = true),
+              keyOf(principal)
+            )(
+              scopeOf
+            )
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  // ---------- audit ----------
+
+  private val auditSearchTool = McpToolDef(
+    name = "audit_search",
+    description =
+      "Search the control-plane audit log. Filters combine with AND; results are scoped to the " +
+        "tenants you can manage.",
+    inputSchema = objectSchema(
+      required = Nil,
+      props = "family" -> strProp("Event family filter."),
+      "actor"  -> strProp("Acting user filter."),
+      "action" -> strProp("Action name filter."),
+      "q"      -> strProp("Free-text filter."),
+      "from"   -> strProp("ISO-8601 lower time bound."),
+      "to"     -> strProp("ISO-8601 upper time bound."),
+      "limit"  -> intProp("Max events (default 100)."),
+      "tenant" -> strProp("Narrow to one tenant (within your scope).")
+    ),
+    adminOnly = true,
+    run = (principal, args) =>
+      auditH
+        .list(
+          str(args, "family"),
+          str(args, "tenant"),
+          str(args, "actor"),
+          str(args, "action"),
+          str(args, "q"),
+          str(args, "from"),
+          str(args, "to"),
+          int(args, "limit"),
+          None,
+          None,
+          keyOf(principal)
+        )(scopeOf)
+        .map(res => bridge(res).map(_.asJson))
+  )

--- a/src/main/scala/ai/starlake/quack/mcp/McpDataTools.scala
+++ b/src/main/scala/ai/starlake/quack/mcp/McpDataTools.scala
@@ -1,0 +1,382 @@
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.McpConfig
+import ai.starlake.quack.edge.RouterFailure
+import ai.starlake.quack.ondemand.PoolSupervisor
+import ai.starlake.quack.ondemand.api.{
+  ArrowRowsDecoder,
+  CatalogHandlers,
+  CatalogHistoryHandlers,
+  CatalogPreviewHandlers,
+  ErrorResponse,
+  PoolPicks,
+  ProfileHandlers,
+  TagHandlers,
+  TenantDbHandlers
+}
+import ai.starlake.quack.ondemand.api.Dtos.given
+import ai.starlake.quack.ondemand.auth.SessionScope
+import cats.effect.IO
+import io.circe.{Json, JsonObject}
+import io.circe.syntax._
+import sttp.model.StatusCode
+
+/** The MCP data tier: the tools every authenticated principal gets. Each tool goes through the SAME
+  * enforcement as the REST/FlightSQL surface it mirrors -- `run_sql` through the injected routed
+  * executor (StatementValidator, classifier, router), the catalog reads through the handlers'
+  * `TenantDbGate`/`TenantScopeCheck` with the principal's raw bearer as `apiKey` -- so there is no
+  * second policy layer to keep in sync.
+  *
+  * Tool descriptions are agent-facing product copy: they tell the consuming agent how to work
+  * (describe before querying, aggregate instead of dumping, how time travel is spelled).
+  */
+final class McpDataTools(
+    cfg: McpConfig,
+    executor: CatalogPreviewHandlers.PreviewExecutor,
+    sup: PoolSupervisor,
+    catalog: CatalogHandlers,
+    history: CatalogHistoryHandlers,
+    tags: TagHandlers,
+    tenantDbs: TenantDbHandlers,
+    profile: ProfileHandlers,
+    scopeOf: String => Option[SessionScope]
+):
+
+  import McpDataTools._
+  import McpToolArgs._
+
+  def tools: List[McpToolDef] = List(
+    runSqlTool,
+    listDatabasesTool,
+    listTablesTool,
+    describeTableTool,
+    tableHistoryTool,
+    listSnapshotsTool,
+    myUsageTool
+  )
+
+  // ---------- shared helpers ----------
+
+  private def identityOf(principal: McpPrincipal): String = principal match
+    case McpPrincipal.StaticKey => CatalogPreviewHandlers.SuperuserIdentity
+    case McpPrincipal.Pat(p)    => p.user.username
+
+  private def connectionIdOf(principal: McpPrincipal): String = principal match
+    case McpPrincipal.StaticKey => "mcp-static"
+    case McpPrincipal.Pat(p)    => s"mcp-${p.patId}"
+
+  private def routerFailureText(f: RouterFailure): String = f match
+    case RouterFailure.AccessDenied(reason)                               => reason
+    case RouterFailure.Unavailable(reason) if reason.contains("resuming") =>
+      "the pool is waking from suspend; retry in a few seconds"
+    case other if other.reason.contains("ConnectException") =>
+      // A statement can race a freshly (re)spawned node's startup: the resume hold
+      // releases on the node record, not on its first passed health probe (the
+      // documented readiness-hold gap). Transient by construction, so say so.
+      "a node is still starting; retry in a few seconds"
+    case other => other.reason
+
+  /** Execute `sql` through the routed executor and decode at most `maxRows` rows. */
+  private def execute(
+      principal: McpPrincipal,
+      poolKey: ai.starlake.quack.model.PoolKey,
+      sql: String,
+      maxRows: Int
+  ): IO[Either[String, Json]] =
+    executor(connectionIdOf(principal), identityOf(principal), poolKey, sql).flatMap {
+      case Left(f)   => IO.pure(Left(routerFailureText(f)))
+      case Right(qr) =>
+        IO.blocking {
+          val (columns, rows, truncated) =
+            try ArrowRowsDecoder.decode(qr.rows, maxRows)
+            finally qr.close()
+          Right(
+            Json.obj(
+              "columns"    -> columns.asJson,
+              "rows"       -> Json.arr(rows.map(r => Json.arr(r*))*),
+              "truncated"  -> Json.fromBoolean(truncated),
+              "nodeId"     -> Json.fromString(qr.nodeId),
+              "durationMs" -> Json.fromLong(qr.durationMs)
+            )
+          )
+        }
+    }
+
+  private def poolKeyFor(
+      tenant: String,
+      database: String,
+      poolArg: Option[String]
+  ): Either[String, ai.starlake.quack.model.PoolKey] =
+    poolArg match
+      case Some(pool) =>
+        sup.findPoolKeyByTenantAndPoolName(tenant, pool) match
+          case Some(key) if key.tenantDb == database => Right(key)
+          case Some(key)                             =>
+            Left(s"pool '$pool' serves database '${key.tenantDb}', not '$database'")
+          case None => Left(s"pool '$pool' not found in tenant '$tenant'")
+      case None =>
+        PoolPicks
+          .readPoolKey(sup, tenant, database)
+          .toRight(s"no pool serves database '$database' in tenant '$tenant'")
+
+  // ---------- run_sql ----------
+
+  private val runSqlTool = McpToolDef(
+    name = "run_sql",
+    description =
+      "Execute SQL against a database. Call describe_table first so you know the columns, and " +
+        "prefer aggregation (GROUP BY, COUNT, LIMIT) over dumping rows: results are capped at " +
+        s"${cfg.maxRows} rows and carry truncated=true when the cap cut them off. Writes are " +
+        "allowed exactly as far as your grants go (RO/RW/DDL); RLS/CLS policies apply. Time " +
+        "travel: SELECT ... FROM t AT (VERSION => n) with a snapshot id from list_snapshots.",
+    inputSchema = objectSchema(
+      required = List("sql", "database"),
+      props = "sql" -> strProp("The SQL statement to execute."),
+      "database" -> strProp("Target database (tenant-db) name."),
+      "tenant"   -> strProp("Tenant id; only for superuser credentials (PATs infer it)."),
+      "pool"     -> strProp("Pool to run on; defaults to a read-capable pool of the database."),
+      "max_rows" -> intProp("Lower the server row cap for this call; it can never raise it.")
+    ),
+    adminOnly = false,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        sql      <- str(args, "sql").toRight("the 'sql' argument is required")
+        database <- str(args, "database").toRight("the 'database' argument is required")
+        poolKey  <- poolKeyFor(tenant, database, str(args, "pool"))
+      yield (poolKey, sql)) match
+        case Left(err)             => IO.pure(Left(err))
+        case Right((poolKey, sql)) =>
+          val eff = math.min(cfg.maxRows, int(args, "max_rows").getOrElse(cfg.maxRows)).max(1)
+          execute(principal, poolKey, sql, eff)
+  )
+
+  // ---------- list_databases ----------
+
+  private val listDatabasesTool = McpToolDef(
+    name = "list_databases",
+    description =
+      "List the databases (tenant-dbs) you can query, with their kind and pools. Start here " +
+        "when you do not know the database name.",
+    inputSchema = objectSchema(
+      required = Nil,
+      props = "tenant" -> strProp("Tenant id; only for superuser credentials (PATs infer it).")
+    ),
+    adminOnly = false,
+    run = (principal, args) =>
+      tenantOf(principal, args) match
+        case Left(err)     => IO.pure(Left(err))
+        case Right(tenant) =>
+          tenantDbs
+            .listTenantDbs(tenant, principal.rawToken)(scopeOf)
+            .map(res => bridge(res).map(_.asJson))
+  )
+
+  // ---------- list_tables ----------
+
+  private val listTablesTool = McpToolDef(
+    name = "list_tables",
+    description = "List schemas and tables of a database. Pass 'schema' to restrict to one schema.",
+    inputSchema = objectSchema(
+      required = List("database"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "schema" -> strProp("Only this schema."),
+      "tenant" -> strProp("Tenant id; only for superuser credentials (PATs infer it).")
+    ),
+    adminOnly = false,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- str(args, "database").toRight("the 'database' argument is required")
+      yield (tenant, database)) match
+        case Left(err)                 => IO.pure(Left(err))
+        case Right((tenant, database)) =>
+          IO.blocking {
+            val key = principal.rawToken
+            for
+              schemas <- bridge(catalog.listSchemas(tenant, database, key)(scopeOf))
+              wanted = str(args, "schema").fold(schemas.map(_.name))(s => List(s))
+              listed <- wanted.foldLeft[Either[String, List[Json]]](Right(Nil)) { (acc, s) =>
+                acc.flatMap { done =>
+                  bridge(catalog.listTables(tenant, database, s, key)(scopeOf))
+                    .map(ts =>
+                      done :+ Json.obj(
+                        "name"   -> Json.fromString(s),
+                        "tables" -> ts.asJson
+                      )
+                    )
+                }
+              }
+            yield Json.obj("schemas" -> Json.arr(listed*))
+          }
+  )
+
+  // ---------- describe_table ----------
+
+  private val describeTableTool = McpToolDef(
+    name = "describe_table",
+    description =
+      "Columns, types and a small data sample for one table. Call this before writing SQL " +
+        "against a table you have not seen.",
+    inputSchema = objectSchema(
+      required = List("database", "schema", "table"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "schema" -> strProp("Schema name."),
+      "table"  -> strProp("Table name."),
+      "tenant" -> strProp("Tenant id; only for superuser credentials (PATs infer it).")
+    ),
+    adminOnly = false,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- str(args, "database").toRight("the 'database' argument is required")
+        schema   <- str(args, "schema").toRight("the 'schema' argument is required")
+        table    <- str(args, "table").toRight("the 'table' argument is required")
+      yield (tenant, database, schema, table)) match
+        case Left(err)                                => IO.pure(Left(err))
+        case Right((tenant, database, schema, table)) =>
+          IO.blocking(
+            bridge(
+              catalog
+                .getTable(tenant, database, schema, table, None, None, None, principal.rawToken)(
+                  scopeOf
+                )
+            )
+          ).flatMap {
+            case Left(err)     => IO.pure(Left(err))
+            case Right(detail) =>
+              poolKeyFor(tenant, database, None) match
+                case Left(_) =>
+                  // No routable pool: the schema alone is still an answer.
+                  IO.pure(Right(Json.obj("table" -> detail.asJson)))
+                case Right(poolKey) =>
+                  // LIMIT one past the sample cap so `truncated` marks that more rows exist.
+                  val sampleSql =
+                    s"""SELECT * FROM "$schema"."$table" LIMIT ${SampleRows + 1}"""
+                  execute(principal, poolKey, sampleSql, SampleRows).map {
+                    case Left(_)       => Right(Json.obj("table" -> detail.asJson))
+                    case Right(sample) =>
+                      Right(
+                        Json.obj(
+                          "table"   -> detail.asJson,
+                          "columns" -> detail.columns.asJson,
+                          "sample"  -> sample
+                        )
+                      )
+                  }
+          }
+  )
+
+  // ---------- table_history ----------
+
+  private val tableHistoryTool = McpToolDef(
+    name = "table_history",
+    description =
+      "Snapshot history of one table: who changed it, when, and how (change verbs). Use the " +
+        "snapshot ids with run_sql time travel: AT (VERSION => n).",
+    inputSchema = objectSchema(
+      required = List("database", "schema", "table"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "schema" -> strProp("Schema name."),
+      "table"  -> strProp("Table name."),
+      "limit"  -> intProp("Max history entries (default 50)."),
+      "tenant" -> strProp("Tenant id; only for superuser credentials (PATs infer it).")
+    ),
+    adminOnly = false,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- str(args, "database").toRight("the 'database' argument is required")
+        schema   <- str(args, "schema").toRight("the 'schema' argument is required")
+        table    <- str(args, "table").toRight("the 'table' argument is required")
+      yield (tenant, database, schema, table)) match
+        case Left(err)                                => IO.pure(Left(err))
+        case Right((tenant, database, schema, table)) =>
+          IO.blocking(
+            bridge(
+              history.history(
+                tenant,
+                database,
+                schema,
+                table,
+                int(args, "limit"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                principal.rawToken
+              )(scopeOf)
+            ).map(_.asJson)
+          )
+  )
+
+  // ---------- list_snapshots ----------
+
+  private val listSnapshotsTool = McpToolDef(
+    name = "list_snapshots",
+    description =
+      "Snapshots and named tags of a database, newest first. Query any snapshot with run_sql: " +
+        "SELECT ... FROM t AT (VERSION => <snapshotId>), or reference a tag's snapshotId.",
+    inputSchema = objectSchema(
+      required = List("database"),
+      props = "database" -> strProp("Database (tenant-db) name."),
+      "limit"  -> intProp("Max snapshots (default 200)."),
+      "tenant" -> strProp("Tenant id; only for superuser credentials (PATs infer it).")
+    ),
+    adminOnly = false,
+    run = (principal, args) =>
+      (for
+        tenant   <- tenantOf(principal, args)
+        database <- str(args, "database").toRight("the 'database' argument is required")
+      yield (tenant, database)) match
+        case Left(err)                 => IO.pure(Left(err))
+        case Right((tenant, database)) =>
+          val key = principal.rawToken
+          for
+            snaps <- IO.blocking(
+              bridge(
+                catalog.listSnapshots(tenant, database, int(args, "limit"), None, None, key)(
+                  scopeOf
+                )
+              )
+            )
+            tagged <- tags.list(tenant, database, key)(scopeOf).map(bridge)
+          yield for
+            s <- snaps
+            t <- tagged
+          yield Json.obj("snapshots" -> s.asJson, "tags" -> t.asJson)
+  )
+
+  // ---------- my_usage ----------
+
+  private val myUsageTool = McpToolDef(
+    name = "my_usage",
+    description =
+      "Your own recent usage: per-day statement counts and your latest statements. Self-scoped " +
+        "to the PAT's owning user.",
+    inputSchema = objectSchema(required = Nil, props = Seq.empty*),
+    adminOnly = false,
+    run = (principal, _) =>
+      principal.rawToken match
+        case None =>
+          IO.pure(
+            Left("my_usage needs a user-owned PAT; the static key has no identity to scope by")
+          )
+        case some =>
+          for
+            usage <- profile.usage(None, some).map(bridge)
+            stmts <- profile.statements(Some(RecentStatements), some).map(bridge)
+          yield for
+            u <- usage
+            s <- stmts
+          yield Json.obj("usage" -> u.asJson, "statements" -> s.asJson)
+  )
+
+object McpDataTools:
+
+  /** Sample rows shown by describe_table. */
+  private val SampleRows = 5
+
+  /** Recent statements included in my_usage. */
+  private val RecentStatements = 20

--- a/src/main/scala/ai/starlake/quack/mcp/McpJsonRpc.scala
+++ b/src/main/scala/ai/starlake/quack/mcp/McpJsonRpc.scala
@@ -1,0 +1,49 @@
+package ai.starlake.quack.mcp
+
+import io.circe.{Decoder, Json, JsonObject}
+
+/** The JSON-RPC 2.0 envelope for the MCP Streamable HTTP transport: one request per POST, one
+  * response per request. Only the shapes `/mcp` actually speaks live here; transport-level concerns
+  * (auth, method dispatch) are [[McpRoutes]]'s.
+  */
+object McpJsonRpc:
+
+  /** An incoming message. `id = None` marks a notification (no response expected). */
+  final case class Request(
+      jsonrpc: String,
+      id: Option[Json],
+      method: String,
+      params: Option[JsonObject]
+  )
+
+  given Decoder[Request] = Decoder.instance { c =>
+    for
+      jsonrpc <- c.getOrElse[String]("jsonrpc")("")
+      id      <- c.get[Option[Json]]("id")
+      method  <- c.get[String]("method")
+      params  <- c.get[Option[JsonObject]]("params")
+    yield Request(jsonrpc, id, method, params)
+  }
+
+  // JSON-RPC 2.0 pre-defined codes; -32602 doubles as the MCP "unknown tool" answer.
+  val ParseError: Int     = -32700
+  val MethodNotFound: Int = -32601
+  val InvalidParams: Int  = -32602
+  val InternalError: Int  = -32603
+
+  def ok(id: Option[Json], result: Json): Json =
+    Json.obj(
+      "jsonrpc" -> Json.fromString("2.0"),
+      "id"      -> id.getOrElse(Json.Null),
+      "result"  -> result
+    )
+
+  def err(id: Option[Json], code: Int, message: String): Json =
+    Json.obj(
+      "jsonrpc" -> Json.fromString("2.0"),
+      "id"      -> id.getOrElse(Json.Null),
+      "error"   -> Json.obj(
+        "code"    -> Json.fromInt(code),
+        "message" -> Json.fromString(message)
+      )
+    )

--- a/src/main/scala/ai/starlake/quack/mcp/McpPrincipal.scala
+++ b/src/main/scala/ai/starlake/quack/mcp/McpPrincipal.scala
@@ -1,0 +1,34 @@
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.ondemand.auth.PatPrincipal
+
+/** The two credentials `/mcp` admits. Session JWTs and passwords are refused at the route, so every
+  * tool sees exactly one of these.
+  */
+sealed trait McpPrincipal:
+  def isAdmin: Boolean
+
+  /** The raw bearer, for currying into the REST handlers' `apiKey` seam so their scope gates
+    * resolve the same principal this route did. `None` for the static key: the handlers' own
+    * static-key arm is not re-entered from here.
+    */
+  def rawToken: Option[String]
+
+object McpPrincipal:
+
+  /** The static `QOD_API_KEY`: superuser-equivalent, cross-tenant. */
+  case object StaticKey extends McpPrincipal:
+    def isAdmin: Boolean         = true
+    def rawToken: Option[String] = None
+
+  /** A personal access token, resolved to its owning user's live principal. The raw bearer rides
+    * along for handler currying but is a plain constructor arg (not a case field), so it never
+    * appears in `toString` or log output.
+    */
+  final class Pat(val p: PatPrincipal, raw: String) extends McpPrincipal:
+    def isAdmin: Boolean          = p.isAdmin
+    def rawToken: Option[String]  = Some(raw)
+    override def toString: String = s"Pat(${p.user.username}, pat=${p.patId})"
+
+  object Pat:
+    def unapply(x: Pat): Some[PatPrincipal] = Some(x.p)

--- a/src/main/scala/ai/starlake/quack/mcp/McpRoutes.scala
+++ b/src/main/scala/ai/starlake/quack/mcp/McpRoutes.scala
@@ -1,0 +1,170 @@
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.McpConfig
+import ai.starlake.quack.ondemand.auth.PatPrincipal
+import cats.effect.IO
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.{Json, JsonObject}
+import io.circe.parser.decode
+import org.http4s.{HttpRoutes, MediaType, Response, Status}
+import org.http4s.dsl.io._
+import org.http4s.headers.`Content-Type`
+import org.typelevel.ci.CIString
+
+/** One MCP tool: metadata for `tools/list` plus its executable body. `run`'s `Left(message)`
+  * becomes a `tools/call` result with `isError: true` (a normal result the agent acts on, per the
+  * MCP error-layering contract), never a JSON-RPC error.
+  */
+final case class McpToolDef(
+    name: String,
+    description: String,
+    inputSchema: Json,
+    adminOnly: Boolean,
+    run: (McpPrincipal, JsonObject) => IO[Either[String, Json]]
+)
+
+/** The MCP Streamable HTTP endpoint: `POST /mcp`, one JSON-RPC message per request, plain JSON
+  * response, no SSE and no session id, so any HA replica answers any request.
+  *
+  * Auth first, before the body is even parsed: `Authorization: Bearer <t>` where `t` is the static
+  * API key (constant-time compare, only when configured non-empty) or a live PAT. A session JWT
+  * fails both arms by construction (wrong prefix for the PAT arm, no constant-time match for the
+  * static arm), which is the design: `/mcp` never admits session credentials and never runs
+  * unauthenticated -- there is no open mode here and never was.
+  *
+  * `resolvePat` is the narrow seam (`PatAuthenticator.resolve` in Main) so protocol tests need no
+  * store.
+  */
+final class McpRoutes(
+    cfg: McpConfig,
+    staticKey: Option[String],
+    resolvePat: String => Option[PatPrincipal],
+    tools: List[McpToolDef],
+    serverVersion: String
+) extends LazyLogging:
+
+  import McpJsonRpc._
+
+  private val byName: Map[String, McpToolDef] = tools.map(t => t.name -> t).toMap
+
+  private def constantTimeEq(a: String, b: String): Boolean =
+    java.security.MessageDigest.isEqual(
+      a.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+      b.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    )
+
+  private def authenticate(header: Option[String]): Option[McpPrincipal] =
+    header.flatMap { h =>
+      if !h.startsWith("Bearer ") then None
+      else
+        val token = h.stripPrefix("Bearer ")
+        if token.nonEmpty && staticKey.exists(k => constantTimeEq(token, k)) then
+          Some(McpPrincipal.StaticKey)
+        else resolvePat(token).map(p => new McpPrincipal.Pat(p, token))
+    }
+
+  private def jsonResponse(status: Status, body: Json): Response[IO] =
+    Response[IO](status)
+      .withEntity(body.noSpaces)
+      .withContentType(`Content-Type`(MediaType.application.json))
+
+  def routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case req @ POST -> Root / "mcp" =>
+      authenticate(req.headers.get(CIString("Authorization")).map(_.head.value)) match
+        case None =>
+          IO.pure(
+            jsonResponse(Status.Unauthorized, Json.obj("error" -> Json.fromString("unauthorized")))
+          )
+        case Some(principal) =>
+          req.as[String].flatMap { raw =>
+            decode[Request](raw) match
+              case Left(_) =>
+                IO.pure(
+                  jsonResponse(Status.Ok, err(None, ParseError, "malformed JSON-RPC request"))
+                )
+              case Right(rpc) => dispatch(principal, rpc)
+          }
+
+    case GET -> Root / "mcp" =>
+      IO.pure(Response[IO](Status.MethodNotAllowed))
+  }
+
+  private def dispatch(principal: McpPrincipal, rpc: Request): IO[Response[IO]] =
+    rpc.method match
+      case "initialize" =>
+        IO.pure(
+          jsonResponse(
+            Status.Ok,
+            ok(
+              rpc.id,
+              Json.obj(
+                "protocolVersion" -> Json.fromString("2025-06-18"),
+                "capabilities"    -> Json.obj("tools" -> Json.obj()),
+                "serverInfo"      -> Json.obj(
+                  "name"    -> Json.fromString("quack-on-demand"),
+                  "version" -> Json.fromString(serverVersion)
+                )
+              )
+            )
+          )
+        )
+
+      case "notifications/initialized" =>
+        IO.pure(Response[IO](Status.Accepted))
+
+      case "ping" =>
+        IO.pure(jsonResponse(Status.Ok, ok(rpc.id, Json.obj())))
+
+      case "tools/list" =>
+        val visible = tools.filter(t => !t.adminOnly || principal.isAdmin)
+        val listed  = visible.map { t =>
+          Json.obj(
+            "name"        -> Json.fromString(t.name),
+            "description" -> Json.fromString(t.description),
+            "inputSchema" -> t.inputSchema
+          )
+        }
+        IO.pure(jsonResponse(Status.Ok, ok(rpc.id, Json.obj("tools" -> Json.arr(listed*)))))
+
+      case "tools/call" =>
+        val params = rpc.params.getOrElse(JsonObject.empty)
+        val name   = params("name").flatMap(_.asString).getOrElse("")
+        val args   = params("arguments").flatMap(_.asObject).getOrElse(JsonObject.empty)
+        byName.get(name) match
+          // adminOnly is re-checked HERE, not just at listing time: the server never
+          // trusts that a client only calls the tools it was shown. Unauthorized and
+          // unknown collapse to one answer (no tier-probing oracle).
+          case Some(tool) if !tool.adminOnly || principal.isAdmin =>
+            tool
+              .run(principal, args)
+              .map {
+                case Right(json) => toolResult(rpc.id, json.noSpaces, isError = false)
+                case Left(msg)   => toolResult(rpc.id, msg, isError = true)
+              }
+              .handleError { t =>
+                val correlationId = java.util.UUID.randomUUID().toString.take(8)
+                logger.error(s"mcp tools/call $name failed [$correlationId]", t)
+                jsonResponse(
+                  Status.Ok,
+                  err(rpc.id, InternalError, s"internal error (correlation id $correlationId)")
+                )
+              }
+          case _ =>
+            IO.pure(jsonResponse(Status.Ok, err(rpc.id, InvalidParams, s"unknown tool: '$name'")))
+
+      case other =>
+        IO.pure(jsonResponse(Status.Ok, err(rpc.id, MethodNotFound, s"method not found: '$other'")))
+
+  private def toolResult(id: Option[Json], text: String, isError: Boolean): Response[IO] =
+    jsonResponse(
+      Status.Ok,
+      ok(
+        id,
+        Json.obj(
+          "content" -> Json.arr(
+            Json.obj("type" -> Json.fromString("text"), "text" -> Json.fromString(text))
+          ),
+          "isError" -> Json.fromBoolean(isError)
+        )
+      )
+    )

--- a/src/main/scala/ai/starlake/quack/mcp/McpToolArgs.scala
+++ b/src/main/scala/ai/starlake/quack/mcp/McpToolArgs.scala
@@ -1,0 +1,69 @@
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.ondemand.api.ErrorResponse
+import io.circe.{Json, JsonObject}
+import sttp.model.StatusCode
+
+/** Argument parsing, schema literals, and the tenant-inference rule shared by both tool tiers. */
+private[mcp] object McpToolArgs:
+
+  def str(args: JsonObject, name: String): Option[String] =
+    args(name).flatMap(_.asString).map(_.trim).filter(_.nonEmpty)
+
+  def int(args: JsonObject, name: String): Option[Int] =
+    args(name).flatMap(_.asNumber).flatMap(_.toInt)
+
+  def long(args: JsonObject, name: String): Option[Long] =
+    args(name).flatMap(_.asNumber).flatMap(_.toLong)
+
+  def bool(args: JsonObject, name: String): Option[Boolean] =
+    args(name).flatMap(_.asBoolean)
+
+  def required(args: JsonObject, name: String): Either[String, String] =
+    str(args, name).toRight(s"the '$name' argument is required")
+
+  def strProp(description: String): Json =
+    Json.obj("type" -> Json.fromString("string"), "description" -> Json.fromString(description))
+
+  def intProp(description: String): Json =
+    Json.obj("type" -> Json.fromString("integer"), "description" -> Json.fromString(description))
+
+  def boolProp(description: String): Json =
+    Json.obj("type" -> Json.fromString("boolean"), "description" -> Json.fromString(description))
+
+  def objectSchema(required: List[String], props: (String, Json)*): Json =
+    Json.obj(
+      "type"       -> Json.fromString("object"),
+      "properties" -> Json.obj(props*),
+      "required"   -> Json.arr(required.map(Json.fromString)*)
+    )
+
+  /** The tenant a tool call acts in. A tenant-scoped PAT owns exactly one answer (an explicit
+    * differing `tenant` argument is an error, never silently ignored); superuser PATs and the
+    * static key must say which tenant they mean.
+    */
+  def tenantOf(principal: McpPrincipal, args: JsonObject): Either[String, String] =
+    val explicit = str(args, "tenant")
+    principal match
+      case McpPrincipal.Pat(p) if p.user.tenant.isDefined =>
+        val own = p.user.tenant.get
+        explicit match
+          case Some(t) if t != own =>
+            Left(
+              s"your token is scoped to tenant '$own'; omit the 'tenant' argument or pass '$own'"
+            )
+          case _ => Right(own)
+      case _ =>
+        explicit.toRight(
+          "the 'tenant' argument is required: a superuser credential is not bound to a tenant"
+        )
+
+  /** REST-handler bridge: the handlers' (code, ErrorResponse) rejections become tool-level error
+    * text, keeping the stable `error` code in front so agents can branch on it.
+    */
+  def bridge[A](res: Either[(StatusCode, ErrorResponse), A]): Either[String, A] =
+    res.left.map((_, e) => s"${e.error}: ${e.message}")
+
+  /** The shared `tenant` schema property: PATs infer it, superuser credentials pass it. */
+  val tenantProp: (String, Json) =
+    "tenant" -> strProp("Tenant id; only for superuser credentials (PATs infer it).")

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -76,7 +76,12 @@ final class ManagerServer(
     // PAT admission on /api: a PAT presented as the bearer credential (X-API-Key
     // header) is accepted wherever its owner's session JWT would be. None (tests /
     // callers without Postgres) keeps the guard session-and-static-key only.
-    patAuth: Option[ai.starlake.quack.ondemand.auth.PatAuthenticator] = None
+    patAuth: Option[ai.starlake.quack.ondemand.auth.PatAuthenticator] = None,
+    // The MCP endpoint (POST /mcp), pre-built by Main when quack-on-demand.mcp.enabled.
+    // Mounted OUTSIDE apiKeyGuard on purpose: /mcp does its own bearer auth (PAT or
+    // static key, never sessions), and the guard's path filter ignores non-/api paths
+    // anyway -- mounting it here keeps that invariant explicit.
+    mcpRoutes: Option[HttpRoutes[IO]] = None
 ) extends LazyLogging:
 
   // The bearer-credential lookups, composed session-first: the JWT verify is a
@@ -900,6 +905,8 @@ final class ManagerServer(
       .withHost(Host.fromString(cfg.host).get)
       .withPort(Port.fromInt(cfg.port).get)
       .withHttpApp(
-        (apiKeyGuard(apiRoutes) <+> uiRoutes <+> moduleStatic <+> rootRedirect).orNotFound
+        (apiKeyGuard(apiRoutes) <+> mcpRoutes.getOrElse(
+          HttpRoutes.empty[IO]
+        ) <+> uiRoutes <+> moduleStatic <+> rootRedirect).orNotFound
       )
       .build

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -68,7 +68,11 @@ final class ManagerServer(
     // Public pre-session password recovery. None (tests / callers that don't wire
     // Postgres) leaves both routes unmounted; the paths still bypass the api-key
     // guard so a wired handler is reachable without a session.
-    passwordReset: Option[PasswordResetHandlers] = None
+    passwordReset: Option[PasswordResetHandlers] = None,
+    // Self-service personal access tokens. None (tests / callers that don't wire
+    // Postgres) leaves the three /api/auth/pat routes unmounted; Main always wires
+    // it since the store lives in the same control-plane database.
+    pat: Option[PatHandlers] = None
 ) extends LazyLogging:
 
   /** Constant-time string equality for secret comparison (static API key). `MessageDigest.isEqual`
@@ -107,7 +111,12 @@ final class ManagerServer(
     */
   private def isProfileApi(path: String): Boolean =
     path == "/api/auth/whoami" || path == "/api/auth/logout" ||
-      path == "/api/profile/usage" || path == "/api/profile/statements"
+      path == "/api/profile/usage" || path == "/api/profile/statements" ||
+      // Personal access tokens are self-service for every principal, admin or
+      // not: the handlers scope every call to the session's own user id, so
+      // there is nothing here a regular user could reach beyond its own tokens.
+      path == "/api/auth/pat/create" || path == "/api/auth/pat/list" ||
+      path == "/api/auth/pat/revoke"
 
   /** Gate on the api namespace. Two modes:
     *   - **`cfg.apiKey` unset** (default zero-config): the namespace is open. A startup warning
@@ -485,6 +494,17 @@ final class ManagerServer(
       }
     )
 
+    // Mounted only when a handler is wired (Main always wires one). Session-only by
+    // construction: the handler refuses a PAT presented as the credential, so these
+    // routes cannot be driven by the very tokens they manage.
+    val patEndpoints: List[ServerEndpoint[Any, IO]] = pat.toList.flatMap { h =>
+      List[ServerEndpoint[Any, IO]](
+        PatEndpoints.create.serverLogic { case (token, req) => h.create(token, req) },
+        PatEndpoints.list.serverLogic(token => h.list(token)),
+        PatEndpoints.revoke.serverLogic { case (token, req) => h.revoke(token, req) }
+      )
+    }
+
     // Mounted only when a handler is wired; the paths are guard-exempt regardless
     // (see isPublicApi), so a wired handler is reachable pre-session.
     val passwordResetEndpoints: List[ServerEndpoint[Any, IO]] = passwordReset.toList.flatMap { h =>
@@ -733,7 +753,7 @@ final class ManagerServer(
       NodeEndpoints.killStatement.serverLogic { case (req, token) =>
         activeStmts.kill(req, token)(sessions.scopeOf)
       }
-    ) ++ authEndpoints ++ passwordResetEndpoints ++ catalogEndpoints ++ tagEndpoints ++ maintenanceEndpoints ++ timeTravelEndpoints ++ catalogHistoryEndpoints ++ undropEndpoints ++ restoreEndpoints ++ metricsEndpoints ++ rbacEndpoints ++ federatedSourceEndpoints ++ moduleEndpoints
+    ) ++ authEndpoints ++ patEndpoints ++ passwordResetEndpoints ++ catalogEndpoints ++ tagEndpoints ++ maintenanceEndpoints ++ timeTravelEndpoints ++ catalogHistoryEndpoints ++ undropEndpoints ++ restoreEndpoints ++ metricsEndpoints ++ rbacEndpoints ++ federatedSourceEndpoints ++ moduleEndpoints
 
     val collisions = ai.starlake.quack.ondemand.module.RouteCollisions.check(endpoints)
     if collisions.nonEmpty then

--- a/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/ManagerServer.scala
@@ -72,8 +72,23 @@ final class ManagerServer(
     // Self-service personal access tokens. None (tests / callers that don't wire
     // Postgres) leaves the three /api/auth/pat routes unmounted; Main always wires
     // it since the store lives in the same control-plane database.
-    pat: Option[PatHandlers] = None
+    pat: Option[PatHandlers] = None,
+    // PAT admission on /api: a PAT presented as the bearer credential (X-API-Key
+    // header) is accepted wherever its owner's session JWT would be. None (tests /
+    // callers without Postgres) keeps the guard session-and-static-key only.
+    patAuth: Option[ai.starlake.quack.ondemand.auth.PatAuthenticator] = None
 ) extends LazyLogging:
+
+  // The bearer-credential lookups, composed session-first: the JWT verify is a
+  // cheap in-memory operation, and PatAuthenticator self-rejects any token
+  // without the qod_pat_ prefix before touching the store, so the composition
+  // costs a session caller nothing and a PAT caller one prefix check.
+  private val scopeOfToken: String => Option[ai.starlake.quack.ondemand.auth.SessionScope] =
+    t => sessions.scopeOf(t).orElse(patAuth.flatMap(_.scopeOf(t)))
+  private val isAdminToken: String => Boolean =
+    t => sessions.isAdmin(t) || patAuth.exists(_.isAdmin(t))
+  private val sessionOfToken: String => Option[SessionTokenStore.Session] =
+    t => sessions.get(t).orElse(patAuth.flatMap(_.sessionOf(t)))
 
   /** Constant-time string equality for secret comparison (static API key). `MessageDigest.isEqual`
     * does not short-circuit on the first differing byte, closing the timing side-channel that
@@ -118,13 +133,13 @@ final class ManagerServer(
       path == "/api/auth/pat/create" || path == "/api/auth/pat/list" ||
       path == "/api/auth/pat/revoke"
 
-  /** Gate on the api namespace. Two modes:
-    *   - **`cfg.apiKey` unset** (default zero-config): the namespace is open. A startup warning
-    *     fires so operators know the manager is exposed; this is the documented dev default. To
-    *     lock it down, set `QOD_API_KEY` (or use the UI which mints session tokens via
-    *     /api/auth/login).
-    *   - **`cfg.apiKey` set**: every `/api/...` request must carry an `X-API-Key` header matching
-    *     either the static key OR a known admin UI session token.
+  /** Gate on the api namespace. Every non-public `/api/...` request must carry a credential: a
+    * session token, a live personal access token (admitted with exactly its owner's scope, admin or
+    * profile-only), or -- when `cfg.apiKey` is set -- the static key via `X-API-Key`.
+    *
+    * An unset (or empty) `cfg.apiKey` only disables the static-key arm; it never opens the
+    * namespace. The former open mode is gone: a keyless dev workflow logs in through
+    * `/api/auth/login` (or sets `QOD_API_KEY`).
     *
     * Sessions come in two flavors since the regular-user profile feature: admin sessions (JWT
     * `role=admin`), which reach the whole namespace, and non-admin sessions minted by a
@@ -144,11 +159,9 @@ final class ManagerServer(
     // with a key no client ever sends.
     val staticConfigured = cfg.apiKey.filter(_.nonEmpty)
     if staticConfigured.isEmpty then
-      // ERROR (not warn): a security misconfiguration report must survive the
-      // quiet default log level (logback root defaults to ERROR).
-      logger.error(
-        "REST API is OPEN: QOD_API_KEY is not set. Set it (or rely on the " +
-          "UI login flow) before exposing the manager beyond localhost."
+      logger.info(
+        "QOD_API_KEY unset: static-key auth disabled; only session and PAT " +
+          "credentials are accepted on /api"
       )
     else logger.info("REST API X-API-Key enforcement enabled (static key + UI session tokens).")
 
@@ -181,15 +194,14 @@ final class ManagerServer(
         val staticMatch = (staticConfigured, headerToken) match
           case (Some(expected), Some(actual)) => constantTimeEq(actual, expected)
           case _                              => false
-        val sessionAdmin = provided.exists(sessions.isAdmin)
-        val openMode     = staticConfigured.isEmpty
+        val sessionAdmin = provided.exists(isAdminToken)
         // Resolved once: it decides both the non-admin demotion below and the
         // per-request tenant scope check further down.
-        val tokenScope      = provided.flatMap(sessions.scopeOf)
+        val tokenScope      = provided.flatMap(scopeOfToken)
         val nonAdminSession = tokenScope.isDefined && !sessionAdmin
 
         val admitted =
-          staticMatch || sessionAdmin || openMode || (nonAdminSession && isProfileApi(path))
+          staticMatch || sessionAdmin || (nonAdminSession && isProfileApi(path))
         // Strip control characters -- jsonb rejects NUL (0x00); cap length so
         // detail stays bounded. An unsanitized `%00` in the path would make
         // the insert throw and the attacker would erase their own trail.
@@ -205,7 +217,7 @@ final class ManagerServer(
             // Audited under the caller's REAL identity (recoverable from the
             // session), so a low-privilege insider sweeping admin endpoints
             // leaves a trail.
-            val caller   = provided.flatMap(sessions.get).map(_.profile)
+            val caller   = provided.flatMap(sessionOfToken).map(_.profile)
             val username = caller.map(_.username).getOrElse("unknown")
             // Rate-limited per principal, not per host: the recorder writes
             // synchronously on the request path, so one authenticated session
@@ -245,7 +257,7 @@ final class ManagerServer(
             OptionT.pure[IO](Response[IO](Status.Unauthorized))
         else
           // Per-request tenant scope check. Only applies when there is a known
-          // session (not the static key, not open mode). Body-tenant endpoints
+          // session (not the static key). Body-tenant endpoints
           // do their own check via TenantScopeCheck.reject.
           val queryTenant = req.uri.query.params.get("tenant")
           val pathTenant  = TenantScopeGuard.extractTenant(path, queryTenant)
@@ -275,10 +287,10 @@ final class ManagerServer(
       // JDBC calls go on `IO.blocking` since Hikari semantics are synchronous.
       List[ServerEndpoint[Any, IO]](
         CatalogEndpoints.listSchemasEndpoint.serverLogic { case (tenant, tenantDb, token) =>
-          IO.blocking(h.listSchemas(tenant, tenantDb, token)(sessions.scopeOf))
+          IO.blocking(h.listSchemas(tenant, tenantDb, token)(scopeOfToken))
         },
         CatalogEndpoints.listTablesEndpoint.serverLogic { case (tenant, tenantDb, schema, token) =>
-          IO.blocking(h.listTables(tenant, tenantDb, schema, token)(sessions.scopeOf))
+          IO.blocking(h.listTables(tenant, tenantDb, schema, token)(scopeOfToken))
         },
         CatalogEndpoints.getTableEndpoint.serverLogic {
           case (tenant, tenantDb, schema, table, asOf, asOfTag, asOfTsRaw, token) =>
@@ -287,14 +299,14 @@ final class ManagerServer(
               case Right(asOfTs) =>
                 IO.blocking(
                   h.getTable(tenant, tenantDb, schema, table, asOf, asOfTag, asOfTs, token)(
-                    sessions.scopeOf
+                    scopeOfToken
                   )
                 )
         },
         CatalogEndpoints.listSnapshotsEndpoint.serverLogic {
           case (tenant, tenantDb, limit, before, table, token) =>
             IO.blocking(
-              h.listSnapshots(tenant, tenantDb, limit, before, table, token)(sessions.scopeOf)
+              h.listSnapshots(tenant, tenantDb, limit, before, table, token)(scopeOfToken)
             )
         }
       )
@@ -306,16 +318,16 @@ final class ManagerServer(
     val tagEndpoints: List[ServerEndpoint[Any, IO]] = tags.toList.flatMap { h =>
       List[ServerEndpoint[Any, IO]](
         TagEndpoints.listTagsEndpoint.serverLogic { case (tenant, tenantDb, token) =>
-          h.list(tenant, tenantDb, token)(sessions.scopeOf)
+          h.list(tenant, tenantDb, token)(scopeOfToken)
         },
         TagEndpoints.createTagEndpoint.serverLogic { case (req, token) =>
-          h.create(req, token)(sessions.scopeOf)
+          h.create(req, token)(scopeOfToken)
         },
         TagEndpoints.deleteTagEndpoint.serverLogic { case (req, token) =>
-          h.delete(req, token)(sessions.scopeOf)
+          h.delete(req, token)(scopeOfToken)
         },
         TagEndpoints.protectTagEndpoint.serverLogic { case (req, token) =>
-          h.protect(req, token)(sessions.scopeOf)
+          h.protect(req, token)(scopeOfToken)
         }
       )
     }
@@ -325,20 +337,20 @@ final class ManagerServer(
     val maintenanceEndpoints: List[ServerEndpoint[Any, IO]] = maintenance.toList.flatMap { h =>
       List[ServerEndpoint[Any, IO]](
         MaintenanceEndpoints.upsertPolicyEndpoint.serverLogic { case (req, token) =>
-          h.upsertPolicy(req, token)(sessions.scopeOf)
+          h.upsertPolicy(req, token)(scopeOfToken)
         },
         MaintenanceEndpoints.deletePolicyEndpoint.serverLogic { case (req, token) =>
-          h.deletePolicy(req, token)(sessions.scopeOf)
+          h.deletePolicy(req, token)(scopeOfToken)
         },
         MaintenanceEndpoints.listPoliciesEndpoint.serverLogic { case (tenant, tenantDb, token) =>
-          h.listPolicies(tenant, tenantDb, token)(sessions.scopeOf)
+          h.listPolicies(tenant, tenantDb, token)(scopeOfToken)
         },
         MaintenanceEndpoints.listRunsEndpoint.serverLogic {
           case (tenant, tenantDb, limit, before, token) =>
-            h.listRuns(tenant, tenantDb, limit, before, token)(sessions.scopeOf)
+            h.listRuns(tenant, tenantDb, limit, before, token)(scopeOfToken)
         },
         MaintenanceEndpoints.triggerRunEndpoint.serverLogic { case (req, token) =>
-          h.triggerRun(req, token)(sessions.scopeOf)
+          h.triggerRun(req, token)(scopeOfToken)
         }
       )
     }
@@ -354,17 +366,17 @@ final class ManagerServer(
               case Left(e)       => IO.pure(Left(e))
               case Right(asOfTs) =>
                 h.preview(tenant, tenantDb, schema, table, asOf, asOfTag, asOfTs, limit, token)(
-                  sessions.scopeOf
+                  scopeOfToken
                 )
         },
         TimeTravelEndpoints.schemaDiffEndpoint.serverLogic {
           case (tenant, tenantDb, schema, table, from, to, token) =>
-            h.schemaDiff(tenant, tenantDb, schema, table, from, to, token)(sessions.scopeOf)
+            h.schemaDiff(tenant, tenantDb, schema, table, from, to, token)(scopeOfToken)
         },
         TimeTravelEndpoints.dataDiffEndpoint.serverLogic {
           case (tenant, tenantDb, schema, table, from, to, limit, cursor, changeType, token) =>
             h.dataDiff(tenant, tenantDb, schema, table, from, to, limit, cursor, changeType, token)(
-              sessions.scopeOf
+              scopeOfToken
             )
         }
       )
@@ -374,10 +386,10 @@ final class ManagerServer(
     val undropEndpoints: List[ServerEndpoint[Any, IO]] = undrop.toList.flatMap { h =>
       List[ServerEndpoint[Any, IO]](
         UndropEndpoints.recoverableEndpoint.serverLogic { case (tenant, tenantDb, limit, token) =>
-          h.recoverable(tenant, tenantDb, limit, token)(sessions.scopeOf)
+          h.recoverable(tenant, tenantDb, limit, token)(scopeOfToken)
         },
         UndropEndpoints.undropEndpoint.serverLogic { case (req, token) =>
-          h.undrop(req, token)(sessions.scopeOf)
+          h.undrop(req, token)(scopeOfToken)
         }
       )
     }
@@ -385,7 +397,7 @@ final class ManagerServer(
     // Restore (Spec 04). Session-gated per request via TenantScopeCheck inside the handler.
     val restoreEndpoints: List[ServerEndpoint[Any, IO]] = restore.toList.map { h =>
       RestoreEndpoints.restoreEndpoint.serverLogic { case (req, token) =>
-        h.restore(req, token)(sessions.scopeOf)
+        h.restore(req, token)(scopeOfToken)
       }
     }
 
@@ -427,7 +439,7 @@ final class ManagerServer(
                   operation,
                   author,
                   token
-                )(sessions.scopeOf)
+                )(scopeOfToken)
               )
       }
     }
@@ -446,7 +458,7 @@ final class ManagerServer(
         profile.statements(limit, token)
       },
       NodeEndpoints.statementHistory.serverLogic { case (limit, token) =>
-        statementHistory.recent(limit, token)(sessions.scopeOf)
+        statementHistory.recent(limit, token)(scopeOfToken)
       },
       TelemetryEndpoints.auditList.serverLogic {
         case (family, tenant, actor, action, q, from, to, limit, before, noTenant, token) =>
@@ -462,21 +474,21 @@ final class ManagerServer(
             before,
             noTenant,
             token
-          )(sessions.scopeOf)
+          )(scopeOfToken)
       },
       TelemetryEndpoints.auditActions.serverLogic(token => auditHandlers.actions(token)),
       TelemetryEndpoints.historyTrends.serverLogic {
         case (granularity, from, to, tenant, pool, token) =>
-          history.trends(granularity, from, to, tenant, pool, token)(sessions.scopeOf)
+          history.trends(granularity, from, to, tenant, pool, token)(scopeOfToken)
       },
       TelemetryEndpoints.historyStatements.serverLogic {
         case (from, to, tenant, pool, user, status, q, limit, before, token) =>
           history.statements(from, to, tenant, pool, user, status, q, limit, before, token)(
-            sessions.scopeOf
+            scopeOfToken
           )
       },
       TelemetryEndpoints.usage.serverLogic { case (from, to, groupBy, tenant, pool, token) =>
-        usage.usage(from, to, groupBy, tenant, pool, token)(sessions.scopeOf)
+        usage.usage(from, to, groupBy, tenant, pool, token)(scopeOfToken)
       },
       AuthEndpoints.oidcStart.serverLogic { case (tenant, returnTo, proto) =>
         auth.oidcStart(tenant, returnTo, proto)
@@ -516,100 +528,100 @@ final class ManagerServer(
 
     val rbacEndpoints: List[ServerEndpoint[Any, IO]] = List[ServerEndpoint[Any, IO]](
       RbacEndpoints.createUser.serverLogic { case (req, token) =>
-        users.createUser(req, token)(sessions.scopeOf)
+        users.createUser(req, token)(scopeOfToken)
       },
       RbacEndpoints.updateUser.serverLogic { case (req, token) =>
-        users.updateUser(req, token)(sessions.scopeOf)
+        users.updateUser(req, token)(scopeOfToken)
       },
       RbacEndpoints.deleteUser.serverLogic { case (req, token) =>
-        users.deleteUser(req, token)(sessions.scopeOf)
+        users.deleteUser(req, token)(scopeOfToken)
       },
       RbacEndpoints.listUsers.serverLogic { case (t, key) =>
-        users.listUsers(t, key)(sessions.scopeOf)
+        users.listUsers(t, key)(scopeOfToken)
       },
       RbacEndpoints.effectivePermissions.serverLogic { case (id, key) =>
-        users.effective(id, key)(sessions.scopeOf)
+        users.effective(id, key)(scopeOfToken)
       },
       RbacEndpoints.createRole.serverLogic { case (req, token) =>
-        roles.createRole(req, token)(sessions.scopeOf)
+        roles.createRole(req, token)(scopeOfToken)
       },
       RbacEndpoints.deleteRole.serverLogic { case (req, token) =>
-        roles.deleteRole(req, token)(sessions.scopeOf)
+        roles.deleteRole(req, token)(scopeOfToken)
       },
       RbacEndpoints.listRoles.serverLogic { case (t, key) =>
-        roles.listRoles(t, key)(sessions.scopeOf)
+        roles.listRoles(t, key)(scopeOfToken)
       },
       RbacEndpoints.grantRolePermission.serverLogic { case (req, token) =>
-        roles.grantPermission(req, token)(sessions.scopeOf)
+        roles.grantPermission(req, token)(scopeOfToken)
       },
       RbacEndpoints.revokeRolePermission.serverLogic { case (req, token) =>
-        roles.revokePermission(req, token)(sessions.scopeOf)
+        roles.revokePermission(req, token)(scopeOfToken)
       },
       RbacEndpoints.listRolePermissions.serverLogic { case (roleId, key) =>
-        roles.listPermissions(roleId, key)(sessions.scopeOf)
+        roles.listPermissions(roleId, key)(scopeOfToken)
       },
       RbacEndpoints.createGroup.serverLogic { case (req, token) =>
-        groups.createGroup(req, token)(sessions.scopeOf)
+        groups.createGroup(req, token)(scopeOfToken)
       },
       RbacEndpoints.deleteGroup.serverLogic { case (req, token) =>
-        groups.deleteGroup(req, token)(sessions.scopeOf)
+        groups.deleteGroup(req, token)(scopeOfToken)
       },
       RbacEndpoints.listGroups.serverLogic { case (t, key) =>
-        groups.listGroups(t, key)(sessions.scopeOf)
+        groups.listGroups(t, key)(scopeOfToken)
       },
       RbacEndpoints.addUserRoleMembership.serverLogic { case (req, token) =>
-        memberships.addUserRole(req, token)(sessions.scopeOf)
+        memberships.addUserRole(req, token)(scopeOfToken)
       },
       RbacEndpoints.removeUserRoleMembership.serverLogic { case (req, token) =>
-        memberships.removeUserRole(req, token)(sessions.scopeOf)
+        memberships.removeUserRole(req, token)(scopeOfToken)
       },
       RbacEndpoints.addUserGroupMembership.serverLogic { case (req, token) =>
-        memberships.addUserGroup(req, token)(sessions.scopeOf)
+        memberships.addUserGroup(req, token)(scopeOfToken)
       },
       RbacEndpoints.removeUserGroupMembership.serverLogic { case (req, token) =>
-        memberships.removeUserGroup(req, token)(sessions.scopeOf)
+        memberships.removeUserGroup(req, token)(scopeOfToken)
       },
       RbacEndpoints.addGroupRoleMembership.serverLogic { case (req, token) =>
-        memberships.addGroupRole(req, token)(sessions.scopeOf)
+        memberships.addGroupRole(req, token)(scopeOfToken)
       },
       RbacEndpoints.removeGroupRoleMembership.serverLogic { case (req, token) =>
-        memberships.removeGroupRole(req, token)(sessions.scopeOf)
+        memberships.removeGroupRole(req, token)(scopeOfToken)
       },
       RbacEndpoints.listGroupRoleMembership.serverLogic { case (groupId, key) =>
-        memberships.listGroupRoles(groupId, key)(sessions.scopeOf)
+        memberships.listGroupRoles(groupId, key)(scopeOfToken)
       },
       RbacEndpoints.grantPoolPermission.serverLogic { case (req, token) =>
-        poolPermissions.grant(req, token)(sessions.scopeOf)
+        poolPermissions.grant(req, token)(scopeOfToken)
       },
       RbacEndpoints.revokePoolPermission.serverLogic { case (req, token) =>
-        poolPermissions.revoke(req, token)(sessions.scopeOf)
+        poolPermissions.revoke(req, token)(scopeOfToken)
       },
       RbacEndpoints.listPoolPermissions.serverLogic { case (t, u, g, key) =>
-        poolPermissions.list(t, u, g, key)(sessions.scopeOf)
+        poolPermissions.list(t, u, g, key)(scopeOfToken)
       },
       RbacEndpoints.createColumnPolicy.serverLogic { case (req, token) =>
-        columnPolicies.create(req, token)(sessions.scopeOf)
+        columnPolicies.create(req, token)(scopeOfToken)
       },
       RbacEndpoints.updateColumnPolicy.serverLogic { case (req, token) =>
-        columnPolicies.update(req, token)(sessions.scopeOf)
+        columnPolicies.update(req, token)(scopeOfToken)
       },
       RbacEndpoints.deleteColumnPolicy.serverLogic { case (req, token) =>
-        columnPolicies.delete(req, token)(sessions.scopeOf)
+        columnPolicies.delete(req, token)(scopeOfToken)
       },
       RbacEndpoints.listColumnPolicies.serverLogic { case (roleId, key) =>
-        columnPolicies.list(roleId, key)(sessions.scopeOf)
+        columnPolicies.list(roleId, key)(scopeOfToken)
       },
       RbacEndpoints.createRowPolicy.serverLogic { case (req, token) =>
-        rowPolicies.create(req, token)(sessions.scopeOf)
+        rowPolicies.create(req, token)(scopeOfToken)
       },
       RbacEndpoints.updateRowPolicy.serverLogic { case (req, token) =>
-        rowPolicies.update(req, token)(sessions.scopeOf)
+        rowPolicies.update(req, token)(scopeOfToken)
       },
       RbacEndpoints.deleteRowPolicy.serverLogic { case (req, token) =>
-        rowPolicies.delete(req, token)(sessions.scopeOf)
+        rowPolicies.delete(req, token)(scopeOfToken)
       },
       RbacEndpoints.listRowPolicies.serverLogic { case (roleId, key) =>
-        rowPolicies.list(roleId, key)(sessions.scopeOf)
+        rowPolicies.list(roleId, key)(scopeOfToken)
       }
     )
 
@@ -646,78 +658,76 @@ final class ManagerServer(
 
     val endpoints: List[ServerEndpoint[Any, IO]] = List[ServerEndpoint[Any, IO]](
       PoolEndpoints.createPool.serverLogic { case (req, token) =>
-        pools.createPool(req, token)(sessions.scopeOf)
+        pools.createPool(req, token)(scopeOfToken)
       },
       PoolEndpoints.scalePool.serverLogic { case (req, token) =>
-        pools.scalePool(req, token)(sessions.scopeOf)
+        pools.scalePool(req, token)(scopeOfToken)
       },
       PoolEndpoints.stopPool.serverLogic { case (req, token) =>
-        pools.stopPool(req, token)(sessions.scopeOf)
+        pools.stopPool(req, token)(scopeOfToken)
       },
       PoolEndpoints.deletePool.serverLogic { case (req, token) =>
-        pools.deletePool(req, token)(sessions.scopeOf)
+        pools.deletePool(req, token)(scopeOfToken)
       },
       PoolEndpoints.suspendPool.serverLogic { case (req, token) =>
-        pools.suspendPool(req, token)(sessions.scopeOf)
+        pools.suspendPool(req, token)(scopeOfToken)
       },
       PoolEndpoints.resumePool.serverLogic { case (req, token) =>
-        pools.resumePool(req, token)(sessions.scopeOf)
+        pools.resumePool(req, token)(scopeOfToken)
       },
-      PoolEndpoints.listPools.serverLogic(token => pools.listPools(token)(sessions.scopeOf)),
+      PoolEndpoints.listPools.serverLogic(token => pools.listPools(token)(scopeOfToken)),
       PoolEndpoints.poolStatus.serverLogic((t, td, p) => pools.poolStatus(t, td, p)),
       PoolEndpoints.setPoolDisabled.serverLogic { case (req, token) =>
-        pools.setPoolDisabled(req, token)(sessions.scopeOf)
+        pools.setPoolDisabled(req, token)(scopeOfToken)
       },
       PoolEndpoints.setPoolResources.serverLogic { case (req, token) =>
-        pools.setResources(req, token)(sessions.scopeOf)
+        pools.setResources(req, token)(scopeOfToken)
       },
       PoolEndpoints.setPoolTemplate.serverLogic { case (req, token) =>
-        pools.setPodTemplate(req, token)(sessions.scopeOf)
+        pools.setPodTemplate(req, token)(scopeOfToken)
       },
       PoolEndpoints.setPoolLockdown.serverLogic { case (req, token) =>
-        pools.setLockdown(req, token)(sessions.scopeOf)
+        pools.setLockdown(req, token)(scopeOfToken)
       },
       PoolEndpoints.setPoolAutoscale.serverLogic { case (req, token) =>
-        pools.setPoolAutoscale(req, token)(sessions.scopeOf)
+        pools.setPoolAutoscale(req, token)(scopeOfToken)
       },
       NodeEndpoints.setMaxConcurrent.serverLogic { case (req, token) =>
-        nodes.setMaxConcurrent(req, token)(sessions.scopeOf)
+        nodes.setMaxConcurrent(req, token)(scopeOfToken)
       },
       NodeEndpoints.quarantineNode.serverLogic { case (req, token) =>
-        nodes.quarantineNode(req, token)(sessions.scopeOf)
+        nodes.quarantineNode(req, token)(scopeOfToken)
       },
       NodeEndpoints.unquarantineNode.serverLogic { case (req, token) =>
-        nodes.unquarantineNode(req, token)(sessions.scopeOf)
+        nodes.unquarantineNode(req, token)(scopeOfToken)
       },
       NodeEndpoints.restartNode.serverLogic { case (req, token) =>
-        nodes.restartNode(req, token)(sessions.scopeOf)
+        nodes.restartNode(req, token)(scopeOfToken)
       },
       TenantEndpoints.createTenant.serverLogic { case (req, token) =>
-        tenants.createTenant(req, token)(sessions.scopeOf)
+        tenants.createTenant(req, token)(scopeOfToken)
       },
-      TenantEndpoints.listTenants.serverLogic(token =>
-        tenants.listTenants(token)(sessions.scopeOf)
-      ),
+      TenantEndpoints.listTenants.serverLogic(token => tenants.listTenants(token)(scopeOfToken)),
       TenantEndpoints.deleteTenant.serverLogic { case (req, token) =>
-        tenants.deleteTenant(req, token)(sessions.scopeOf)
+        tenants.deleteTenant(req, token)(scopeOfToken)
       },
       TenantEndpoints.setTenantDisabled.serverLogic { case (req, token) =>
-        tenants.setTenantDisabled(req, token)(sessions.scopeOf)
+        tenants.setTenantDisabled(req, token)(scopeOfToken)
       },
       TenantEndpoints.setTenantAuth.serverLogic { case (req, token) =>
-        tenants.setTenantAuth(req, token)(sessions.scopeOf)
+        tenants.setTenantAuth(req, token)(scopeOfToken)
       },
       TenantEndpoints.createTenantDb.serverLogic { case (req, token) =>
-        tenantDbs.createTenantDb(req, token)(sessions.scopeOf)
+        tenantDbs.createTenantDb(req, token)(scopeOfToken)
       },
       TenantEndpoints.listTenantDbs.serverLogic { case (tenant, token) =>
-        tenantDbs.listTenantDbs(tenant, token)(sessions.scopeOf)
+        tenantDbs.listTenantDbs(tenant, token)(scopeOfToken)
       },
       TenantEndpoints.deleteTenantDb.serverLogic { case (req, token) =>
-        tenantDbs.deleteTenantDb(req, token)(sessions.scopeOf)
+        tenantDbs.deleteTenantDb(req, token)(scopeOfToken)
       },
       TenantEndpoints.updateTenantDb.serverLogic { case (req, token) =>
-        tenantDbs.update(req, token)(sessions.scopeOf)
+        tenantDbs.update(req, token)(scopeOfToken)
       },
       Endpoints.health.serverLogic(_ => health.health),
       Endpoints.ready.serverLogic(_ => health.ready),
@@ -742,16 +752,14 @@ final class ManagerServer(
           )
         )
       ),
-      Endpoints.serverConfig.serverLogic(token => serverConfig.list(token)(sessions.scopeOf)),
-      Endpoints.manifestExport.serverLogic(token => manifest.exportYaml(token)(sessions.scopeOf)),
+      Endpoints.serverConfig.serverLogic(token => serverConfig.list(token)(scopeOfToken)),
+      Endpoints.manifestExport.serverLogic(token => manifest.exportYaml(token)(scopeOfToken)),
       Endpoints.manifestImport.serverLogic { case (body, token) =>
-        manifest.importYaml(body, token)(sessions.scopeOf)
+        manifest.importYaml(body, token)(scopeOfToken)
       },
-      NodeEndpoints.activeStatements.serverLogic(token =>
-        activeStmts.list(token)(sessions.scopeOf)
-      ),
+      NodeEndpoints.activeStatements.serverLogic(token => activeStmts.list(token)(scopeOfToken)),
       NodeEndpoints.killStatement.serverLogic { case (req, token) =>
-        activeStmts.kill(req, token)(sessions.scopeOf)
+        activeStmts.kill(req, token)(scopeOfToken)
       }
     ) ++ authEndpoints ++ patEndpoints ++ passwordResetEndpoints ++ catalogEndpoints ++ tagEndpoints ++ maintenanceEndpoints ++ timeTravelEndpoints ++ catalogHistoryEndpoints ++ undropEndpoints ++ restoreEndpoints ++ metricsEndpoints ++ rbacEndpoints ++ federatedSourceEndpoints ++ moduleEndpoints
 

--- a/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/Dtos.scala
@@ -498,6 +498,43 @@ final case class AuthModeResponse(
     ssoProviderName: String = ""
 )
 
+// ----- Personal access tokens -----
+
+/** Mint request. `name` is an operator-facing label (what the token is for), not an identifier: it
+  * is never unique and never resolves anything. `expiresAt` absent means "no expiry" -- revocation
+  * is then the only way to retire the token.
+  */
+final case class PatCreateRequest(
+    name: String,
+    expiresAt: Option[java.time.Instant] = None
+)
+
+/** The ONLY response that ever carries the raw `token`: it is stored hashed, so a caller that loses
+  * this value must mint a new one.
+  */
+final case class PatCreateResponse(
+    id: String,
+    name: String,
+    token: String,
+    expiresAt: Option[java.time.Instant] = None
+)
+
+/** Listing row: metadata only, deliberately without the raw token or its hash. `revoked` collapses
+  * the store's `revokedAt` timestamp to the one bit a client acts on.
+  */
+final case class PatEntry(
+    id: String,
+    name: String,
+    createdAt: java.time.Instant,
+    expiresAt: Option[java.time.Instant] = None,
+    lastUsedAt: Option[java.time.Instant] = None,
+    revoked: Boolean = false
+)
+
+final case class PatListResponse(tokens: List[PatEntry] = Nil)
+
+final case class PatRevokeRequest(id: String)
+
 // ----- Recent statement history -----
 final case class StatementHistoryEntry(
     ts: String, // ISO-8601 UTC
@@ -1162,6 +1199,14 @@ object Dtos:
   given Codec[LoginResponse]         = ConfiguredCodec.derived
   given Codec[WhoamiResponse]        = ConfiguredCodec.derived
   given Codec[AuthModeResponse]      = ConfiguredCodec.derived
+
+  // Personal access tokens. ConfiguredCodec throughout so a body omitting an
+  // optional field (`expiresAt`) still decodes against the defaults.
+  given Codec[PatCreateRequest]  = ConfiguredCodec.derived
+  given Codec[PatCreateResponse] = ConfiguredCodec.derived
+  given Codec[PatEntry]          = ConfiguredCodec.derived
+  given Codec[PatListResponse]   = ConfiguredCodec.derived
+  given Codec[PatRevokeRequest]  = ConfiguredCodec.derived
 
   given Codec[StatementHistoryEntry]    = deriveCodec
   given Codec[StatementHistoryResponse] = deriveCodec

--- a/src/main/scala/ai/starlake/quack/ondemand/api/EndpointModules.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/EndpointModules.scala
@@ -13,6 +13,7 @@ object EndpointModules:
     NodeEndpoints,
     TenantEndpoints,
     AuthEndpoints,
+    PatEndpoints,
     ProfileEndpoints,
     TelemetryEndpoints,
     FederatedSourceEndpoints,

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PatEndpoints.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PatEndpoints.scala
@@ -35,7 +35,13 @@ object PatEndpoints:
       .in(jsonBody[PatCreateRequest])
       .out(jsonBody[PatCreateResponse])
 
-  /** The caller's own tokens, live and retired, metadata only. */
+  /** The caller's own tokens, live and retired, metadata only.
+    *
+    * CLIENT CONTRACT: this route declares NO body input, so callers MUST post an empty body. A JSON
+    * body sent here is never drained by the server, which desynchronizes the HTTP/1.1 connection --
+    * the NEXT request on that same (pooled, keep-alive) connection then fails with an EOF while
+    * reading the response. The same applies to any request the api-key guard rejects before decode.
+    */
   val list: PublicEndpoint[
     Option[String],
     (sttp.model.StatusCode, ErrorResponse),

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PatEndpoints.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PatEndpoints.scala
@@ -1,0 +1,62 @@
+package ai.starlake.quack.ondemand.api
+
+import Dtos.given
+import Endpoints.authToken
+import sttp.tapir._
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe._
+
+/** Personal-access-token self-service surface (`/api/auth/pat/create|list|revoke`), split out of
+  * [[Endpoints]] to stay below the JVM's 64KB `<clinit>` ceiling (see [[RbacEndpoints]] for the
+  * rationale). Registered in [[EndpointModules.all]].
+  *
+  * Every route is strictly self-scoped: the acting identity comes from the session token via
+  * [[Endpoints.authToken]], so there is deliberately NO tenant, user, or owner input anywhere on
+  * this surface -- a caller can only ever mint, list and revoke its own tokens, and no request
+  * field can widen that. [[PatHandlers]] additionally refuses a PAT presented as the credential, so
+  * these are session-only routes even though the transport carries any bearer.
+  */
+object PatEndpoints:
+
+  private val base = endpoint
+    .in("api")
+    .errorOut(statusCode.and(jsonBody[ErrorResponse]))
+
+  /** Mint. The response is the only place the raw token is ever shown. */
+  val create: PublicEndpoint[
+    (Option[String], PatCreateRequest),
+    (sttp.model.StatusCode, ErrorResponse),
+    PatCreateResponse,
+    Any
+  ] =
+    base.post
+      .in("auth" / "pat" / "create")
+      .in(authToken)
+      .in(jsonBody[PatCreateRequest])
+      .out(jsonBody[PatCreateResponse])
+
+  /** The caller's own tokens, live and retired, metadata only. */
+  val list: PublicEndpoint[
+    Option[String],
+    (sttp.model.StatusCode, ErrorResponse),
+    PatListResponse,
+    Any
+  ] =
+    base.post
+      .in("auth" / "pat" / "list")
+      .in(authToken)
+      .out(jsonBody[PatListResponse])
+
+  /** Retire one of the caller's own tokens. An id owned by someone else, an unknown id, and an
+    * already-revoked id all answer `404 not_found` -- see [[PatHandlers.revoke]].
+    */
+  val revoke: PublicEndpoint[
+    (Option[String], PatRevokeRequest),
+    (sttp.model.StatusCode, ErrorResponse),
+    Unit,
+    Any
+  ] =
+    base.post
+      .in("auth" / "pat" / "revoke")
+      .in(authToken)
+      .in(jsonBody[PatRevokeRequest])

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PatHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PatHandlers.scala
@@ -1,0 +1,119 @@
+package ai.starlake.quack.ondemand.api
+
+import ai.starlake.quack.ondemand.state.{PatRecord, PatStore}
+import ai.starlake.quack.ondemand.telemetry.{AuditActions, AuditRecorder}
+import cats.effect.IO
+import sttp.model.StatusCode
+
+/** Self-service personal-access-token management (`/api/auth/pat/create|list|revoke`).
+  *
+  * Two rules shape every handler here:
+  *
+  *   - **Session-only.** The acting identity is read from a session JWT, and a value carrying
+  *     [[PatStore.TokenPrefix]] is refused `403 session_required` BEFORE any store call. A PAT is a
+  *     long-lived credential meant to be pasted into agents and scripts; letting one mint a
+  *     successor or revoke its siblings would make a single leaked token unrevocable in practice,
+  *     since the thief could always roll forward. Re-authenticating with a password (or SSO) is the
+  *     price of touching the credential set itself.
+  *   - **Self-scoped.** The owning user id comes from the session, never from a request field
+  *     (there is none), and every store call is scoped by it. So `list` shows only the caller's own
+  *     tokens and `revoke` can only ever retire one of them.
+  *
+  * `revoke` deliberately collapses "unknown id", "id owned by someone else" and "already revoked"
+  * into one `404 not_found`: distinguishing them would turn the endpoint into an oracle for which
+  * token ids exist under other accounts.
+  *
+  * @param userIdOf
+  *   resolves the session's `(tenant, username)` to the `qodstate_user` surrogate id that owns the
+  *   tokens. `Main` wires `UserStore.userIdOf`; a session whose principal has no row (an OIDC
+  *   identity that was never provisioned) resolves to `None` and is refused `401`.
+  */
+final class PatHandlers(
+    pats: PatStore,
+    sessions: SessionTokenStore,
+    userIdOf: (Option[String], String) => Option[String],
+    audit: AuditRecorder = AuditRecorder.noop
+):
+
+  type Out[A] = IO[Either[(StatusCode, ErrorResponse), A]]
+
+  private val sessionRequired =
+    (
+      StatusCode.Forbidden,
+      ErrorResponse(
+        "session_required",
+        "personal access tokens are managed from a logged-in session, not with a PAT"
+      )
+    )
+
+  private val noIdentity =
+    (
+      StatusCode.Unauthorized,
+      ErrorResponse("no_session_identity", "log in to manage personal access tokens")
+    )
+
+  private val notFound =
+    (StatusCode.NotFound, ErrorResponse("not_found", "no such personal access token"))
+
+  /** The owning user id behind the presented credential, or the error the caller gets. A PAT is
+    * rejected on the prefix alone (no store hit): the refusal must not depend on whether the token
+    * is live, or a revoked PAT would report a different code than a valid one.
+    */
+  private def identityOf(token: Option[String]): Either[(StatusCode, ErrorResponse), String] =
+    if token.exists(_.startsWith(PatStore.TokenPrefix)) then Left(sessionRequired)
+    else
+      token
+        .flatMap(sessions.get)
+        .flatMap(s => userIdOf(s.profile.tenant, s.profile.username))
+        .toRight(noIdentity)
+
+  def create(token: Option[String], req: PatCreateRequest): Out[PatCreateResponse] = IO.blocking {
+    identityOf(token).flatMap { uid =>
+      val name = req.name.trim
+      if name.isEmpty then
+        Left((StatusCode.BadRequest, ErrorResponse("invalid_name", "token name must be non-empty")))
+      else if req.expiresAt.exists(!_.isAfter(java.time.Instant.now())) then
+        Left(
+          (
+            StatusCode.BadRequest,
+            ErrorResponse("invalid_expiry", "expiresAt must be in the future")
+          )
+        )
+      else
+        val (rec, raw) = pats.mint(uid, name, req.expiresAt)
+        audit.rest(
+          token,
+          "auth",
+          AuditActions.AuthPatCreate,
+          "ok",
+          target = Some(rec.id),
+          detail = Map("name" -> rec.name)
+        )
+        Right(PatCreateResponse(rec.id, rec.name, raw, rec.expiresAt))
+    }
+  }
+
+  def list(token: Option[String]): Out[PatListResponse] = IO.blocking {
+    identityOf(token).map(uid => PatListResponse(pats.list(uid).map(entryOf)))
+  }
+
+  def revoke(token: Option[String], req: PatRevokeRequest): Out[Unit] = IO.blocking {
+    identityOf(token).flatMap { uid =>
+      if pats.revoke(uid, req.id.trim) then
+        audit.rest(token, "auth", AuditActions.AuthPatRevoke, "ok", target = Some(req.id.trim))
+        Right(())
+      else
+        audit.rest(token, "auth", AuditActions.AuthPatRevoke, "denied", target = Some(req.id.trim))
+        Left(notFound)
+    }
+  }
+
+  private def entryOf(r: PatRecord): PatEntry =
+    PatEntry(
+      id = r.id,
+      name = r.name,
+      createdAt = r.createdAt,
+      expiresAt = r.expiresAt,
+      lastUsedAt = r.lastUsedAt,
+      revoked = r.revokedAt.isDefined
+    )

--- a/src/main/scala/ai/starlake/quack/ondemand/api/PatHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/PatHandlers.scala
@@ -1,6 +1,6 @@
 package ai.starlake.quack.ondemand.api
 
-import ai.starlake.quack.ondemand.state.{PatRecord, PatStore}
+import ai.starlake.quack.ondemand.state.{PatRecord, PatStore, RbacUser}
 import ai.starlake.quack.ondemand.telemetry.{AuditActions, AuditRecorder}
 import cats.effect.IO
 import sttp.model.StatusCode
@@ -19,19 +19,25 @@ import sttp.model.StatusCode
   *     (there is none), and every store call is scoped by it. So `list` shows only the caller's own
   *     tokens and `revoke` can only ever retire one of them.
   *
+  * A resolved but DISABLED owner is refused `403 account_disabled` before any store call. Disabling
+  * a user already locks their existing tokens out at use time (`PatAuthenticator` gates on
+  * `enabled`); this closes the mint-time half, so a session minted before the row was disabled
+  * cannot leave a working credential behind it.
+  *
   * `revoke` deliberately collapses "unknown id", "id owned by someone else" and "already revoked"
   * into one `404 not_found`: distinguishing them would turn the endpoint into an oracle for which
   * token ids exist under other accounts.
   *
-  * @param userIdOf
-  *   resolves the session's `(tenant, username)` to the `qodstate_user` surrogate id that owns the
-  *   tokens. `Main` wires `UserStore.userIdOf`; a session whose principal has no row (an OIDC
-  *   identity that was never provisioned) resolves to `None` and is refused `401`.
+  * @param userOf
+  *   resolves the session's `(tenant, username)` to the `qodstate_user` ROW that owns the tokens --
+  *   the whole row, because `enabled` is part of the decision. `Main` wires
+  *   `PostgresControlPlaneStore.findUser`; a session whose principal has no row (an OIDC identity
+  *   that was never provisioned) resolves to `None` and is refused `401`.
   */
 final class PatHandlers(
     pats: PatStore,
     sessions: SessionTokenStore,
-    userIdOf: (Option[String], String) => Option[String],
+    userOf: (Option[String], String) => Option[RbacUser],
     audit: AuditRecorder = AuditRecorder.noop
 ):
 
@@ -52,26 +58,39 @@ final class PatHandlers(
       ErrorResponse("no_session_identity", "log in to manage personal access tokens")
     )
 
+  private val accountDisabled =
+    (
+      StatusCode.Forbidden,
+      ErrorResponse("account_disabled", "this account is disabled")
+    )
+
   private val notFound =
     (StatusCode.NotFound, ErrorResponse("not_found", "no such personal access token"))
 
-  /** The owning user id behind the presented credential, or the error the caller gets. A PAT is
-    * rejected on the prefix alone (no store hit): the refusal must not depend on whether the token
-    * is live, or a revoked PAT would report a different code than a valid one.
+  /** The owning user id behind the presented credential, or the error the caller gets: a PAT (`403
+    * session_required`), no resolvable principal (`401 no_session_identity`), or a resolved but
+    * disabled row (`403 account_disabled`). A PAT is rejected on the prefix alone (no store hit):
+    * the refusal must not depend on whether the token is live, or a revoked PAT would report a
+    * different code than a valid one.
     */
   private def identityOf(token: Option[String]): Either[(StatusCode, ErrorResponse), String] =
     if token.exists(_.startsWith(PatStore.TokenPrefix)) then Left(sessionRequired)
     else
       token
         .flatMap(sessions.get)
-        .flatMap(s => userIdOf(s.profile.tenant, s.profile.username))
-        .toRight(noIdentity)
+        .flatMap(s => userOf(s.profile.tenant, s.profile.username)) match
+        case None                  => Left(noIdentity)
+        case Some(u) if !u.enabled => Left(accountDisabled)
+        case Some(u)               => Right(u.id)
 
   def create(token: Option[String], req: PatCreateRequest): Out[PatCreateResponse] = IO.blocking {
     identityOf(token).flatMap { uid =>
       val name = req.name.trim
       if name.isEmpty then
         Left((StatusCode.BadRequest, ErrorResponse("invalid_name", "token name must be non-empty")))
+      // Deliberately `!isAfter`, not `isBefore`: an expiry of exactly now yields a
+      // token that is already dead on arrival, so it is refused with the same code
+      // as a past one rather than minted and immediately unusable.
       else if req.expiresAt.exists(!_.isAfter(java.time.Instant.now())) then
         Left(
           (

--- a/src/main/scala/ai/starlake/quack/ondemand/api/ProfileHandlers.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/api/ProfileHandlers.scala
@@ -29,9 +29,13 @@ import java.time.temporal.ChronoUnit
   *
   * `tenantById` is a lookup seam (`PoolSupervisor.getTenantById` in production) and `now` is
   * injectable, so the whole contract is testable without Postgres.
+  *
+  * `sessionOf` is the composed bearer lookup (session JWT first, then PAT), not the raw
+  * `SessionTokenStore`: a personal access token authenticates AS its owning user and must see the
+  * same self-scoped profile a login session would.
   */
 final class ProfileHandlers(
-    tokens: SessionTokenStore,
+    sessionOf: String => Option[SessionTokenStore.Session],
     telemetry: TelemetryStore,
     stmtHistory: StatementHistoryStore,
     tenantById: String => Option[Tenant],
@@ -45,7 +49,7 @@ final class ProfileHandlers(
   private val DefaultLimit  = 50
 
   def usage(days: Option[Int], token: Option[String]): Out[UsageResponse] = IO.blocking {
-    sessionOf(token).map { s =>
+    requireSession(token).map { s =>
       val d       = clamp(days, DefaultDays, MaxDays)
       val toTs    = now()
       val fromTs  = toTs.minus(d.toLong, ChronoUnit.DAYS)
@@ -88,7 +92,7 @@ final class ProfileHandlers(
 
   def statements(limit: Option[Int], token: Option[String]): Out[StatementHistoryResponse] =
     IO.delay {
-      sessionOf(token).map { s =>
+      requireSession(token).map { s =>
         val n       = clamp(limit, DefaultLimit, MaxStatements)
         val aliases = visibleTenantAliases(s)
         // Snapshot the FULL window and filter before capping, so a noisier
@@ -107,15 +111,15 @@ final class ProfileHandlers(
     math.max(1, math.min(max, requested.getOrElse(default)))
 
   /** Resolve the caller's session, or the single error every profile route answers with. Every
-    * non-Ok lookup arm collapses to the same code on purpose: the client's remedy is identical (log
-    * in, then retry), and a caller presenting the static key has no identity at all.
+    * failed lookup collapses to the same code on purpose: the client's remedy is identical (log in,
+    * then retry), and a caller presenting the static key has no identity at all.
     */
-  private def sessionOf(
+  private def requireSession(
       token: Option[String]
   ): Either[(StatusCode, ErrorResponse), SessionTokenStore.Session] =
-    tokens.lookupResult(token.getOrElse("")) match
-      case SessionTokenStore.LookupResult.Ok(s) => Right(s)
-      case _                                    =>
+    token.flatMap(sessionOf) match
+      case Some(s) => Right(s)
+      case None    =>
         Left(
           (
             StatusCode.BadRequest,

--- a/src/main/scala/ai/starlake/quack/ondemand/auth/PatAuthenticator.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/auth/PatAuthenticator.scala
@@ -31,6 +31,16 @@ final case class PatPrincipal(user: RbacUser, patId: String, scope: SessionScope
   *
   * Every entry point resolves from scratch (one store hit each, restamping `last_used_at`); a
   * caller needing more than one facet should call [[resolve]] once and read the principal.
+  *
+  * @param grantsFor
+  *   MUST be wired row-only: `u => List(UserGrant(u.tenant, u.role))`, the grant list
+  *   `AuthHandlers.mintSessionFor` builds in `Db` mode. A PAT is bound to one `qodstate_user` row,
+  *   so the principal is unambiguous; an identity-keyed lookup (`UserStore.grantsForIdentity`,
+  *   which matches by username across tenants) would fold in the grants of the SAME-NAMED but
+  *   DIFFERENT user in another tenant -- usernames are unique only per tenant
+  *   (`qodstate_user_scoped_unique`) -- handing the PAT `manageableTenants` its owner's own login
+  *   session does not have. The seam exists so tests can stub, not so callers can widen the
+  *   principal.
   */
 final class PatAuthenticator(
     pats: PatStore,

--- a/src/main/scala/ai/starlake/quack/ondemand/auth/PatAuthenticator.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/auth/PatAuthenticator.scala
@@ -1,0 +1,94 @@
+package ai.starlake.quack.ondemand.auth
+
+import ai.starlake.quack.edge.auth.AuthenticatedProfile
+import ai.starlake.quack.ondemand.api.SessionTokenStore
+import ai.starlake.quack.ondemand.state.{PatStore, RbacUser, UserGrant}
+
+import java.time.Instant
+
+/** A personal access token resolved to the principal it authenticates: the owning `qodstate_user`
+  * row, the id of the `qodstate_pat` row that was presented (for audit), the authorization envelope
+  * the caller gets, and whether that envelope carries management privileges.
+  */
+final case class PatPrincipal(user: RbacUser, patId: String, scope: SessionScope, isAdmin: Boolean)
+
+/** Turns a raw PAT bearer token into a principal, mirroring what `AuthHandlers.mintSessionFor`
+  * derives from a password login so a PAT is accepted wherever a session JWT is.
+  *
+  * Layering: [[PatStore.verify]] answers "is this token live" (unknown hash, revoked, expired all
+  * collapse to `None`) but deliberately says nothing about the owning user, so the `enabled` gate
+  * lives HERE -- disabling a user must lock their tokens out without revoking them one by one.
+  *
+  * Scope, from the owning row plus every other `qodstate_user` row the same identity holds
+  * (`grantsFor`, the lookup `AuthHandlers` feeds `mintSessionFor` for OIDC logins):
+  *   - `superuser` = the owning row is tenant-less, which is how the whole data plane
+  *     (`PostgresAclValidator`, the RLS/CLS rewriters, the handshake pool gate) defines a
+  *     superuser. NOTE the login path additionally requires `role = admin` on that row, so a
+  *     tenant-less NON-admin row -- already an ACL-bypassing superuser on the FlightSQL side --
+  *     resolves to a superuser scope here while being refused `admin_required` at password login.
+  *     That row shape is anomalous (every seeded / imported tenant-less row is an admin); the
+  *     divergence is called out so it is a decision, not an accident.
+  *   - `manageableTenants` = the tenants where this identity carries role `admin`, from the owning
+  *     row or any sibling grant.
+  *
+  * Every entry point resolves from scratch (one store hit each, restamping `last_used_at`); a
+  * caller needing more than one facet should call [[resolve]] once and read the principal.
+  */
+final class PatAuthenticator(
+    pats: PatStore,
+    userById: String => Option[RbacUser],
+    grantsFor: RbacUser => List[UserGrant]
+):
+
+  /** The principal behind `token`, or `None` when the token is not a PAT at all, is unknown /
+    * revoked / expired, or its owner no longer exists or is disabled. A value without the
+    * [[PatStore.TokenPrefix]] (a session JWT, an API key) is rejected before any store call, so the
+    * shared bearer path can try PATs first without paying a query per request.
+    */
+  def resolve(token: String): Option[PatPrincipal] =
+    if !token.startsWith(PatStore.TokenPrefix) then None
+    else
+      pats
+        .verify(token)
+        .flatMap(rec => userById(rec.userId).filter(_.enabled).map(user => (rec.id, user)))
+        .map { (patId, user) =>
+          val scope = scopeFor(user)
+          PatPrincipal(user, patId, scope, adminOf(user, scope))
+        }
+
+  /** Authorization envelope for `token`, for the `TenantScopeCheck` gates that only need the scope.
+    */
+  def scopeOf(token: String): Option[SessionScope] = resolve(token).map(_.scope)
+
+  /** Whether `token` carries management privileges. `false` for every unresolvable token. */
+  def isAdmin(token: String): Boolean = resolve(token).exists(_.isAdmin)
+
+  /** A synthetic session equivalent to what a password login would mint for this principal, so the
+    * session-consuming handlers (whoami, the profile endpoints) work off a PAT unchanged. The role
+    * is the computed privilege level, not the raw `qodstate_user.role` label, matching the `admin`
+    * / `user` distinction `LoginResponse.admin` carries.
+    */
+  def sessionOf(token: String): Option[SessionTokenStore.Session] =
+    resolve(token).map { p =>
+      SessionTokenStore.Session(
+        profile = AuthenticatedProfile(
+          username = p.user.username,
+          role = if p.isAdmin then "admin" else "user",
+          groups = Set.empty,
+          claims = Map.empty,
+          authMethod = "pat",
+          tenant = p.user.tenant
+        ),
+        scope = p.scope,
+        createdAt = Instant.now()
+      )
+    }
+
+  private def scopeFor(user: RbacUser): SessionScope =
+    val manageable = (UserGrant(user.tenant, user.role) :: grantsFor(user)).collect {
+      case UserGrant(Some(t), r) if r.equalsIgnoreCase("admin") => t
+    }.toSet
+    SessionScope(superuser = user.tenant.isEmpty, manageableTenants = manageable)
+
+  private def adminOf(user: RbacUser, scope: SessionScope): Boolean =
+    scope.superuser || user.role.equalsIgnoreCase("admin") || scope.manageableTenants.nonEmpty

--- a/src/main/scala/ai/starlake/quack/ondemand/auth/PatAuthenticator.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/auth/PatAuthenticator.scala
@@ -19,16 +19,14 @@ final case class PatPrincipal(user: RbacUser, patId: String, scope: SessionScope
   * collapse to `None`) but deliberately says nothing about the owning user, so the `enabled` gate
   * lives HERE -- disabling a user must lock their tokens out without revoking them one by one.
   *
-  * Scope, from the owning row plus every other `qodstate_user` row the same identity holds
-  * (`grantsFor`, the lookup `AuthHandlers` feeds `mintSessionFor` for OIDC logins):
-  *   - `superuser` = the owning row is tenant-less, which is how the whole data plane
-  *     (`PostgresAclValidator`, the RLS/CLS rewriters, the handshake pool gate) defines a
-  *     superuser. NOTE the login path additionally requires `role = admin` on that row, so a
-  *     tenant-less NON-admin row -- already an ACL-bypassing superuser on the FlightSQL side --
-  *     resolves to a superuser scope here while being refused `admin_required` at password login.
-  *     That row shape is anomalous (every seeded / imported tenant-less row is an admin); the
-  *     divergence is called out so it is a decision, not an accident.
-  *   - `manageableTenants` = the tenants where this identity carries role `admin`, from the owning
+  * Scope, from the owning row plus any sibling grant `grantsFor` reports:
+  *   - `superuser` = the owning row is tenant-less AND carries role `admin`, the definition
+  *     `AuthHandlers.mintSessionFor` applies at login. A PAT authenticates AS its owning user, so
+  *     it must never outrank that user's own login session: a tenant-less non-admin row is demoted
+  *     to a profile-only principal here exactly as login refuses it `admin_required`. (The data
+  *     plane -- `PostgresAclValidator`, the RLS/CLS rewriters, the handshake pool gate -- keys its
+  *     own bypass off `tenant.isEmpty` alone; that is the FlightSQL side's rule, not this one.)
+  *   - `manageableTenants` = the tenants where this principal carries role `admin`, from the owning
   *     row or any sibling grant.
   *
   * Every entry point resolves from scratch (one store hit each, restamping `last_used_at`); a
@@ -53,7 +51,7 @@ final class PatAuthenticator(
         .flatMap(rec => userById(rec.userId).filter(_.enabled).map(user => (rec.id, user)))
         .map { (patId, user) =>
           val scope = scopeFor(user)
-          PatPrincipal(user, patId, scope, adminOf(user, scope))
+          PatPrincipal(user, patId, scope, adminOf(scope))
         }
 
   /** Authorization envelope for `token`, for the `TenantScopeCheck` gates that only need the scope.
@@ -88,7 +86,14 @@ final class PatAuthenticator(
     val manageable = (UserGrant(user.tenant, user.role) :: grantsFor(user)).collect {
       case UserGrant(Some(t), r) if r.equalsIgnoreCase("admin") => t
     }.toSet
-    SessionScope(superuser = user.tenant.isEmpty, manageableTenants = manageable)
+    SessionScope(
+      superuser = user.tenant.isEmpty && user.role.equalsIgnoreCase("admin"),
+      manageableTenants = manageable
+    )
 
-  private def adminOf(user: RbacUser, scope: SessionScope): Boolean =
-    scope.superuser || user.role.equalsIgnoreCase("admin") || scope.manageableTenants.nonEmpty
+  /** `mintSessionFor`'s `isAdminPrincipal`. A separate "own row is admin" disjunct would be dead:
+    * the owning row's grant is folded into `manageableTenants` when it is tenant-scoped, and into
+    * `superuser` when it is not.
+    */
+  private def adminOf(scope: SessionScope): Boolean =
+    scope.superuser || scope.manageableTenants.nonEmpty

--- a/src/main/scala/ai/starlake/quack/ondemand/state/PatStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/PatStore.scala
@@ -1,0 +1,186 @@
+package ai.starlake.quack.ondemand.state
+
+import ai.starlake.quack.model.Names
+import com.typesafe.scalalogging.LazyLogging
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+
+import java.security.{MessageDigest, SecureRandom}
+import java.sql.{Connection, ResultSet, Timestamp}
+import java.time.Instant
+import java.util.Base64
+
+/** A row in `qodstate_pat` (Liquibase `0032`). `id` is a surrogate `pat-<32 hex chars>`; the raw
+  * bearer token is never persisted, only its SHA-256 hash (see [[PatStore.sha256Hex]]). `revokedAt`
+  * and an expired `expiresAt` both make the token permanently unusable via [[PatStore.verify]].
+  */
+final case class PatRecord(
+    id: String,
+    userId: String,
+    name: String,
+    createdAt: Instant,
+    expiresAt: Option[Instant],
+    lastUsedAt: Option[Instant],
+    revokedAt: Option[Instant]
+)
+
+/** Manages the `qodstate_pat` table -- personal access tokens, long-lived bearer credentials for
+  * agents (MCP) and scripts that authenticate as a `qodstate_user` row without a password.
+  *
+  * Mint returns the raw token exactly once; only its SHA-256 hash is stored (`token_hash`, unique).
+  * `verify` looks the hash up, rejects a revoked or expired row, and stamps `last_used_at` on a
+  * live hit so operators can see which tokens are actually in use. `revoke` is scoped to the owning
+  * user: a caller can never revoke another user's token, mirroring `UserStore`'s per-row semantics.
+  */
+final class PatStore(
+    jdbcUrl: String,
+    dbUser: String,
+    dbPassword: String,
+    poolSize: Int = 5,
+    clock: () => Instant = () => Instant.now()
+) extends LazyLogging:
+
+  // Force driver registration so the JDBC URL resolves before HikariCP
+  // probes the connection.
+  Class.forName("org.postgresql.Driver")
+
+  private val dataSource: HikariDataSource =
+    val hc = new HikariConfig()
+    hc.setJdbcUrl(jdbcUrl)
+    hc.setUsername(dbUser)
+    hc.setPassword(dbPassword)
+    hc.setMaximumPoolSize(poolSize)
+    hc.setMinimumIdle(math.min(2, poolSize))
+    hc.setConnectionTimeout(5000)
+    hc.setPoolName("qod-pat-store")
+    new HikariDataSource(hc)
+
+  private def withConn[A](f: Connection => A): A =
+    val c = dataSource.getConnection
+    try f(c)
+    finally c.close()
+
+  /** Release the pool's idle connections. Idempotent. Called from Main's shutdown hook. */
+  def close(): Unit = if !dataSource.isClosed then dataSource.close()
+
+  private val rnd = new SecureRandom()
+
+  /** Mint a fresh token for `userId`. Returns the stored record and the raw token; the raw value is
+    * shown to the caller exactly once here and is never persisted or retrievable again.
+    */
+  def mint(userId: String, name: String, expiresAt: Option[Instant]): (PatRecord, String) =
+    val raw =
+      val bytes = new Array[Byte](32)
+      rnd.nextBytes(bytes)
+      PatStore.TokenPrefix + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+    val now    = clock()
+    val record = PatRecord(Names.newSurrogateId("pat"), userId, name, now, expiresAt, None, None)
+    withConn { c =>
+      val ps = c.prepareStatement(
+        "INSERT INTO qodstate_pat (id, user_id, name, token_hash, created_at, expires_at) " +
+          "VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      try
+        ps.setString(1, record.id)
+        ps.setString(2, userId)
+        ps.setString(3, name)
+        ps.setString(4, PatStore.sha256Hex(raw))
+        ps.setTimestamp(5, Timestamp.from(now))
+        expiresAt match
+          case Some(e) => ps.setTimestamp(6, Timestamp.from(e))
+          case None    => ps.setNull(6, java.sql.Types.TIMESTAMP_WITH_TIMEZONE)
+        ps.executeUpdate()
+        ()
+      finally ps.close()
+    }
+    (record, raw)
+
+  /** Live-token lookup: `None` on an unrecognized hash, a revoked row, an expired row, or a value
+    * that doesn't even carry [[PatStore.TokenPrefix]]. On a live hit, stamps `last_used_at` in the
+    * same statement.
+    */
+  def verify(token: String): Option[PatRecord] =
+    if !token.startsWith(PatStore.TokenPrefix) then None
+    else
+      withConn { c =>
+        val ps = c.prepareStatement(
+          "UPDATE qodstate_pat SET last_used_at = NOW() WHERE token_hash = ? " +
+            "AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > NOW()) " +
+            "RETURNING id, user_id, name, created_at, expires_at, last_used_at, revoked_at"
+        )
+        try
+          ps.setString(1, PatStore.sha256Hex(token))
+          val rs = ps.executeQuery()
+          try if rs.next() then Some(rowOf(rs)) else None
+          finally rs.close()
+        finally ps.close()
+      }
+
+  /** All PATs (live and revoked/expired) owned by `userId`, newest first. */
+  def list(userId: String): List[PatRecord] =
+    withConn { c =>
+      val ps = c.prepareStatement(
+        "SELECT id, user_id, name, created_at, expires_at, last_used_at, revoked_at " +
+          "FROM qodstate_pat WHERE user_id = ? ORDER BY created_at DESC"
+      )
+      try
+        ps.setString(1, userId)
+        val rs  = ps.executeQuery()
+        val buf = scala.collection.mutable.ListBuffer.empty[PatRecord]
+        try
+          while rs.next() do buf += rowOf(rs)
+        finally rs.close()
+        buf.toList
+      finally ps.close()
+    }
+
+  /** Revoke `patId`, scoped to `userId`: returns `false` (no-op) for a token owned by a different
+    * user, an already-revoked token, or an unknown id, so a caller can never revoke someone else's
+    * token nor learn whether an id exists under another account.
+    */
+  def revoke(userId: String, patId: String): Boolean =
+    withConn { c =>
+      val ps = c.prepareStatement(
+        "UPDATE qodstate_pat SET revoked_at = NOW() WHERE id = ? AND user_id = ? AND revoked_at IS NULL"
+      )
+      try
+        ps.setString(1, patId)
+        ps.setString(2, userId)
+        ps.executeUpdate() == 1
+      finally ps.close()
+    }
+
+  private def rowOf(rs: ResultSet): PatRecord =
+    PatRecord(
+      id = rs.getString("id"),
+      userId = rs.getString("user_id"),
+      name = rs.getString("name"),
+      createdAt = rs.getTimestamp("created_at").toInstant,
+      expiresAt = Option(rs.getTimestamp("expires_at")).map(_.toInstant),
+      lastUsedAt = Option(rs.getTimestamp("last_used_at")).map(_.toInstant),
+      revokedAt = Option(rs.getTimestamp("revoked_at")).map(_.toInstant)
+    )
+
+object PatStore:
+  val TokenPrefix = "qod_pat_"
+
+  def sha256Hex(s: String): String =
+    MessageDigest.getInstance("SHA-256").digest(s.getBytes("UTF-8")).map(b => f"$b%02x").mkString
+
+  /** Build a store from the global `defaultMetastore` map. Same shape as
+    * `UserStore.fromDefaultMetastore` so the PAT table lives next to the user table by default.
+    */
+  def fromDefaultMetastore(meta: Map[String, String]): PatStore =
+    def required(k: String) =
+      meta
+        .get(k)
+        .filter(_.nonEmpty)
+        .getOrElse(
+          sys.error(s"defaultMetastore.$k must be set for PatStore")
+        )
+    val host = required("pgHost")
+    val port = required("pgPort")
+    val user = required("pgUser")
+    val pass = required("pgPassword")
+    val db   = required("dbName")
+    val url  = s"jdbc:postgresql://$host:$port/$db"
+    new PatStore(url, user, pass)

--- a/src/main/scala/ai/starlake/quack/ondemand/state/UserStore.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/UserStore.scala
@@ -92,6 +92,12 @@ final class UserStore(
     try f(c)
     finally c.close()
 
+  /** The database name this store is connected to, parsed from the JDBC URL's final path segment
+    * (e.g. `jdbc:postgresql://host:5432/mydb` -> `mydb`). Lets a caller (tests, PAT wiring) open a
+    * second connection to the same database without re-deriving the URL.
+    */
+  val dbName: String = jdbcUrl.substring(jdbcUrl.lastIndexOf('/') + 1)
+
   /** Release the pool's idle connections. Idempotent. Called from Main's shutdown hook. */
   def close(): Unit = if !dataSource.isClosed then dataSource.close()
 
@@ -259,6 +265,54 @@ final class UserStore(
         ps.setString(1, id)
         val rs = ps.executeQuery()
         try if rs.next() then Some(rs.getString(1)) else None
+        finally rs.close()
+      finally ps.close()
+    }
+
+  /** The surrogate id of the `(tenant, username)` row, or `None` if no such row exists. `tenant =
+    * None` looks up the superuser row (`tenant IS NULL`). Used by callers (PAT minting, tests) that
+    * need to resolve a login identity to the FK value stored on other tables.
+    */
+  def userIdOf(tenant: Option[String], username: String): Option[String] =
+    withConn { c =>
+      val ps = c.prepareStatement(
+        "SELECT id FROM qodstate_user WHERE tenant IS NOT DISTINCT FROM ? AND username = ?"
+      )
+      try
+        ps.setString(1, tenant.orNull)
+        ps.setString(2, username)
+        val rs = ps.executeQuery()
+        try if rs.next() then Some(rs.getString(1)) else None
+        finally rs.close()
+      finally ps.close()
+    }
+
+  /** The row with this surrogate id, or `None` if it no longer exists. */
+  def userById(id: String): Option[RbacUser] =
+    withConn { c =>
+      val ps = c.prepareStatement(
+        "SELECT id, tenant, username, role, enabled, must_change_password, email, created_at, updated_at " +
+          "FROM qodstate_user WHERE id = ?"
+      )
+      try
+        ps.setString(1, id)
+        val rs = ps.executeQuery()
+        try
+          if rs.next() then
+            Some(
+              RbacUser(
+                id = rs.getString("id"),
+                tenant = Option(rs.getString("tenant")),
+                username = rs.getString("username"),
+                role = rs.getString("role"),
+                enabled = rs.getBoolean("enabled"),
+                mustChangePassword = rs.getBoolean("must_change_password"),
+                email = Option(rs.getString("email")),
+                createdAt = Option(rs.getTimestamp("created_at")).map(_.toInstant),
+                updatedAt = Option(rs.getTimestamp("updated_at")).map(_.toInstant)
+              )
+            )
+          else None
         finally rs.close()
       finally ps.close()
     }

--- a/src/main/scala/ai/starlake/quack/ondemand/telemetry/AuditActions.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/telemetry/AuditActions.scala
@@ -18,6 +18,10 @@ object AuditActions:
   val AuthRevoke        = "auth.revoke"
   // Self-service credential rotation via the public POST /api/auth/change-password.
   val AuthPasswordChange = "auth.password.change"
+  // Personal access tokens: long-lived bearer credentials a user mints for itself.
+  // Audited under the acting session's identity; the raw token is never in the row.
+  val AuthPatCreate = "auth.pat.create"
+  val AuthPatRevoke = "auth.pat.revoke"
   // tenant + database
   val TenantCreate      = "tenant.create"
   val TenantDelete      = "tenant.delete"
@@ -107,6 +111,8 @@ object AuditActions:
     AuthLogout,
     AuthRevoke,
     AuthPasswordChange,
+    AuthPatCreate,
+    AuthPatRevoke,
     TenantCreate,
     TenantDelete,
     TenantSetDisabled,

--- a/src/test/scala/ai/starlake/quack/mcp/McpAdminToolsSpec.scala
+++ b/src/test/scala/ai/starlake/quack/mcp/McpAdminToolsSpec.scala
@@ -1,0 +1,217 @@
+// src/test/scala/ai/starlake/quack/mcp/McpAdminToolsSpec.scala
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.edge.{ActiveStatementRegistry, StatementHistoryStore}
+import ai.starlake.quack.model.{PoolKey, RoleDistribution, Tenant, TenantDbKind}
+import ai.starlake.quack.ondemand.PoolSupervisor
+import ai.starlake.quack.ondemand.api.{
+  ActiveStatementHandlers,
+  AuditHandlers,
+  MaintenanceHandlers,
+  NodeHandlers,
+  PoolHandlers,
+  SetPoolAutoscaleRequest,
+  TagHandlers
+}
+import ai.starlake.quack.ondemand.auth.{PatPrincipal, SessionScope}
+import ai.starlake.quack.ondemand.ha.StateChangePublisher
+import ai.starlake.quack.ondemand.state.{InMemoryControlPlaneStore, RbacUser}
+import ai.starlake.quack.ondemand.telemetry.NoopTelemetryStore
+import cats.effect.unsafe.implicits.global
+import io.circe.{Json, JsonObject}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Admin-tier MCP tool contract over the in-memory supervisor: scale (incl. the autoscale-band
+  * refusal), suspend/resume, statement kill scoping, the protect-only tag rule, and audit search.
+  */
+class McpAdminToolsSpec extends AnyFlatSpec with Matchers:
+
+  private val Tenant0  = "acme"
+  private val TenantDb = "acme_default"
+  private val Pool     = "sales"
+  private val Key      = PoolKey(Tenant0, TenantDb, Pool)
+
+  private val patToken = "qod_pat_alice"
+
+  private def adminPat(tenant: String = Tenant0): McpPrincipal =
+    new McpPrincipal.Pat(
+      PatPrincipal(
+        user = RbacUser(id = "u1", tenant = Some(tenant), username = "alice", role = "admin"),
+        patId = "pat-1",
+        scope = SessionScope(superuser = false, manageableTenants = Set(tenant)),
+        isAdmin = true
+      ),
+      patToken
+    )
+
+  private final class Fixture:
+    val store    = new InMemoryControlPlaneStore()
+    val backend  = ai.starlake.quack.ondemand.runtime.testkit.StubQuackBackend.noop()
+    val tracker  = new ai.starlake.quack.edge.adapter.NodeLoadTracker
+    val sup      = new PoolSupervisor(backend, tracker, store)
+    val registry = new ActiveStatementRegistry()
+
+    // DuckLake kind via direct store upsert (the supervisor's create path would probe a real
+    // metastore): the tag tools gate on kind=ducklake, and everything else is kind-agnostic.
+    sup.createTenant(Tenant(Tenant0)).unsafeRunSync()
+    store.upsertTenantDb(
+      ai.starlake.quack.model.TenantDb(
+        id = "td-acme0001",
+        tenantId = Tenant0,
+        name = TenantDb,
+        kind = TenantDbKind.DuckLake,
+        metastore = Map(
+          "pgHost"     -> "127.0.0.1",
+          "pgPort"     -> "5432",
+          "pgUser"     -> "u",
+          "pgPassword" -> "p",
+          "dbName"     -> TenantDb,
+          "schemaName" -> "main"
+        ),
+        dataPath = "/tmp/qod-mcp-admin-test"
+      )
+    )
+    sup.restore()
+    sup.createPool(Key, RoleDistribution(0, 0, 1)).unsafeRunSync()
+
+    val scopeOf: String => Option[SessionScope] =
+      t =>
+        if t == patToken then
+          Some(SessionScope(superuser = false, manageableTenants = Set(Tenant0)))
+        else None
+
+    val pools      = new PoolHandlers(sup, tracker)
+    val nodes      = new NodeHandlers(sup, tracker, store, StateChangePublisher.noop)
+    val statements =
+      new ActiveStatementHandlers(registry, new StatementHistoryStore(), store, haEnabled = false)
+    val maintenance = new MaintenanceHandlers(sup, store)
+    val tags        = new TagHandlers(
+      sup,
+      store,
+      snapshotExists = (_, _, _) => true,
+      snapshotsExist = (_, _, ids) => ids
+    )
+    val audit = new AuditHandlers(NoopTelemetryStore)
+
+    val tools = new McpAdminTools(pools, nodes, statements, maintenance, tags, audit, scopeOf)
+
+    def call(name: String, principal: McpPrincipal, args: (String, Json)*): Either[String, Json] =
+      val tool = tools.tools.find(_.name == name).getOrElse(fail(s"tool $name not defined"))
+      tool.adminOnly shouldBe true
+      tool.run(principal, JsonObject(args*)).unsafeRunSync()
+
+  "scale_pool" should "scale the pool and report the new size" in {
+    val f   = new Fixture
+    val out = f.call(
+      "scale_pool",
+      McpPrincipal.StaticKey,
+      "tenant"   -> Json.fromString(Tenant0),
+      "database" -> Json.fromString(TenantDb),
+      "pool"     -> Json.fromString(Pool),
+      "dual"     -> Json.fromInt(2)
+    )
+    out.isRight shouldBe true
+    f.sup.get(Key).get.nodes should have size 2
+  }
+
+  it should "surface the outside_band refusal for a pool with a declared band" in {
+    val f = new Fixture
+    f.pools
+      .setPoolAutoscale(
+        SetPoolAutoscaleRequest(Tenant0, TenantDb, Pool, minNodes = Some(1), maxNodes = Some(2)),
+        None
+      )(f.scopeOf)
+      .unsafeRunSync()
+      .isRight shouldBe true
+    val out = f.call(
+      "scale_pool",
+      McpPrincipal.StaticKey,
+      "tenant"   -> Json.fromString(Tenant0),
+      "database" -> Json.fromString(TenantDb),
+      "pool"     -> Json.fromString(Pool),
+      "dual"     -> Json.fromInt(5)
+    )
+    out.swap.toOption.get should include("outside_band")
+  }
+
+  "suspend_pool / resume_pool" should "round-trip the suspended flag" in {
+    val f = new Fixture
+    f.call(
+      "suspend_pool",
+      adminPat(),
+      "database" -> Json.fromString(TenantDb),
+      "pool"     -> Json.fromString(Pool)
+    ).isRight shouldBe true
+    f.sup.get(Key).get.suspended shouldBe true
+    f.call(
+      "resume_pool",
+      adminPat(),
+      "database" -> Json.fromString(TenantDb),
+      "pool"     -> Json.fromString(Pool)
+    ).isRight shouldBe true
+    f.sup.get(Key).get.suspended shouldBe false
+  }
+
+  "kill_statement" should "404 a cross-tenant statement and report already-completed for unknown ids" in {
+    val f  = new Fixture
+    val id = f.registry.register("bob", "globex", "bi", "n1", "SELECT 1")
+    // Tenant-scoped admin PAT: the other tenant's statement is invisible (404, no leak).
+    val crossed = f.call("kill_statement", adminPat(), "id" -> Json.fromString(id))
+    crossed.swap.toOption.get should include("not_found")
+    // Unknown id: not an error (it may simply have finished) -- the handler's contract.
+    val unknown = f.call("kill_statement", adminPat(), "id" -> Json.fromString("nope"))
+    unknown.toOption.get.hcursor.get[String]("status").toOption shouldBe Some("already-completed")
+  }
+
+  "protect_tag" should "always protect and expose no unprotect surface" in {
+    val f = new Fixture
+    f.call(
+      "create_tag",
+      McpPrincipal.StaticKey,
+      "tenant"      -> Json.fromString(Tenant0),
+      "database"    -> Json.fromString(TenantDb),
+      "name"        -> Json.fromString("v1"),
+      "snapshot_id" -> Json.fromLong(3L)
+    ).isRight shouldBe true
+
+    val schema = f.tools.tools.find(_.name == "protect_tag").get.inputSchema.noSpaces
+    schema should not include "protected"
+
+    f.call(
+      "protect_tag",
+      McpPrincipal.StaticKey,
+      "tenant"   -> Json.fromString(Tenant0),
+      "database" -> Json.fromString(TenantDb),
+      "name"     -> Json.fromString("v1")
+    ).isRight shouldBe true
+    f.store.listSnapshotTags(Tenant0, TenantDb).find(_.name == "v1").get.isProtected shouldBe true
+
+    // There is no unprotect and no tag delete anywhere in the admin tier.
+    f.tools.tools.map(_.name) should not contain "delete_tag"
+  }
+
+  "audit_search" should "map filters through and admit the static key" in {
+    val f   = new Fixture
+    val out = f.call(
+      "audit_search",
+      McpPrincipal.StaticKey,
+      "actor" -> Json.fromString("alice"),
+      "q"     -> Json.fromString("pool"),
+      "limit" -> Json.fromInt(10)
+    )
+    withClue(out)(out.isRight shouldBe true)
+  }
+
+  "list_pools and get_pool_status" should "answer for the static key" in {
+    val f = new Fixture
+    f.call("list_pools", McpPrincipal.StaticKey).isRight shouldBe true
+    val status = f.call(
+      "get_pool_status",
+      McpPrincipal.StaticKey,
+      "tenant"   -> Json.fromString(Tenant0),
+      "database" -> Json.fromString(TenantDb),
+      "pool"     -> Json.fromString(Pool)
+    )
+    withClue(status)(status.isRight shouldBe true)
+  }

--- a/src/test/scala/ai/starlake/quack/mcp/McpDataToolsSpec.scala
+++ b/src/test/scala/ai/starlake/quack/mcp/McpDataToolsSpec.scala
@@ -1,0 +1,297 @@
+// src/test/scala/ai/starlake/quack/mcp/McpDataToolsSpec.scala
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.McpConfig
+import ai.starlake.quack.edge.adapter.TestArrow
+import ai.starlake.quack.edge.{RouterFailure, StatementHistoryStore}
+import ai.starlake.quack.edge.FlightSqlRouter
+import ai.starlake.quack.model.{PoolKey, TenantDbKind}
+import ai.starlake.quack.ondemand.PoolSupervisor
+import ai.starlake.quack.ondemand.api.{
+  CatalogColumnEntry,
+  CatalogDataFileEntry,
+  CatalogHandlers,
+  CatalogHistoryHandlers,
+  CatalogPreviewHandlers,
+  CatalogTableDetailResponse,
+  CatalogTableEntry,
+  ProfileHandlers,
+  TagHandlers,
+  TenantDbHandlers
+}
+import ai.starlake.quack.ondemand.auth.{PatPrincipal, SessionScope}
+import ai.starlake.quack.ondemand.catalog.DuckLakeCatalogReader
+import ai.starlake.quack.ondemand.state.{InMemoryControlPlaneStore, RbacUser}
+import ai.starlake.quack.ondemand.telemetry.NoopTelemetryStore
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.circe.{Json, JsonObject}
+import io.circe.parser.parse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Data-tier MCP tool contract: tenant inference, the run_sql row cap, error surfacing, and the
+  * describe_table composition. Built over the in-memory supervisor + TestArrow readers; no Postgres
+  * and no Flight wire.
+  */
+class McpDataToolsSpec extends AnyFlatSpec with Matchers:
+
+  private val Tenant   = "acme"
+  private val TenantDb = "acme_default"
+
+  private val patToken = "qod_pat_alice"
+
+  private def patFor(tenant: Option[String], admin: Boolean): McpPrincipal =
+    val scope = SessionScope(
+      superuser = tenant.isEmpty && admin,
+      manageableTenants = if admin then tenant.toSet else Set.empty
+    )
+    new McpPrincipal.Pat(
+      PatPrincipal(
+        user = RbacUser(
+          id = "u1",
+          tenant = tenant,
+          username = "alice",
+          role = if admin then "admin" else "user"
+        ),
+        patId = "pat-1",
+        scope = scope,
+        isAdmin = admin
+      ),
+      patToken
+    )
+
+  private val stubDetail = CatalogTableDetailResponse(
+    CatalogTableEntry("tpch1", "region", 5L, 1, None),
+    List(CatalogColumnEntry(0, "r_regionkey", "INTEGER", false, false)),
+    List(CatalogDataFileEntry("s3://lake/tpch1/region.parquet", 2048L, 5L, 1L))
+  )
+
+  private val stubReader: DuckLakeCatalogReader =
+    new DuckLakeCatalogReader(null):
+      override def getTable(schema: String, table: String, asOf: Option[Long] = None) =
+        if schema == "tpch1" && table == "region" then Some(stubDetail) else None
+      override def maxSnapshotId(): Option[Long] = Some(5L)
+
+  /** Executor answering every statement with a fresh N-row TestArrow reader. */
+  private def rangeExecutor(rows: Int): CatalogPreviewHandlers.PreviewExecutor =
+    (_, _, _, _) =>
+      IO.pure(
+        Right(
+          ai.starlake.quack.edge.QueryResult(
+            TestArrow.readerFor(s"SELECT * FROM range($rows) t(x)"),
+            () => (),
+            "n1",
+            5L
+          )
+        )
+      )
+
+  private def fixture(
+      executor: CatalogPreviewHandlers.PreviewExecutor,
+      cfg: McpConfig = McpConfig()
+  ): McpDataTools =
+    val store   = new InMemoryControlPlaneStore()
+    val backend = ai.starlake.quack.ondemand.runtime.testkit.StubQuackBackend.noop()
+    val tracker = new ai.starlake.quack.edge.adapter.NodeLoadTracker
+    val sup     = new PoolSupervisor(backend, tracker, store)
+    sup.createTenant(ai.starlake.quack.model.Tenant(Tenant)).unsafeRunSync()
+    sup.createTenantDb(Tenant, TenantDb, TenantDbKind.InMemory, Map.empty, "").unsafeRunSync()
+    sup
+      .createPool(
+        PoolKey(Tenant, TenantDb, "sales"),
+        ai.starlake.quack.model.RoleDistribution(0, 0, 1)
+      )
+      .unsafeRunSync()
+
+    val scopeOf: String => Option[SessionScope] =
+      t =>
+        if t == patToken then Some(SessionScope(superuser = false, manageableTenants = Set(Tenant)))
+        else None
+
+    val catalog = new CatalogHandlers((_, _) => stubReader, sup, store)
+    val history = new CatalogHistoryHandlers((_, _) => stubReader, sup)
+    val tags    = new TagHandlers(
+      sup,
+      store,
+      snapshotExists = (_, _, _) => true,
+      snapshotsExist = (_, _, ids) => ids
+    )
+    val tenantDbs = new TenantDbHandlers(sup, federatedStore = None, catalog = None)
+    val profile   = new ProfileHandlers(
+      _ => None,
+      NoopTelemetryStore,
+      new StatementHistoryStore(),
+      _ => None
+    )
+    new McpDataTools(cfg, executor, sup, catalog, history, tags, tenantDbs, profile, scopeOf)
+
+  private def call(
+      tools: McpDataTools,
+      name: String,
+      principal: McpPrincipal,
+      args: (String, Json)*
+  ): Either[String, Json] =
+    tools.tools
+      .find(_.name == name)
+      .getOrElse(fail(s"tool $name not defined"))
+      .run(principal, JsonObject(args*))
+      .unsafeRunSync()
+
+  // ------------------------------------------------------------------
+  // run_sql
+  // ------------------------------------------------------------------
+
+  "run_sql" should "return columns, rows and truncated=false under the cap" in {
+    val tools = fixture(rangeExecutor(3))
+    val out   = call(
+      tools,
+      "run_sql",
+      McpPrincipal.StaticKey,
+      "sql"      -> Json.fromString("SELECT * FROM t"),
+      "database" -> Json.fromString(TenantDb),
+      "tenant"   -> Json.fromString(Tenant)
+    )
+    val json = out.toOption.getOrElse(fail(s"expected Right, got $out"))
+    json.hcursor.downField("columns").as[List[Json]].toOption.get should have size 1
+    json.hcursor.downField("rows").as[List[Json]].toOption.get should have size 3
+    json.hcursor.get[Boolean]("truncated").toOption shouldBe Some(false)
+    json.hcursor.get[String]("nodeId").toOption shouldBe Some("n1")
+  }
+
+  it should "clamp max_rows to the server cap" in {
+    val tools = fixture(rangeExecutor(10), cfg = McpConfig(maxRows = 3))
+    val out   = call(
+      tools,
+      "run_sql",
+      McpPrincipal.StaticKey,
+      "sql"      -> Json.fromString("SELECT * FROM t"),
+      "database" -> Json.fromString(TenantDb),
+      "tenant"   -> Json.fromString(Tenant),
+      // Above the server cap on purpose: the arg can only lower the cap, never raise it.
+      "max_rows" -> Json.fromInt(100)
+    )
+    val json = out.toOption.getOrElse(fail(s"expected Right, got $out"))
+    json.hcursor.downField("rows").as[List[Json]].toOption.get should have size 3
+    json.hcursor.get[Boolean]("truncated").toOption shouldBe Some(true)
+  }
+
+  it should "surface an ACL denial with the validator's reason text" in {
+    val denied: CatalogPreviewHandlers.PreviewExecutor =
+      (_, _, _, _) => IO.pure(Left(RouterFailure.AccessDenied("missing RW grant on tpch1.region")))
+    val tools = fixture(denied)
+    val out   = call(
+      tools,
+      "run_sql",
+      McpPrincipal.StaticKey,
+      "sql"      -> Json.fromString("DELETE FROM region"),
+      "database" -> Json.fromString(TenantDb),
+      "tenant"   -> Json.fromString(Tenant)
+    )
+    out.isLeft shouldBe true
+    out.swap.toOption.get should include("missing RW grant on tpch1.region")
+  }
+
+  it should "translate a resuming-pool Unavailable into an agent-actionable retry message" in {
+    val resuming: CatalogPreviewHandlers.PreviewExecutor =
+      (_, _, _, _) => IO.pure(Left(RouterFailure.Unavailable("pool is resuming; no node yet")))
+    val tools = fixture(resuming)
+    val out   = call(
+      tools,
+      "run_sql",
+      McpPrincipal.StaticKey,
+      "sql"      -> Json.fromString("SELECT 1"),
+      "database" -> Json.fromString(TenantDb),
+      "tenant"   -> Json.fromString(Tenant)
+    )
+    out.swap.toOption.get should include("retry")
+  }
+
+  it should "translate a node-startup connect failure into a retry message" in {
+    val starting: CatalogPreviewHandlers.PreviewExecutor =
+      (_, _, _, _) =>
+        IO.pure(Left(RouterFailure.Internal("permanent failure: java.net.ConnectException")))
+    val tools = fixture(starting)
+    val out   = call(
+      tools,
+      "run_sql",
+      McpPrincipal.StaticKey,
+      "sql"      -> Json.fromString("SELECT 1"),
+      "database" -> Json.fromString(TenantDb),
+      "tenant"   -> Json.fromString(Tenant)
+    )
+    out.swap.toOption.get should include("retry")
+  }
+
+  // ------------------------------------------------------------------
+  // tenant inference
+  // ------------------------------------------------------------------
+
+  it should "infer the tenant from a tenant-scoped PAT" in {
+    val tools = fixture(rangeExecutor(1))
+    val out   = call(
+      tools,
+      "run_sql",
+      patFor(Some(Tenant), admin = true),
+      "sql"      -> Json.fromString("SELECT 1"),
+      "database" -> Json.fromString(TenantDb)
+    )
+    out.isRight shouldBe true
+  }
+
+  it should "refuse an explicit tenant argument that differs from the PAT's tenant" in {
+    val tools = fixture(rangeExecutor(1))
+    val out   = call(
+      tools,
+      "run_sql",
+      patFor(Some(Tenant), admin = true),
+      "sql"      -> Json.fromString("SELECT 1"),
+      "database" -> Json.fromString(TenantDb),
+      "tenant"   -> Json.fromString("globex")
+    )
+    out.swap.toOption.get should include(Tenant)
+  }
+
+  it should "require an explicit tenant for the static key, naming the argument" in {
+    val tools = fixture(rangeExecutor(1))
+    val out   = call(
+      tools,
+      "run_sql",
+      McpPrincipal.StaticKey,
+      "sql"      -> Json.fromString("SELECT 1"),
+      "database" -> Json.fromString(TenantDb)
+    )
+    out.swap.toOption.get should include("tenant")
+  }
+
+  // ------------------------------------------------------------------
+  // describe_table
+  // ------------------------------------------------------------------
+
+  "describe_table" should "compose catalog columns with a decoded sample" in {
+    val tools = fixture(rangeExecutor(2))
+    val out   = call(
+      tools,
+      "describe_table",
+      McpPrincipal.StaticKey,
+      "database" -> Json.fromString(TenantDb),
+      "schema"   -> Json.fromString("tpch1"),
+      "table"    -> Json.fromString("region"),
+      "tenant"   -> Json.fromString(Tenant)
+    )
+    val json = out.toOption.getOrElse(fail(s"expected Right, got $out"))
+    val cols = json.hcursor.downField("columns").as[List[Json]].toOption.get
+    cols.flatMap(_.hcursor.get[String]("name").toOption) should contain("r_regionkey")
+    json.hcursor.downField("sample").downField("rows").as[List[Json]].toOption.get should
+      have size 2
+  }
+
+  // ------------------------------------------------------------------
+  // my_usage
+  // ------------------------------------------------------------------
+
+  "my_usage" should "refuse the static key (no identity to scope by)" in {
+    val tools = fixture(rangeExecutor(1))
+    val out   = call(tools, "my_usage", McpPrincipal.StaticKey)
+    out.swap.toOption.get should include("PAT")
+  }

--- a/src/test/scala/ai/starlake/quack/mcp/McpEndToEndSpec.scala
+++ b/src/test/scala/ai/starlake/quack/mcp/McpEndToEndSpec.scala
@@ -1,0 +1,208 @@
+// src/test/scala/ai/starlake/quack/mcp/McpEndToEndSpec.scala
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.ondemand.auth.PatAuthenticator
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserGrant, UserStore}
+import ai.starlake.quack.security.{ManagerServerHarness, SecurityFixtures}
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.net.URI
+import java.net.http.{HttpRequest, HttpResponse}
+import java.nio.charset.StandardCharsets
+import scala.util.Try
+
+/** Full-wire MCP contract: real HTTP against the harness-booted manager with a Postgres PAT store,
+  * covering auth arms, tool tiering per principal, and the enabled=false unmount.
+  */
+class McpEndToEndSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll:
+
+  TestPostgres.dropStrayTestDatabases("qodmcpe2e")
+
+  private val dbName = s"qodmcpe2e_test_${System.nanoTime()}"
+
+  private var users: UserStore          = null
+  private var pats: PatStore            = null
+  private var patAuth: PatAuthenticator = null
+
+  override def beforeAll(): Unit =
+    if TestPostgres.reachable then
+      TestPostgres.psql("postgres", s"""CREATE DATABASE "$dbName"""")
+      val url = TestPostgres.dbUrl(dbName)
+      new LiquibaseRunner(url, TestPostgres.pgUser, TestPostgres.pgPass).run()
+      users = new UserStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      pats = new PatStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      patAuth = new PatAuthenticator(pats, users.userById, u => List(UserGrant(u.tenant, u.role)))
+      users.upsertUser(None, SecurityFixtures.RootUsername, SecurityFixtures.RootPassword, "admin")
+      users.upsertUser(
+        Some(SecurityFixtures.TenantId),
+        SecurityFixtures.AliceUsername,
+        SecurityFixtures.AlicePassword,
+        "admin"
+      )
+      users.upsertUser(
+        Some(SecurityFixtures.TenantId),
+        SecurityFixtures.BobUsername,
+        SecurityFixtures.BobPassword,
+        "user"
+      )
+
+  override def afterAll(): Unit =
+    if pats != null then pats.close()
+    if users != null then users.close()
+    Try(TestPostgres.dropDatabase(dbName))
+    ()
+
+  private def mintPat(tenant: Option[String], username: String): String =
+    val uid = users.userIdOf(tenant, username).getOrElse(fail(s"user $username missing"))
+    pats.mint(uid, s"mcp-$username", None)._2
+
+  private def withHarness(
+      staticApiKey: Option[String] = Some("static-key-1"),
+      mcpEnabled: Boolean = true
+  )(body: ManagerServerHarness.Harness => Unit): Unit =
+    TestPostgres.ensureReachable()
+    val fix = SecurityFixtures.freshStore()
+    val h   = ManagerServerHarness.boot(
+      fix.store,
+      staticApiKey = staticApiKey,
+      patStore = Some(pats),
+      patUserOf =
+        Some((tenant, username) => users.userIdOf(tenant, username).flatMap(users.userById)),
+      patAuth = Some(patAuth),
+      mcpEnabled = mcpEnabled
+    )
+    try body(h)
+    finally h.shutdown()
+
+  private def rpc(method: String, id: Int = 1, params: Json = Json.obj()): String =
+    Json
+      .obj(
+        "jsonrpc" -> Json.fromString("2.0"),
+        "id"      -> Json.fromInt(id),
+        "method"  -> Json.fromString(method),
+        "params"  -> params
+      )
+      .noSpaces
+
+  private def postMcp(
+      h: ManagerServerHarness.Harness,
+      body: String,
+      bearer: Option[String]
+  ): HttpResponse[String] =
+    val b = HttpRequest
+      .newBuilder(URI.create(s"${h.baseUrl}/mcp"))
+      .header("Content-Type", "application/json")
+      .timeout(java.time.Duration.ofSeconds(10))
+      .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+    bearer.foreach(t => b.header("Authorization", s"Bearer $t"))
+    h.httpClient.send(b.build(), HttpResponse.BodyHandlers.ofString())
+
+  private def toolNames(body: String): List[String] =
+    parse(body).toOption
+      .flatMap(_.hcursor.downField("result").downField("tools").as[List[Json]].toOption)
+      .getOrElse(Nil)
+      .flatMap(_.hcursor.get[String]("name").toOption)
+
+  // ------------------------------------------------------------------
+
+  "POST /mcp" should "answer initialize for an admin PAT" in withHarness() { h =>
+    val resp = postMcp(h, rpc("initialize"), Some(mintPat(None, SecurityFixtures.RootUsername)))
+    withClue(s"body: ${resp.body()}") {
+      resp.statusCode() shouldBe 200
+      parse(resp.body()).toOption.get.hcursor
+        .downField("result")
+        .downField("serverInfo")
+        .get[String]("name")
+        .toOption shouldBe Some("quack-on-demand")
+    }
+  }
+
+  it should "tier tools/list by principal" in withHarness() { h =>
+    val adminTools =
+      toolNames(
+        postMcp(
+          h,
+          rpc("tools/list"),
+          Some(mintPat(Some(SecurityFixtures.TenantId), SecurityFixtures.AliceUsername))
+        ).body()
+      )
+    adminTools should contain allOf ("run_sql", "list_databases", "scale_pool", "kill_statement")
+
+    val userTools =
+      toolNames(
+        postMcp(
+          h,
+          rpc("tools/list"),
+          Some(mintPat(Some(SecurityFixtures.TenantId), SecurityFixtures.BobUsername))
+        ).body()
+      )
+    userTools should contain("run_sql")
+    userTools should not contain "scale_pool"
+  }
+
+  it should "answer list_databases for a tenant-admin PAT with the seeded tenant-db" in
+    withHarness() { h =>
+      val alice  = mintPat(Some(SecurityFixtures.TenantId), SecurityFixtures.AliceUsername)
+      val params = Json.obj(
+        "name"      -> Json.fromString("list_databases"),
+        "arguments" -> Json.obj()
+      )
+      val resp = postMcp(h, rpc("tools/call", params = params), Some(alice))
+      withClue(s"body: ${resp.body()}") {
+        resp.statusCode() shouldBe 200
+        val result = parse(resp.body()).toOption.get.hcursor.downField("result")
+        result.get[Boolean]("isError").toOption shouldBe Some(false)
+        val text = result.downField("content").downN(0).get[String]("text").toOption.getOrElse("")
+        text should include(SecurityFixtures.TenantDbName)
+      }
+    }
+
+  it should "refuse scale_pool for a role=user PAT with -32602" in withHarness() { h =>
+    val bob    = mintPat(Some(SecurityFixtures.TenantId), SecurityFixtures.BobUsername)
+    val params = Json.obj(
+      "name"      -> Json.fromString("scale_pool"),
+      "arguments" -> Json.obj(
+        "database" -> Json.fromString(SecurityFixtures.TenantDbName),
+        "pool"     -> Json.fromString(SecurityFixtures.PoolName),
+        "dual"     -> Json.fromInt(2)
+      )
+    )
+    val resp = postMcp(h, rpc("tools/call", params = params), Some(bob))
+    withClue(s"body: ${resp.body()}") {
+      parse(resp.body()).toOption.get.hcursor
+        .downField("error")
+        .get[Int]("code")
+        .toOption shouldBe Some(-32602)
+    }
+  }
+
+  it should "401 a session JWT" in withHarness() { h =>
+    val session = h.mintToken(SecurityFixtures.RootUsername, SecurityFixtures.RootPassword)
+    postMcp(h, rpc("ping"), Some(session)).statusCode() shouldBe 401
+  }
+
+  it should "401 any non-PAT bearer when no static key is configured" in
+    withHarness(staticApiKey = None) { h =>
+      postMcp(h, rpc("ping"), Some("some-random-value")).statusCode() shouldBe 401
+      postMcp(h, rpc("ping"), None).statusCode() shouldBe 401
+    }
+
+  it should "405 a GET" in withHarness() { h =>
+    val req = HttpRequest
+      .newBuilder(URI.create(s"${h.baseUrl}/mcp"))
+      .timeout(java.time.Duration.ofSeconds(10))
+      .GET()
+      .build()
+    h.httpClient.send(req, HttpResponse.BodyHandlers.ofString()).statusCode() shouldBe 405
+  }
+
+  it should "404 when mcp is disabled" in withHarness(mcpEnabled = false) { h =>
+    val resp =
+      postMcp(h, rpc("ping"), Some(mintPat(None, SecurityFixtures.RootUsername)))
+    resp.statusCode() shouldBe 404
+  }

--- a/src/test/scala/ai/starlake/quack/mcp/McpProtocolSpec.scala
+++ b/src/test/scala/ai/starlake/quack/mcp/McpProtocolSpec.scala
@@ -1,0 +1,223 @@
+// src/test/scala/ai/starlake/quack/mcp/McpProtocolSpec.scala
+package ai.starlake.quack.mcp
+
+import ai.starlake.quack.McpConfig
+import ai.starlake.quack.ondemand.auth.{PatPrincipal, SessionScope}
+import ai.starlake.quack.ondemand.state.RbacUser
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.circe.{Json, JsonObject}
+import io.circe.parser.parse
+import org.http4s.{Method, Request, Response, Status, Uri}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Route-level contract of the MCP endpoint: auth arms, the JSON-RPC envelope, and tool tiering. No
+  * server boot, no Postgres: `resolvePat` is an injected lookup and the tools are fakes.
+  */
+class McpProtocolSpec extends AnyFlatSpec with Matchers:
+
+  private val AdminPat = "qod_pat_admin"
+  private val UserPat  = "qod_pat_user"
+
+  private def principal(role: String, admin: Boolean): PatPrincipal =
+    PatPrincipal(
+      user = RbacUser(id = "u1", tenant = Some("acme"), username = "alice", role = role),
+      patId = "pat-1",
+      scope = SessionScope(
+        superuser = false,
+        manageableTenants = if admin then Set("acme") else Set.empty
+      ),
+      isAdmin = admin
+    )
+
+  private val resolvePat: String => Option[PatPrincipal] =
+    case AdminPat => Some(principal("admin", admin = true))
+    case UserPat  => Some(principal("user", admin = false))
+    case _        => None
+
+  private val echoTool = McpToolDef(
+    name = "echo",
+    description = "echo the arguments back",
+    inputSchema = Json.obj("type" -> Json.fromString("object")),
+    adminOnly = false,
+    run = (_, args) => IO.pure(Right(Json.fromJsonObject(args)))
+  )
+
+  private val failTool = McpToolDef(
+    name = "always_fails",
+    description = "returns a tool-level error",
+    inputSchema = Json.obj("type" -> Json.fromString("object")),
+    adminOnly = false,
+    run = (_, _) => IO.pure(Left("the pool is waking from suspend; retry in a few seconds"))
+  )
+
+  private val adminTool = McpToolDef(
+    name = "scale_pool",
+    description = "admin only",
+    inputSchema = Json.obj("type" -> Json.fromString("object")),
+    adminOnly = true,
+    run = (_, _) => IO.pure(Right(Json.obj("scaled" -> Json.True)))
+  )
+
+  private def routes(staticKey: Option[String] = Some("sk")) =
+    new McpRoutes(
+      cfg = McpConfig(),
+      staticKey = staticKey,
+      resolvePat = resolvePat,
+      tools = List(echoTool, failTool, adminTool),
+      serverVersion = "test"
+    ).routes.orNotFound
+
+  private def post(
+      body: String,
+      bearer: Option[String],
+      staticKey: Option[String] = Some("sk")
+  ): Response[IO] =
+    val base = Request[IO](Method.POST, Uri.unsafeFromString("/mcp")).withEntity(body)
+    val req  = bearer.fold(base)(t =>
+      base.putHeaders(
+        org.http4s.Header.Raw(org.typelevel.ci.CIString("Authorization"), s"Bearer $t")
+      )
+    )
+    routes(staticKey).run(req).unsafeRunSync()
+
+  private def bodyJson(resp: Response[IO]): Json =
+    parse(new String(resp.body.compile.toVector.unsafeRunSync().toArray)).toOption
+      .getOrElse(Json.Null)
+
+  private def rpc(method: String, id: Int = 1, params: Json = Json.obj()): String =
+    Json
+      .obj(
+        "jsonrpc" -> Json.fromString("2.0"),
+        "id"      -> Json.fromInt(id),
+        "method"  -> Json.fromString(method),
+        "params"  -> params
+      )
+      .noSpaces
+
+  private def toolNames(resp: Response[IO]): List[String] =
+    bodyJson(resp).hcursor
+      .downField("result")
+      .downField("tools")
+      .as[List[Json]]
+      .getOrElse(Nil)
+      .flatMap(_.hcursor.get[String]("name").toOption)
+
+  // ------------------------------------------------------------------
+  // auth arms
+  // ------------------------------------------------------------------
+
+  "POST /mcp" should "401 with no Authorization header" in {
+    post(rpc("ping"), bearer = None).status shouldBe Status.Unauthorized
+  }
+
+  it should "401 a session-JWT-looking bearer" in {
+    post(rpc("ping"), bearer = Some("eyJhbGciOiJIUzI1NiJ9.e30.sig")).status shouldBe
+      Status.Unauthorized
+  }
+
+  it should "401 an empty bearer even with no static key configured" in {
+    post(rpc("ping"), bearer = Some(""), staticKey = None).status shouldBe Status.Unauthorized
+  }
+
+  it should "401 the would-be static key when none is configured" in {
+    post(rpc("ping"), bearer = Some("sk"), staticKey = None).status shouldBe Status.Unauthorized
+  }
+
+  it should "admit the static key as an admin principal" in {
+    val resp = post(rpc("tools/list"), bearer = Some("sk"))
+    resp.status shouldBe Status.Ok
+    toolNames(resp) should contain allOf ("echo", "always_fails", "scale_pool")
+  }
+
+  // ------------------------------------------------------------------
+  // protocol envelope
+  // ------------------------------------------------------------------
+
+  it should "answer initialize with serverInfo and the tools capability" in {
+    val resp = post(rpc("initialize"), bearer = Some(AdminPat))
+    resp.status shouldBe Status.Ok
+    val result = bodyJson(resp).hcursor.downField("result")
+    result.get[String]("protocolVersion").toOption shouldBe Some("2025-06-18")
+    result.downField("serverInfo").get[String]("name").toOption shouldBe Some("quack-on-demand")
+    result.downField("capabilities").downField("tools").succeeded shouldBe true
+  }
+
+  it should "accept notifications/initialized with 202 and no body" in {
+    val n = Json
+      .obj(
+        "jsonrpc" -> Json.fromString("2.0"),
+        "method"  -> Json.fromString("notifications/initialized")
+      )
+      .noSpaces
+    val resp = post(n, bearer = Some(AdminPat))
+    resp.status shouldBe Status.Accepted
+  }
+
+  it should "answer ping with an empty result" in {
+    val resp = post(rpc("ping"), bearer = Some(UserPat))
+    bodyJson(resp).hcursor.downField("result").focus shouldBe Some(Json.obj())
+  }
+
+  it should "answer an unknown method with -32601" in {
+    val resp = post(rpc("resources/list"), bearer = Some(AdminPat))
+    bodyJson(resp).hcursor.downField("error").get[Int]("code").toOption shouldBe Some(-32601)
+  }
+
+  it should "answer malformed JSON with -32700 and a null id" in {
+    val resp = post("{not json", bearer = Some(AdminPat))
+    val c    = bodyJson(resp).hcursor
+    c.downField("error").get[Int]("code").toOption shouldBe Some(-32700)
+    c.downField("id").focus shouldBe Some(Json.Null)
+  }
+
+  it should "405 a GET" in {
+    val req = Request[IO](Method.GET, Uri.unsafeFromString("/mcp"))
+    routes().run(req).unsafeRunSync().status shouldBe Status.MethodNotAllowed
+  }
+
+  // ------------------------------------------------------------------
+  // tool tiering
+  // ------------------------------------------------------------------
+
+  "tools/list" should "show both tiers to an admin PAT and only the data tier to a user PAT" in {
+    toolNames(post(rpc("tools/list"), bearer = Some(AdminPat))) should
+      contain allOf ("echo", "always_fails", "scale_pool")
+    val userTools = toolNames(post(rpc("tools/list"), bearer = Some(UserPat)))
+    userTools should contain allOf ("echo", "always_fails")
+    userTools should not contain "scale_pool"
+  }
+
+  "tools/call" should "refuse an admin tool for a user PAT with -32602" in {
+    val params = Json.obj("name" -> Json.fromString("scale_pool"), "arguments" -> Json.obj())
+    val resp   = post(rpc("tools/call", params = params), bearer = Some(UserPat))
+    bodyJson(resp).hcursor.downField("error").get[Int]("code").toOption shouldBe Some(-32602)
+  }
+
+  it should "refuse an unknown tool with -32602" in {
+    val params = Json.obj("name" -> Json.fromString("nope"), "arguments" -> Json.obj())
+    val resp   = post(rpc("tools/call", params = params), bearer = Some(AdminPat))
+    bodyJson(resp).hcursor.downField("error").get[Int]("code").toOption shouldBe Some(-32602)
+  }
+
+  it should "run a tool and wrap Right as non-error text content" in {
+    val params = Json.obj(
+      "name"      -> Json.fromString("echo"),
+      "arguments" -> Json.obj("x" -> Json.fromInt(7))
+    )
+    val resp   = post(rpc("tools/call", params = params), bearer = Some(UserPat))
+    val result = bodyJson(resp).hcursor.downField("result")
+    result.get[Boolean]("isError").toOption shouldBe Some(false)
+    val text = result.downField("content").downN(0).get[String]("text").toOption.getOrElse("")
+    parse(text).toOption.flatMap(_.hcursor.get[Int]("x").toOption) shouldBe Some(7)
+  }
+
+  it should "wrap Left as isError text content" in {
+    val params = Json.obj("name" -> Json.fromString("always_fails"), "arguments" -> Json.obj())
+    val resp   = post(rpc("tools/call", params = params), bearer = Some(UserPat))
+    val result = bodyJson(resp).hcursor.downField("result")
+    result.get[Boolean]("isError").toOption shouldBe Some(true)
+    result.downField("content").downN(0).get[String]("text").toOption.getOrElse("") should
+      include("retry in a few seconds")
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/api/ProfileHandlersSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/api/ProfileHandlersSpec.scala
@@ -83,7 +83,7 @@ class ProfileHandlersSpec extends AnyFlatSpec with Matchers:
       telemetry: TelemetryStore = new StubTelemetry(Nil),
       history: StatementHistoryStore = new StatementHistoryStore()
   ): ProfileHandlers =
-    new ProfileHandlers(tokens, telemetry, history, tenantById, () => Now)
+    new ProfileHandlers(tokens.get, telemetry, history, tenantById, () => Now)
 
   private def sessionFor(
       tokens: SessionTokenStore,

--- a/src/test/scala/ai/starlake/quack/ondemand/auth/PatAuthenticatorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/auth/PatAuthenticatorSpec.scala
@@ -67,6 +67,20 @@ class PatAuthenticatorSpec extends AnyFlatSpec with Matchers:
       principal.isAdmin shouldBe true
   }
 
+  it should "demote a tenant-less NON-admin row to a profile-only principal" in withFreshDb {
+    (_, users, pats) =>
+      // A PAT authenticates as its owning user, so it may never outrank that user's own login
+      // session: `AuthHandlers.mintSessionFor` refuses this row `admin_required`, and the
+      // tenant-less-but-not-admin shape must not buy a superuser scope here either.
+      val (_, token) = seed(users, pats, None, "ghost", "user")
+      val auth       = authOf(users, pats)
+      val principal  = auth.resolve(token).getOrElse(fail("PAT did not resolve"))
+      principal.scope.superuser shouldBe false
+      principal.scope.manageableTenants shouldBe empty
+      principal.isAdmin shouldBe false
+      auth.sessionOf(token).map(_.profile.role) shouldBe Some("user")
+  }
+
   it should "scope a tenant-admin PAT to the tenants it administers" in withFreshDb {
     (_, users, pats) =>
       val (_, token) = seed(users, pats, Some("t-acme"), "alice", "admin")

--- a/src/test/scala/ai/starlake/quack/ondemand/auth/PatAuthenticatorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/auth/PatAuthenticatorSpec.scala
@@ -1,0 +1,148 @@
+package ai.starlake.quack.ondemand.auth
+
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserStore}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import scala.util.Try
+
+/** Principal resolution for personal access tokens: [[PatAuthenticator]] turns a raw bearer token
+  * into the same `(SessionScope, AuthenticatedProfile)` shape a password login mints, so the
+  * management plane can consume a PAT wherever it consumes a session JWT.
+  */
+class PatAuthenticatorSpec extends AnyFlatSpec with Matchers:
+
+  TestPostgres.dropStrayTestDatabases("qodpau")
+
+  private def withFreshDb(test: (String, UserStore, PatStore) => Unit): Unit =
+    TestPostgres.ensureReachable()
+    val dbName = s"qodpau_test_${System.nanoTime()}"
+    TestPostgres.psql("postgres", s"""CREATE DATABASE "$dbName"""")
+    try
+      val url = TestPostgres.dbUrl(dbName)
+      new LiquibaseRunner(url, TestPostgres.pgUser, TestPostgres.pgPass).run()
+      val users = new UserStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      val pats  = new PatStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      try test(dbName, users, pats)
+      finally
+        pats.close()
+        users.close()
+    finally Try(TestPostgres.dropDatabase(dbName))
+
+  /** The real store and the real row lookup; `grantsFor` uses the by-identity lookup `AuthHandlers`
+    * feeds `mintSessionFor` on the OIDC path. None of the cases below has a same-username row in a
+    * second tenant, so they hold identically under a row-only `grantsFor` (the DB-login shape) --
+    * the wiring choice stays open for the task that wires Main.
+    */
+  private def authOf(users: UserStore, pats: PatStore): PatAuthenticator =
+    new PatAuthenticator(
+      pats,
+      id => users.userById(id),
+      u => users.grantsForIdentity(u.username, u.email)
+    )
+
+  private def seed(
+      users: UserStore,
+      pats: PatStore,
+      tenant: Option[String],
+      username: String,
+      role: String,
+      expiresAt: Option[Instant] = None
+  ): (String, String) =
+    users.upsertUser(tenant, username, "pw", role)
+    val uid      = users.userIdOf(tenant, username).get
+    val (_, tok) = pats.mint(uid, "claude-code", expiresAt)
+    (uid, tok)
+
+  "resolve" should "give a tenant-less admin PAT a superuser scope" in withFreshDb {
+    (_, users, pats) =>
+      val (uid, token) = seed(users, pats, None, "root", "admin")
+      val principal    = authOf(users, pats).resolve(token).getOrElse(fail("PAT did not resolve"))
+      principal.user.id shouldBe uid
+      principal.patId should startWith("pat-")
+      principal.scope.superuser shouldBe true
+      principal.scope.manageableTenants shouldBe empty
+      principal.isAdmin shouldBe true
+  }
+
+  it should "scope a tenant-admin PAT to the tenants it administers" in withFreshDb {
+    (_, users, pats) =>
+      val (_, token) = seed(users, pats, Some("t-acme"), "alice", "admin")
+      val auth       = authOf(users, pats)
+      val principal  = auth.resolve(token).getOrElse(fail("PAT did not resolve"))
+      principal.scope.superuser shouldBe false
+      principal.scope.manageableTenants shouldBe Set("t-acme")
+      principal.isAdmin shouldBe true
+      auth.scopeOf(token) shouldBe Some(principal.scope)
+      auth.isAdmin(token) shouldBe true
+  }
+
+  it should "resolve a regular tenant user as a non-admin principal" in withFreshDb {
+    (_, users, pats) =>
+      val (_, token) = seed(users, pats, Some("t-acme"), "bob", "user")
+      val auth       = authOf(users, pats)
+      val principal  = auth.resolve(token).getOrElse(fail("PAT did not resolve"))
+      principal.scope.superuser shouldBe false
+      principal.scope.manageableTenants shouldBe empty
+      principal.isAdmin shouldBe false
+      auth.isAdmin(token) shouldBe false
+  }
+
+  it should "refuse a disabled user's token" in withFreshDb { (dbName, users, pats) =>
+    val (uid, token) = seed(users, pats, Some("t-acme"), "carol", "admin")
+    TestPostgres.psql(dbName, s"UPDATE qodstate_user SET enabled = false WHERE id = '$uid'")
+    val auth = authOf(users, pats)
+    auth.resolve(token) shouldBe None
+    auth.scopeOf(token) shouldBe None
+    auth.isAdmin(token) shouldBe false
+    auth.sessionOf(token) shouldBe None
+  }
+
+  it should "refuse a revoked token and an expired token" in withFreshDb { (_, users, pats) =>
+    users.upsertUser(None, "root", "pw", "admin")
+    val uid          = users.userIdOf(None, "root").get
+    val (rec, live)  = pats.mint(uid, "revoked-soon", None)
+    val (_, expired) = pats.mint(uid, "expired", Some(Instant.now().minusSeconds(60)))
+    val auth         = authOf(users, pats)
+    auth.resolve(live) should not be empty
+    pats.revoke(uid, rec.id) shouldBe true
+    auth.resolve(live) shouldBe None
+    auth.resolve(expired) shouldBe None
+  }
+
+  it should "refuse a session-JWT-shaped value without consulting the store" in withFreshDb {
+    (_, users, pats) =>
+      val (_, token) = seed(users, pats, None, "root", "admin")
+      val auth       = authOf(users, pats)
+      // Closing the pool turns any store call into a thrown SQLException, so a plain `None` here
+      // proves the prefix guard short-circuited before the lookup, while the prefixed token below
+      // proves the store WOULD have been consulted.
+      pats.close()
+      auth.resolve("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.sig") shouldBe None
+      auth.isAdmin("") shouldBe false
+      an[Exception] should be thrownBy auth.resolve(token)
+  }
+
+  "sessionOf" should "mint a pat-authenticated session with the demoted role" in withFreshDb {
+    (_, users, pats) =>
+      val (_, adminToken) = seed(users, pats, Some("t-acme"), "alice", "admin")
+      val (_, userToken)  = seed(users, pats, Some("t-acme"), "bob", "user")
+      val auth            = authOf(users, pats)
+
+      val adminSession = auth.sessionOf(adminToken).getOrElse(fail("admin PAT did not resolve"))
+      adminSession.profile.username shouldBe "alice"
+      adminSession.profile.role shouldBe "admin"
+      adminSession.profile.authMethod shouldBe "pat"
+      adminSession.profile.tenant shouldBe Some("t-acme")
+      adminSession.profile.groups shouldBe empty
+      adminSession.profile.claims shouldBe empty
+      adminSession.scope shouldBe SessionScope(superuser = false, Set("t-acme"))
+      adminSession.createdAt.isBefore(Instant.now().plusSeconds(5)) shouldBe true
+
+      val userSession = auth.sessionOf(userToken).getOrElse(fail("user PAT did not resolve"))
+      userSession.profile.role shouldBe "user"
+      userSession.profile.authMethod shouldBe "pat"
+      userSession.scope.manageableTenants shouldBe empty
+  }

--- a/src/test/scala/ai/starlake/quack/ondemand/auth/PatAuthenticatorSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/auth/PatAuthenticatorSpec.scala
@@ -1,7 +1,7 @@
 package ai.starlake.quack.ondemand.auth
 
 import ai.starlake.quack.ondemand.state.testkit.TestPostgres
-import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserStore}
+import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserGrant, UserStore}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -31,16 +31,16 @@ class PatAuthenticatorSpec extends AnyFlatSpec with Matchers:
         users.close()
     finally Try(TestPostgres.dropDatabase(dbName))
 
-  /** The real store and the real row lookup; `grantsFor` uses the by-identity lookup `AuthHandlers`
-    * feeds `mintSessionFor` on the OIDC path. None of the cases below has a same-username row in a
-    * second tenant, so they hold identically under a row-only `grantsFor` (the DB-login shape) --
-    * the wiring choice stays open for the task that wires Main.
+  /** The real store, the real row lookup, and the row-only `grantsFor` the class documents as the
+    * required wiring (`mintSessionFor`'s `Db`-mode grant list). Deliberately NOT
+    * `UserStore.grantsForIdentity`: that one matches by username across tenants, and usernames are
+    * unique only per tenant, so it would let a PAT inherit a same-named foreign admin's tenants.
     */
   private def authOf(users: UserStore, pats: PatStore): PatAuthenticator =
     new PatAuthenticator(
       pats,
       id => users.userById(id),
-      u => users.grantsForIdentity(u.username, u.email)
+      u => List(UserGrant(u.tenant, u.role))
     )
 
   private def seed(
@@ -126,16 +126,25 @@ class PatAuthenticatorSpec extends AnyFlatSpec with Matchers:
     auth.resolve(expired) shouldBe None
   }
 
-  it should "refuse a session-JWT-shaped value without consulting the store" in withFreshDb {
+  it should "refuse a session-JWT-shaped value without any lookup" in withFreshDb {
     (_, users, pats) =>
       val (_, token) = seed(users, pats, None, "root", "admin")
-      val auth       = authOf(users, pats)
-      // Closing the pool turns any store call into a thrown SQLException, so a plain `None` here
-      // proves the prefix guard short-circuited before the lookup, while the prefixed token below
-      // proves the store WOULD have been consulted.
+      val lookups    = new java.util.concurrent.atomic.AtomicInteger(0)
+      val auth       = new PatAuthenticator(
+        pats,
+        id => { lookups.incrementAndGet(); users.userById(id) },
+        u => List(UserGrant(u.tenant, u.role))
+      )
+      // What is pinned is the end-to-end property: a non-PAT value costs no user lookup (the
+      // counter stays at zero) and no connection (the pool is closed, so any query would throw --
+      // the real token below shows the store IS otherwise on the path). It does NOT pin WHICH
+      // layer short-circuits: PatStore.verify carries the same prefix guard, so dropping the one
+      // in PatAuthenticator would keep this green. `PatStore` is final, so a stub that counts
+      // verify calls is not available to separate them.
       pats.close()
       auth.resolve("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.sig") shouldBe None
       auth.isAdmin("") shouldBe false
+      lookups.get() shouldBe 0
       an[Exception] should be thrownBy auth.resolve(token)
   }
 
@@ -144,6 +153,7 @@ class PatAuthenticatorSpec extends AnyFlatSpec with Matchers:
       val (_, adminToken) = seed(users, pats, Some("t-acme"), "alice", "admin")
       val (_, userToken)  = seed(users, pats, Some("t-acme"), "bob", "user")
       val auth            = authOf(users, pats)
+      val before          = Instant.now()
 
       val adminSession = auth.sessionOf(adminToken).getOrElse(fail("admin PAT did not resolve"))
       adminSession.profile.username shouldBe "alice"
@@ -153,7 +163,9 @@ class PatAuthenticatorSpec extends AnyFlatSpec with Matchers:
       adminSession.profile.groups shouldBe empty
       adminSession.profile.claims shouldBe empty
       adminSession.scope shouldBe SessionScope(superuser = false, Set("t-acme"))
-      adminSession.createdAt.isBefore(Instant.now().plusSeconds(5)) shouldBe true
+      // Minted now, not carried over from the token's own createdAt: bounded on BOTH sides.
+      adminSession.createdAt.isBefore(before.minusSeconds(1)) shouldBe false
+      adminSession.createdAt.isAfter(Instant.now().plusSeconds(5)) shouldBe false
 
       val userSession = auth.sessionOf(userToken).getOrElse(fail("user PAT did not resolve"))
       userSession.profile.role shouldBe "user"

--- a/src/test/scala/ai/starlake/quack/ondemand/state/LiquibaseRunnerSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/LiquibaseRunnerSpec.scala
@@ -59,6 +59,7 @@ class LiquibaseRunnerSpec extends AnyFlatSpec with Matchers:
           "qodstate_maintenance_run",
           "qodstate_managed_prefix",
           "qodstate_node",
+          "qodstate_pat",
           "qodstate_pool",
           "qodstate_pool_load",
           "qodstate_pool_permission",
@@ -106,8 +107,9 @@ class LiquibaseRunnerSpec extends AnyFlatSpec with Matchers:
       // 1 snapshot-tag table (snapshot_tag, Liquibase 0020) +
       // 2 maintenance tables (policy + run, Liquibase 0021) +
       // 1 autoscale-demand table (pool_load, Liquibase 0026) +
-      // 1 tombstone-registry table (managed_prefix, Liquibase 0027).
+      // 1 tombstone-registry table (managed_prefix, Liquibase 0027) +
+      // 1 personal-access-token table (pat, Liquibase 0032).
       // qodstate_tenant_identity is gone -- auth provider is a tenant attribute now.
-      rs.getInt(1) shouldBe 26
+      rs.getInt(1) shouldBe 27
     finally c.close()
   }

--- a/src/test/scala/ai/starlake/quack/ondemand/state/PatStoreSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/PatStoreSpec.scala
@@ -1,0 +1,93 @@
+package ai.starlake.quack.ondemand.state
+
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.DriverManager
+import java.time.Instant
+import scala.util.Try
+
+/** Persistence semantics of `qodstate_pat` (changelog 0032) through [[PatStore]]: mint stores only
+  * the SHA-256 hash of the token, verify enforces expiry/revocation and stamps `last_used_at`, and
+  * revoke is scoped to the owning user.
+  */
+class PatStoreSpec extends AnyFlatSpec with Matchers:
+
+  TestPostgres.dropStrayTestDatabases("qodpat")
+
+  private def withFreshDb(test: (UserStore, PatStore) => Unit): Unit =
+    TestPostgres.ensureReachable()
+    val dbName = s"qodpat_test_${System.nanoTime()}"
+    TestPostgres.psql("postgres", s"""CREATE DATABASE "$dbName"""")
+    try
+      val url = TestPostgres.dbUrl(dbName)
+      new LiquibaseRunner(url, TestPostgres.pgUser, TestPostgres.pgPass).run()
+      val users = new UserStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      val pats  = new PatStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      try test(users, pats)
+      finally
+        pats.close()
+        users.close()
+    finally Try(TestPostgres.dropDatabase(dbName))
+
+  private def seedUser(users: UserStore): String =
+    users.upsertUser(None, "alice", "pw", "admin")
+    users.userIdOf(None, "alice").get
+
+  /** Row count for a raw SQL predicate against the fresh test db, via a direct JDBC connection
+    * (TestPostgres.psql returns Unit, not the query output, so it cannot back an assertion here).
+    */
+  private def countWhere(dbName: String, whereSql: String): Int =
+    val c = DriverManager.getConnection(
+      TestPostgres.dbUrl(dbName),
+      TestPostgres.pgUser,
+      TestPostgres.pgPass
+    )
+    try
+      val rs =
+        c.createStatement().executeQuery(s"SELECT count(*) FROM qodstate_pat WHERE $whereSql")
+      rs.next()
+      rs.getInt(1)
+    finally c.close()
+
+  "mint + verify" should "round-trip and never store the raw token" in withFreshDb {
+    (users, pats) =>
+      val uid             = seedUser(users)
+      val (record, token) = pats.mint(uid, "claude-code", None)
+      token should startWith(PatStore.TokenPrefix)
+      record.userId shouldBe uid
+      pats.verify(token).map(_.id) shouldBe Some(record.id)
+      // raw token is not in the table
+      countWhere(users.dbName, s"token_hash = '$token'") shouldBe 0
+  }
+
+  it should "stamp last_used_at on verify" in withFreshDb { (users, pats) =>
+    val uid        = seedUser(users)
+    val (_, token) = pats.mint(uid, "t", None)
+    pats.verify(token)
+    pats.list(uid).head.lastUsedAt should not be empty
+  }
+
+  "verify" should "reject an expired token" in withFreshDb { (users, pats) =>
+    val uid        = seedUser(users)
+    val (_, token) = pats.mint(uid, "old", Some(Instant.now().minusSeconds(60)))
+    pats.verify(token) shouldBe None
+  }
+
+  it should "reject a revoked token and reject garbage" in withFreshDb { (users, pats) =>
+    val uid             = seedUser(users)
+    val (record, token) = pats.mint(uid, "t", None)
+    pats.revoke(uid, record.id) shouldBe true
+    pats.verify(token) shouldBe None
+    pats.verify("qod_pat_notarealtoken") shouldBe None
+    pats.verify("") shouldBe None
+  }
+
+  "revoke" should "refuse another user's token" in withFreshDb { (users, pats) =>
+    val uid = seedUser(users)
+    users.upsertUser(None, "bob", "pw", "admin")
+    val bobId       = users.userIdOf(None, "bob").get
+    val (record, _) = pats.mint(uid, "t", None)
+    pats.revoke(bobId, record.id) shouldBe false
+  }

--- a/src/test/scala/ai/starlake/quack/security/CatalogAsOfTagSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/CatalogAsOfTagSpec.scala
@@ -56,54 +56,65 @@ class CatalogAsOfTagSpec extends AnyFlatSpec with Matchers with SecurityHttpHelp
     fix.store.createSnapshotTag(
       SnapshotTag("stag-dead", Tenant, TenantDb, "dead", VacuumedSnapshot)
     )
-    val h = ManagerServerHarness.boot(fix.store, catalogReader = Some((_, _) => stub.reader))
+    val h = ManagerServerHarness.boot(
+      fix.store,
+      staticApiKey = Some(Key),
+      catalogReader = Some((_, _) => stub.reader)
+    )
     try test(h, stub)
     finally h.shutdown()
+
+  // This spec pins selector RESOLUTION, not authz, so every call rides the
+  // static key; the guard itself is pinned by CatalogAuthzSpec.
+  private val Key = "catalog-asoftag-key"
 
   private def tableUrl(h: ManagerServerHarness.Harness, params: String): String =
     s"${h.baseUrl}/api/catalog/tenant/$Tenant/database/$TenantDb/schemas/tpch1/tables/region$params"
 
+  private def fetch(h: ManagerServerHarness.Harness, params: String) =
+    get(h.httpClient, tableUrl(h, params), apiKey = Some(Key))
+
   "the catalog table endpoint" should "resolve asOfTag to the tag's snapshot id" in withHarness {
     (h, stub) =>
-      val resp = get(h.httpClient, tableUrl(h, "?asOfTag=v1"))
+      val resp = fetch(h, "?asOfTag=v1")
       withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 200)
       stub.seenAsOf shouldBe Some(Some(LiveSnapshot))
   }
 
   it should "404 an unknown tag without touching the reader" in withHarness { (h, stub) =>
-    val resp = get(h.httpClient, tableUrl(h, "?asOfTag=nope"))
+    val resp = fetch(h, "?asOfTag=nope")
     withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 404)
     resp.body() should include("tag 'nope' not found")
     stub.seenAsOf shouldBe None
   }
 
   it should "400 when both asOf and asOfTag are supplied" in withHarness { (h, stub) =>
-    val resp = get(h.httpClient, tableUrl(h, s"?asOf=$LiveSnapshot&asOfTag=v1"))
+    val resp = fetch(h, s"?asOf=$LiveSnapshot&asOfTag=v1")
     withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 400)
     stub.seenAsOf shouldBe None
   }
 
   it should "return 410 a dangling tag (vacuumed snapshot)" in withHarness { (h, stub) =>
-    val resp = get(h.httpClient, tableUrl(h, "?asOfTag=dead"))
+    val resp = fetch(h, "?asOfTag=dead")
     withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 410)
     resp.body() should include("snapshot_expired")
   }
 
   it should "still read latest when neither param is supplied" in withHarness { (h, stub) =>
-    val resp = get(h.httpClient, tableUrl(h, ""))
+    val resp = fetch(h, "")
     withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 200)
     stub.seenAsOf shouldBe Some(None)
   }
 
   it should "keep the numeric asOf path intact" in withHarness { (h, stub) =>
-    val resp = get(h.httpClient, tableUrl(h, s"?asOf=$LiveSnapshot"))
+    val resp = fetch(h, s"?asOf=$LiveSnapshot")
     withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 200)
     stub.seenAsOf shouldBe Some(Some(LiveSnapshot))
   }
 
   it should "400 invalid_selector on a malformed asOfTs without touching the reader" in withHarness {
     (h, stub) =>
-      val resp = get(h.httpClient, tableUrl(h, "?asOfTs=not-a-timestamp"))
+      val resp = fetch(h, "?asOfTs=not-a-timestamp")
       withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 400)
       resp.body() should include("invalid_selector")
       resp.body() should include("asOfTs must be ISO-8601")
@@ -112,7 +123,7 @@ class CatalogAsOfTagSpec extends AnyFlatSpec with Matchers with SecurityHttpHelp
 
   it should "resolve asOfTs and return resolvedSnapshot in response" in withHarness { (h, stub) =>
     val ts   = "2026-01-01T00:00:00Z"
-    val resp = get(h.httpClient, tableUrl(h, s"?asOfTs=$ts"))
+    val resp = fetch(h, s"?asOfTs=$ts")
     withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 200)
     resp.body() should include("\"resolvedSnapshot\"")
     stub.seenAsOf shouldBe Some(Some(LiveSnapshot))
@@ -120,7 +131,7 @@ class CatalogAsOfTagSpec extends AnyFlatSpec with Matchers with SecurityHttpHelp
 
   it should "return 410 snapshot_expired when asOf points to a vacuumed snapshot" in withHarness {
     (h, stub) =>
-      val resp = get(h.httpClient, tableUrl(h, s"?asOf=$VacuumedSnapshot"))
+      val resp = fetch(h, s"?asOf=$VacuumedSnapshot")
       withClue(s"body: ${resp.body()}")(resp.statusCode() shouldBe 410)
       resp.body() should include("snapshot_expired")
   }

--- a/src/test/scala/ai/starlake/quack/security/CatalogAuthzSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/CatalogAuthzSpec.scala
@@ -16,7 +16,8 @@ import java.net.http.HttpResponse
   * [[ai.starlake.quack.ondemand.api.TagEndpoints]]: `apiKeyGuard` at the perimeter plus the
   * handler-level TenantScopeCheck gate. This spec pins: credential-less 401 (static key set),
   * cross-tenant 403 tenant_forbidden, superuser pass-through, 404 on an unknown tenant (no
-  * existence leak), listTenantDbs scope gating, and the open-mode dev path staying zero-config.
+  * existence leak), listTenantDbs scope gating, and the keyless 401 with no static key configured
+  * (the former open mode is gone).
   */
 class CatalogAuthzSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers:
 
@@ -142,18 +143,17 @@ class CatalogAuthzSpec extends AnyFlatSpec with Matchers with SecurityHttpHelper
     finally h.shutdown()
   }
 
-  it should "keep the zero-config dev path: open mode (no static key) admits a same-tenant read" in {
-    // UI path regression: no static key, no cookie, no token. apiKeyGuard is
-    // open and TenantScopeCheck admits key-less callers, so the catalog
-    // browser keeps working on a dev laptop without any configuration.
+  it should "refuse a credential-less read even with no static key configured (open mode is gone)" in {
+    // The former zero-config open mode admitted this keyless read; the strict
+    // posture answers 401 and the dev path is a login (or QOD_API_KEY).
     val (h, _) = bootWithTwoTenants()
     try
       val resp = get(
         h.httpClient,
         schemasUrl(h, SecurityFixtures.TenantId, SecurityFixtures.TenantDbName)
       )
-      withClue(s"open-mode credential-less GET schemas body: ${resp.body()}") {
-        resp.statusCode() shouldBe 200
+      withClue(s"credential-less GET schemas body: ${resp.body()}") {
+        resp.statusCode() shouldBe 401
       }
     finally h.shutdown()
   }
@@ -162,7 +162,7 @@ class CatalogAuthzSpec extends AnyFlatSpec with Matchers with SecurityHttpHelper
     val (h, _) = bootWithTwoTenants()
     try
       val token = h.mintToken(SecurityFixtures.RootUsername, SecurityFixtures.RootPassword)
-      val resp = get(
+      val resp  = get(
         h.httpClient,
         s"${h.baseUrl}/api/catalog/tenant/${SecurityFixtures.TenantId}/database/${SecurityFixtures.TenantDbName}/snapshots?table=tpch1.region",
         apiKey = Some(token)

--- a/src/test/scala/ai/starlake/quack/security/ManagerRestSecuritySpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/ManagerRestSecuritySpec.scala
@@ -21,12 +21,48 @@ class ManagerRestSecuritySpec extends AnyFlatSpec with Matchers with SecurityHtt
   // A. apiKeyGuard modes
   // ------------------------------------------------------------------
 
-  "apiKeyGuard" should "allow GET /api/tenants with no key when staticApiKey is None (open mode)" in {
+  "apiKeyGuard" should "refuse an unauthenticated /api call even with no static key configured" in {
     val fix = SecurityFixtures.freshStore()
     val h   = ManagerServerHarness.boot(fix.store, staticApiKey = None)
     try
+      // No open mode: an unset key means "static-key auth disabled", never
+      // "namespace open". Only a session (or PAT) credential admits.
       val resp = get(h.httpClient, s"${h.baseUrl}/api/tenant/list")
       withClue(s"GET /api/tenant/list body: ${resp.body()}") {
+        resp.statusCode() shouldBe 401
+      }
+      val token  = h.mintToken(SecurityFixtures.RootUsername, SecurityFixtures.RootPassword)
+      val authed = get(h.httpClient, s"${h.baseUrl}/api/tenant/list", apiKey = Some(token))
+      withClue(s"session GET /api/tenant/list body: ${authed.body()}") {
+        authed.statusCode() shouldBe 200
+      }
+    finally h.shutdown()
+  }
+
+  it should "treat an empty static key exactly like an unset one" in {
+    val fix = SecurityFixtures.freshStore()
+    // Compose / k8s configs routinely materialize QOD_API_KEY="" -- pureconfig
+    // then yields Some(""), which must neither open the namespace nor become a
+    // matchable key.
+    val h = ManagerServerHarness.boot(fix.store, staticApiKey = Some(""))
+    try
+      val keyless = get(h.httpClient, s"${h.baseUrl}/api/tenant/list")
+      withClue(s"keyless body: ${keyless.body()}") {
+        keyless.statusCode() shouldBe 401
+      }
+      val emptyKey = get(h.httpClient, s"${h.baseUrl}/api/tenant/list", apiKey = Some(""))
+      withClue(s"empty-key body: ${emptyKey.body()}") {
+        emptyKey.statusCode() shouldBe 401
+      }
+    finally h.shutdown()
+  }
+
+  it should "keep public endpoints keyless with no static key configured" in {
+    val fix = SecurityFixtures.freshStore()
+    val h   = ManagerServerHarness.boot(fix.store, staticApiKey = None)
+    try
+      val resp = get(h.httpClient, s"${h.baseUrl}/api/config/client")
+      withClue(s"GET /api/config/client body: ${resp.body()}") {
         resp.statusCode() shouldBe 200
       }
     finally h.shutdown()

--- a/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
+++ b/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
@@ -270,7 +270,10 @@ object ManagerServerHarness:
       ] = None,
       // PAT admission on /api (guard + profile handlers). None keeps the guard
       // session-and-static-key only, exactly like a Main boot without Postgres.
-      patAuth: Option[ai.starlake.quack.ondemand.auth.PatAuthenticator] = None
+      patAuth: Option[ai.starlake.quack.ondemand.auth.PatAuthenticator] = None,
+      // Mount POST /mcp wired over the harness handlers, mirroring Main's
+      // mcp.enabled gate. Off by default so pre-existing specs see no new route.
+      mcpEnabled: Boolean = false
   ): Harness =
     val mgrCfg =
       minimalManagerConfig(port = 0).copy(apiKey = staticApiKey)
@@ -472,6 +475,52 @@ object ManagerServerHarness:
 
     val metricsEndpoint = new MetricsEndpoint(prometheus = None, beforeScrape = () => ())
 
+    // MCP endpoint over the SAME handler instances the REST surface uses, mirroring
+    // Main's wiring (composed scopeOf; PAT resolution via patAuth; static key shared
+    // with the api-key guard).
+    val mcpRoutes: Option[org.http4s.HttpRoutes[IO]] =
+      if !mcpEnabled then None
+      else
+        val mcpScopeOf: String => Option[ai.starlake.quack.ondemand.auth.SessionScope] =
+          t => sessions.scopeOf(t).orElse(patAuth.flatMap(_.scopeOf(t)))
+        val mcpCatalog = catalogHandlers.getOrElse(
+          new CatalogHandlers((_, _) => noSnapshotReader, sup, store)
+        )
+        val mcpHistory = catalogHistoryHandlers.getOrElse(
+          new CatalogHistoryHandlers((_, _) => noSnapshotReader, sup)
+        )
+        val dataTools = new ai.starlake.quack.mcp.McpDataTools(
+          ai.starlake.quack.McpConfig(),
+          previewExecutor,
+          sup,
+          mcpCatalog,
+          mcpHistory,
+          tagHandlers,
+          tenantDbs,
+          profileHandlers,
+          mcpScopeOf
+        )
+        val adminTools = new ai.starlake.quack.mcp.McpAdminTools(
+          pools,
+          nodes,
+          activeStmtHandlers,
+          maintenanceHandlers,
+          tagHandlers,
+          auditHandlers,
+          mcpScopeOf
+        )
+        Some(
+          new ai.starlake.quack.mcp.McpRoutes(
+            ai.starlake.quack.McpConfig(),
+            staticApiKey.filter(_.nonEmpty),
+            patAuth.fold[String => Option[ai.starlake.quack.ondemand.auth.PatPrincipal]](_ => None)(
+              pa => pa.resolve
+            ),
+            dataTools.tools ++ adminTools.tools,
+            serverVersion = "test-harness"
+          ).routes
+        )
+
     val mgr = new ManagerServer(
       mgrCfg,
       edgeCfg,
@@ -514,7 +563,8 @@ object ManagerServerHarness:
       moduleStaticMounts = moduleStaticMounts,
       passwordReset = Some(passwordResetHandlers),
       pat = patHandlers,
-      patAuth = patAuth
+      patAuth = patAuth,
+      mcpRoutes = mcpRoutes
     )
 
     // Bound the boot. http4s Ember on macOS occasionally stalls binding port

--- a/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
+++ b/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
@@ -254,7 +254,17 @@ object ManagerServerHarness:
       moduleStaticMounts: List[ai.starlake.quack.spi.StaticMount] = Nil,
       // SPI module event sink (Task 9): defaulted to noop so every pre-existing caller
       // compiles unchanged; specs that want to observe emissions pass a recording sink.
-      events: ai.starlake.quack.spi.ManagerEventSink = ai.starlake.quack.spi.ManagerEventSink.noop
+      events: ai.starlake.quack.spi.ManagerEventSink = ai.starlake.quack.spi.ManagerEventSink.noop,
+      // Personal access tokens. qodstate_pat FKs qodstate_user, so the store is real
+      // Postgres or nothing: None (the default) leaves the three /api/auth/pat routes
+      // unmounted and every pre-existing spec untouched. PatRestSpec passes a store
+      // against a fresh test database.
+      patStore: Option[ai.starlake.quack.ondemand.state.PatStore] = None,
+      // How the PAT handler resolves the session principal to the owning user-row id.
+      // Unset falls back to the fixture store (the in-memory analogue of Main's
+      // UserStore.userIdOf); PatRestSpec passes a real UserStore on the same database
+      // as `patStore` so the qodstate_pat FK resolves.
+      patUserIdOf: Option[(Option[String], String) => Option[String]] = None
   ): Harness =
     val mgrCfg =
       minimalManagerConfig(port = 0).copy(apiKey = staticApiKey)
@@ -304,6 +314,16 @@ object ManagerServerHarness:
       resolveTenant = raw => sup.getTenantById(raw).map(_.id),
       publicBaseUrl = ""
     )
+
+    // Mounted only when the spec supplies a (Postgres-backed) PAT store.
+    val patHandlers = patStore.map { pats =>
+      new ai.starlake.quack.ondemand.api.PatHandlers(
+        pats,
+        sessions,
+        patUserIdOf.getOrElse((tenant, username) => store.findUser(tenant, username).map(_.id)),
+        audit = audit
+      )
+    }
 
     val statementStore     = new StatementHistoryStore()
     val historyHandlers    = new StatementHistoryHandlers(statementStore, sup)
@@ -485,7 +505,8 @@ object ManagerServerHarness:
       moduleEndpoints = moduleEndpoints,
       modulePublicPrefixes = modulePublicPrefixes,
       moduleStaticMounts = moduleStaticMounts,
-      passwordReset = Some(passwordResetHandlers)
+      passwordReset = Some(passwordResetHandlers),
+      pat = patHandlers
     )
 
     // Bound the boot. http4s Ember on macOS occasionally stalls binding port

--- a/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
+++ b/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
@@ -267,7 +267,10 @@ object ManagerServerHarness:
       // resolves.
       patUserOf: Option[
         (Option[String], String) => Option[ai.starlake.quack.ondemand.state.RbacUser]
-      ] = None
+      ] = None,
+      // PAT admission on /api (guard + profile handlers). None keeps the guard
+      // session-and-static-key only, exactly like a Main boot without Postgres.
+      patAuth: Option[ai.starlake.quack.ondemand.auth.PatAuthenticator] = None
   ): Harness =
     val mgrCfg =
       minimalManagerConfig(port = 0).copy(apiKey = staticApiKey)
@@ -334,7 +337,8 @@ object ManagerServerHarness:
     val historyApiHandlers = new HistoryHandlers(telemetryStore)
     val usageHandlers      = new UsageHandlers(telemetryStore)
     val profileHandlers    = new ai.starlake.quack.ondemand.api.ProfileHandlers(
-      sessions,
+      // Mirror Main: session JWT first, then PAT.
+      t => sessions.get(t).orElse(patAuth.flatMap(_.sessionOf(t))),
       telemetryStore,
       statementStore,
       id => sup.getTenantById(id)
@@ -509,7 +513,8 @@ object ManagerServerHarness:
       modulePublicPrefixes = modulePublicPrefixes,
       moduleStaticMounts = moduleStaticMounts,
       passwordReset = Some(passwordResetHandlers),
-      pat = patHandlers
+      pat = patHandlers,
+      patAuth = patAuth
     )
 
     // Bound the boot. http4s Ember on macOS occasionally stalls binding port

--- a/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
+++ b/src/test/scala/ai/starlake/quack/security/ManagerServerHarness.scala
@@ -260,11 +260,14 @@ object ManagerServerHarness:
       // unmounted and every pre-existing spec untouched. PatRestSpec passes a store
       // against a fresh test database.
       patStore: Option[ai.starlake.quack.ondemand.state.PatStore] = None,
-      // How the PAT handler resolves the session principal to the owning user-row id.
-      // Unset falls back to the fixture store (the in-memory analogue of Main's
-      // UserStore.userIdOf); PatRestSpec passes a real UserStore on the same database
-      // as `patStore` so the qodstate_pat FK resolves.
-      patUserIdOf: Option[(Option[String], String) => Option[String]] = None
+      // How the PAT handler resolves the session principal to the owning user row
+      // (the whole row: `enabled` decides whether a mint is refused). Unset falls back
+      // to the fixture store, the in-memory analogue of what Main wires; PatRestSpec
+      // passes a lookup against the same database as `patStore` so the qodstate_pat FK
+      // resolves.
+      patUserOf: Option[
+        (Option[String], String) => Option[ai.starlake.quack.ondemand.state.RbacUser]
+      ] = None
   ): Harness =
     val mgrCfg =
       minimalManagerConfig(port = 0).copy(apiKey = staticApiKey)
@@ -320,7 +323,7 @@ object ManagerServerHarness:
       new ai.starlake.quack.ondemand.api.PatHandlers(
         pats,
         sessions,
-        patUserIdOf.getOrElse((tenant, username) => store.findUser(tenant, username).map(_.id)),
+        patUserOf.getOrElse((tenant, username) => store.findUser(tenant, username)),
         audit = audit
       )
     }

--- a/src/test/scala/ai/starlake/quack/security/PatApiAdmissionSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/PatApiAdmissionSpec.scala
@@ -1,0 +1,192 @@
+// src/test/scala/ai/starlake/quack/security/PatApiAdmissionSpec.scala
+package ai.starlake.quack.security
+
+import ai.starlake.quack.ondemand.auth.PatAuthenticator
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserGrant, UserStore}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+/** End-to-end contract of a PAT presented as the `/api` bearer credential (`X-API-Key` header): the
+  * guard admits it exactly as it would the owning user's login session.
+  *
+  * The static key is ALWAYS configured in these cases, so what admits a PAT is the guard's own PAT
+  * arm, never the open-mode fallback. Pinned here:
+  *   - an admin-owned PAT reaches the admin surface;
+  *   - a role=user PAT is demoted to the profile allowlist (`403 admin_required` elsewhere), and
+  *     the profile handlers resolve its identity, so `/api/profile/usage` answers 200;
+  *   - a revoked PAT is anonymous: `401` everywhere, indistinguishable from garbage;
+  *   - a tenant-admin PAT carries its owner's tenant scope, so a cross-tenant `?tenant=` path is
+  *     `403 tenant_forbidden` (the same perimeter check a session gets);
+  *   - a PAT still cannot manage PATs (`403 session_required`), now proven THROUGH the guard.
+  */
+class PatApiAdmissionSpec
+    extends AnyFlatSpec
+    with Matchers
+    with SecurityHttpHelpers
+    with BeforeAndAfterAll:
+
+  TestPostgres.dropStrayTestDatabases("qodpatadm")
+
+  private val dbName = s"qodpatadm_test_${System.nanoTime()}"
+
+  private var users: UserStore          = null
+  private var pats: PatStore            = null
+  private var patAuth: PatAuthenticator = null
+
+  override def beforeAll(): Unit =
+    if TestPostgres.reachable then
+      TestPostgres.psql("postgres", s"""CREATE DATABASE "$dbName"""")
+      val url = TestPostgres.dbUrl(dbName)
+      new LiquibaseRunner(url, TestPostgres.pgUser, TestPostgres.pgPass).run()
+      users = new UserStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      pats = new PatStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      // Row-only grants, the wiring PatAuthenticator's scaladoc requires: a PAT
+      // is bound to one user row and must never fold in a same-named user's grants.
+      patAuth = new PatAuthenticator(pats, users.userById, u => List(UserGrant(u.tenant, u.role)))
+      users.upsertUser(None, SecurityFixtures.RootUsername, SecurityFixtures.RootPassword, "admin")
+      users.upsertUser(
+        Some(SecurityFixtures.TenantId),
+        SecurityFixtures.AliceUsername,
+        SecurityFixtures.AlicePassword,
+        "admin"
+      )
+      users.upsertUser(
+        Some(SecurityFixtures.TenantId),
+        SecurityFixtures.BobUsername,
+        SecurityFixtures.BobPassword,
+        "user"
+      )
+
+  override def afterAll(): Unit =
+    if pats != null then pats.close()
+    if users != null then users.close()
+    Try(TestPostgres.dropDatabase(dbName))
+    ()
+
+  /** Mint a live PAT for `(tenant, username)` directly against the store; returns (patId, raw). */
+  private def mintFor(tenant: Option[String], username: String): (String, String) =
+    val uid = users
+      .userIdOf(tenant, username)
+      .getOrElse(fail(s"fixture user $username not found"))
+    val (rec, raw) = pats.mint(uid, s"spec-$username", None)
+    (rec.id, raw)
+
+  /** Static key configured in every case: reaching a handler with a PAT proves the guard's PAT arm
+    * admitted it, not the open-mode fallback (which Task 5 removes outright).
+    */
+  private def withHarness(body: ManagerServerHarness.Harness => Unit): Unit =
+    TestPostgres.ensureReachable()
+    val fix = SecurityFixtures.freshStore()
+    val h   = ManagerServerHarness.boot(
+      fix.store,
+      staticApiKey = Some("static-key-1"),
+      patStore = Some(pats),
+      patUserOf =
+        Some((tenant, username) => users.userIdOf(tenant, username).flatMap(users.userById)),
+      patAuth = Some(patAuth)
+    )
+    try body(h)
+    finally h.shutdown()
+
+  // ------------------------------------------------------------------
+  // (a) admin PAT reaches the admin surface
+  // ------------------------------------------------------------------
+
+  "a superuser-owned PAT" should "be admitted on the admin surface" in withHarness { h =>
+    val (_, raw) = mintFor(None, SecurityFixtures.RootUsername)
+    val resp     = get(h.httpClient, s"${h.baseUrl}/api/pool/list", apiKey = Some(raw))
+    withClue(s"GET /api/pool/list body: ${resp.body()}") {
+      resp.statusCode() shouldBe 200
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // (b) role=user PAT: profile allowlist only
+  // ------------------------------------------------------------------
+
+  "a role=user PAT" should "reach its own profile surface and nothing else" in withHarness { h =>
+    val (_, raw) = mintFor(Some(SecurityFixtures.TenantId), SecurityFixtures.BobUsername)
+
+    val usage = get(h.httpClient, s"${h.baseUrl}/api/profile/usage", apiKey = Some(raw))
+    withClue(s"GET /api/profile/usage body: ${usage.body()}") {
+      usage.statusCode() shouldBe 200
+    }
+
+    val sealedOff = get(h.httpClient, s"${h.baseUrl}/api/pool/list", apiKey = Some(raw))
+    withClue(s"GET /api/pool/list body: ${sealedOff.body()}") {
+      sealedOff.statusCode() shouldBe 403
+      errorCode(sealedOff.body()) should contain("admin_required")
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // (c) revoked PAT is anonymous
+  // ------------------------------------------------------------------
+
+  "a revoked PAT" should "get 401 everywhere" in withHarness { h =>
+    val uid = users
+      .userIdOf(None, SecurityFixtures.RootUsername)
+      .getOrElse(fail("fixture user root not found"))
+    val (rec, raw) = pats.mint(uid, "to-revoke", None)
+    pats.revoke(uid, rec.id) shouldBe true
+
+    List("/api/pool/list", "/api/profile/usage").foreach { path =>
+      val resp = get(h.httpClient, s"${h.baseUrl}$path", apiKey = Some(raw))
+      withClue(s"GET $path body: ${resp.body()}") {
+        resp.statusCode() shouldBe 401
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // (d) tenant scope travels with the PAT
+  // ------------------------------------------------------------------
+
+  "a tenant-admin PAT" should "be tenant-confined exactly like its owner's session" in withHarness {
+    h =>
+      val (_, raw) = mintFor(Some(SecurityFixtures.TenantId), SecurityFixtures.AliceUsername)
+
+      // Own tenant: through the guard and the handler.
+      val own = get(
+        h.httpClient,
+        s"${h.baseUrl}/api/user/list?tenant=${SecurityFixtures.TenantId}",
+        apiKey = Some(raw)
+      )
+      withClue(s"own-tenant body: ${own.body()}") {
+        own.statusCode() shouldBe 200
+      }
+
+      // Another tenant: the perimeter guard's scope check fires.
+      val crossed = get(
+        h.httpClient,
+        s"${h.baseUrl}/api/user/list?tenant=${SecurityFixtures.GlobexTenantId}",
+        apiKey = Some(raw)
+      )
+      withClue(s"cross-tenant body: ${crossed.body()}") {
+        crossed.statusCode() shouldBe 403
+        errorCode(crossed.body()) should contain("tenant_forbidden")
+      }
+  }
+
+  // ------------------------------------------------------------------
+  // (e) a PAT still cannot manage PATs, now proven through the guard
+  // ------------------------------------------------------------------
+
+  "a PAT presented on the PAT-management routes" should "still be refused 403 session_required" in
+    withHarness { h =>
+      val (_, raw) = mintFor(None, SecurityFixtures.RootUsername)
+      val denied   = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"successor"}""",
+        apiKey = Some(raw)
+      )
+      withClue(s"create-with-pat body: ${denied.body()}") {
+        denied.statusCode() shouldBe 403
+        errorCode(denied.body()) should contain("session_required")
+      }
+    }

--- a/src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
@@ -1,0 +1,366 @@
+// src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
+package ai.starlake.quack.security
+
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserStore}
+import io.circe.parser.parse
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+/** End-to-end contract of the three personal-access-token REST routes
+  * (`/api/auth/pat/{create,list,revoke}`).
+  *
+  * The routes are session-JWT-only and strictly self-scoped: the caller's identity comes from the
+  * session token, never from a request field, so there is no tenant (or user) parameter anywhere on
+  * the surface. Two properties are load-bearing and pinned here:
+  *   - a PAT can never manage PATs (`403 session_required`), so a leaked token cannot mint itself a
+  *     successor or revoke the tokens that would lock it out;
+  *   - a caller can only ever see and revoke its OWN tokens, and another user's id is answered
+  *     `404 not_found` -- indistinguishable from an id that never existed (no existence leak).
+  *
+  * The PAT store is real Postgres (`qodstate_pat` carries an FK to `qodstate_user`), shared by
+  * every case in the suite; the fixture users are created once through a real [[UserStore]] on that
+  * same database, which is exactly what `Main` wires as the handler's `userIdOf`.
+  */
+class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers with BeforeAndAfterAll:
+
+  TestPostgres.dropStrayTestDatabases("qodpatrest")
+
+  private val dbName = s"qodpatrest_test_${System.nanoTime()}"
+
+  private var users: UserStore = null
+  private var pats: PatStore   = null
+
+  override def beforeAll(): Unit =
+    if TestPostgres.reachable then
+      TestPostgres.psql("postgres", s"""CREATE DATABASE "$dbName"""")
+      val url = TestPostgres.dbUrl(dbName)
+      new LiquibaseRunner(url, TestPostgres.pgUser, TestPostgres.pgPass).run()
+      users = new UserStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      pats = new PatStore(url, TestPostgres.pgUser, TestPostgres.pgPass)
+      // Mirror the in-memory login fixture into the PAT database: the qodstate_pat
+      // FK is on the user row id, so the id the handler resolves must exist here.
+      users.upsertUser(None, SecurityFixtures.RootUsername, SecurityFixtures.RootPassword, "admin")
+      users.upsertUser(
+        Some(SecurityFixtures.TenantId),
+        SecurityFixtures.AliceUsername,
+        SecurityFixtures.AlicePassword,
+        "admin"
+      )
+      users.upsertUser(
+        Some(SecurityFixtures.TenantId),
+        SecurityFixtures.BobUsername,
+        SecurityFixtures.BobPassword,
+        "user"
+      )
+
+  override def afterAll(): Unit =
+    if pats != null then pats.close()
+    if users != null then users.close()
+    Try(TestPostgres.dropDatabase(dbName))
+    ()
+
+  /** Boot a harness wired to the shared PAT store, with `userIdOf` resolved through the real
+    * [[UserStore]] exactly as `Main` does.
+    */
+  private def withHarness(
+      staticApiKey: Option[String] = None
+  )(body: ManagerServerHarness.Harness => Unit): Unit =
+    TestPostgres.ensureReachable()
+    val fix = SecurityFixtures.freshStore()
+    val h   = ManagerServerHarness.boot(
+      fix.store,
+      staticApiKey = staticApiKey,
+      patStore = Some(pats),
+      patUserIdOf = Some((tenant, username) => users.userIdOf(tenant, username))
+    )
+    try body(h)
+    finally h.shutdown()
+
+  private def field(body: String, name: String): Option[String] =
+    parse(body).toOption.flatMap(_.hcursor.get[String](name).toOption)
+
+  private def tokenEntries(body: String): List[io.circe.Json] =
+    parse(body).toOption
+      .flatMap(_.hcursor.get[List[io.circe.Json]]("tokens").toOption)
+      .getOrElse(Nil)
+
+  private def entryFlag(entry: io.circe.Json, name: String): Option[Boolean] =
+    entry.hcursor.get[Boolean](name).toOption
+
+  private def rootSession(h: ManagerServerHarness.Harness): String =
+    h.mintToken(SecurityFixtures.RootUsername, SecurityFixtures.RootPassword)
+
+  private def tenantSession(h: ManagerServerHarness.Harness, user: String, pass: String): String =
+    h.mintToken(user, pass, tenant = Some(SecurityFixtures.TenantId))
+
+  // ------------------------------------------------------------------
+  // 1 + 2. mint, then list
+  // ------------------------------------------------------------------
+
+  "POST /api/auth/pat/create" should "mint a prefixed token, list it once, and never echo it again" in
+    withHarness() { h =>
+      val session = rootSession(h)
+      val created = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"claude-code"}""",
+        apiKey = Some(session)
+      )
+      withClue(s"create body: ${created.body()}") {
+        created.statusCode() shouldBe 200
+      }
+      val raw = field(created.body(), "token").getOrElse(fail("no token in create response"))
+      raw should startWith(PatStore.TokenPrefix)
+      field(created.body(), "name") shouldBe Some("claude-code")
+      val id = field(created.body(), "id").getOrElse(fail("no id in create response"))
+
+      // The raw token is a real credential against the store exactly once.
+      pats.verify(raw).map(_.id) shouldBe Some(id)
+
+      val listed = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/list",
+        // `list` declares no body input, so nothing would consume one: an unread
+        // request body desynchronizes the reused HTTP/1.1 connection.
+        "",
+        apiKey = Some(session)
+      )
+      withClue(s"list body: ${listed.body()}") {
+        listed.statusCode() shouldBe 200
+      }
+      val mine =
+        tokenEntries(listed.body()).filter(_.hcursor.get[String]("id").toOption.contains(id))
+      mine should have size 1
+      entryFlag(mine.head, "revoked") shouldBe Some(false)
+      // The listing is metadata only: the raw secret is unrecoverable after mint.
+      listed.body() should not include raw
+    }
+
+  // ------------------------------------------------------------------
+  // 3. revoke, then revoke again
+  // ------------------------------------------------------------------
+
+  "POST /api/auth/pat/revoke" should "flip the listing to revoked and 404 a second revoke" in
+    withHarness() { h =>
+      val session = rootSession(h)
+      val created = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"to-revoke"}""",
+        apiKey = Some(session)
+      )
+      created.statusCode() shouldBe 200
+      val id  = field(created.body(), "id").getOrElse(fail("no id in create response"))
+      val raw = field(created.body(), "token").getOrElse(fail("no token in create response"))
+
+      val revoked = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/revoke",
+        s"""{"id":"$id"}""",
+        apiKey = Some(session)
+      )
+      withClue(s"revoke body: ${revoked.body()}") {
+        revoked.statusCode() shouldBe 200
+      }
+      pats.verify(raw) shouldBe None
+
+      val listed = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/list",
+        // `list` declares no body input, so nothing would consume one: an unread
+        // request body desynchronizes the reused HTTP/1.1 connection.
+        "",
+        apiKey = Some(session)
+      )
+      val entry = tokenEntries(listed.body())
+        .find(_.hcursor.get[String]("id").toOption.contains(id))
+        .getOrElse(fail(s"revoked token missing from listing: ${listed.body()}"))
+      entryFlag(entry, "revoked") shouldBe Some(true)
+
+      // Already revoked is not distinguishable from unknown: both 404.
+      val again = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/revoke",
+        s"""{"id":"$id"}""",
+        apiKey = Some(session)
+      )
+      withClue(s"second revoke body: ${again.body()}") {
+        again.statusCode() shouldBe 404
+        errorCode(again.body()) should contain("not_found")
+      }
+    }
+
+  // ------------------------------------------------------------------
+  // 4. a PAT may not manage PATs
+  // ------------------------------------------------------------------
+
+  "a PAT presented as the credential" should "be refused 403 session_required" in withHarness() {
+    h =>
+      val session = rootSession(h)
+      val created = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"agent"}""",
+        apiKey = Some(session)
+      )
+      created.statusCode() shouldBe 200
+      val raw = field(created.body(), "token").getOrElse(fail("no token in create response"))
+
+      // Open-mode harness on purpose: the api-key guard is out of the way, so what
+      // answers here is the handler's own session-only gate (which is what must hold
+      // once the guard learns to admit PATs as a bearer credential).
+      val denied = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"successor"}""",
+        apiKey = Some(raw)
+      )
+      withClue(s"create-with-pat body: ${denied.body()}") {
+        denied.statusCode() shouldBe 403
+        errorCode(denied.body()) should contain("session_required")
+      }
+
+      val deniedList = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/list",
+        // `list` declares no body input, so nothing would consume one: an unread
+        // request body desynchronizes the reused HTTP/1.1 connection.
+        "",
+        apiKey = Some(raw)
+      )
+      deniedList.statusCode() shouldBe 403
+      errorCode(deniedList.body()) should contain("session_required")
+
+      val deniedRevoke = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/revoke",
+        """{"id":"pat-whatever"}""",
+        apiKey = Some(raw)
+      )
+      deniedRevoke.statusCode() shouldBe 403
+      errorCode(deniedRevoke.body()) should contain("session_required")
+  }
+
+  // ------------------------------------------------------------------
+  // 5. no credential at all
+  // ------------------------------------------------------------------
+
+  "an anonymous caller" should "be refused 401 on every PAT route" in
+    withHarness(staticApiKey = Some("k1")) { h =>
+      List("create", "list", "revoke").foreach { verb =>
+        // Empty body on purpose: the guard rejects before any decode, and a body
+        // it never reads would poison the next request on the same connection.
+        val resp = post(h.httpClient, s"${h.baseUrl}/api/auth/pat/$verb", "")
+        withClue(s"anonymous $verb body: ${resp.body()}") {
+          resp.statusCode() shouldBe 401
+        }
+      }
+    }
+
+  // ------------------------------------------------------------------
+  // 6. a regular (role=user) session manages its own tokens
+  // ------------------------------------------------------------------
+
+  "a role=user session" should "create, list and revoke its own PATs through the profile allowlist" in
+    withHarness(staticApiKey = Some("k1")) { h =>
+      // Static key set, so the guard is enforcing: reaching the handler at all
+      // proves the three paths are on the non-admin profile allowlist.
+      val session = tenantSession(h, SecurityFixtures.BobUsername, SecurityFixtures.BobPassword)
+
+      // Same session on an admin route stays sealed -- the allowlist widened by
+      // exactly the PAT paths, not by the /api/auth namespace.
+      val sealedOff = get(h.httpClient, s"${h.baseUrl}/api/pool/list", apiKey = Some(session))
+      withClue(s"GET /api/pool/list body: ${sealedOff.body()}") {
+        sealedOff.statusCode() shouldBe 403
+        errorCode(sealedOff.body()) should contain("admin_required")
+      }
+
+      val created = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"bob-agent"}""",
+        apiKey = Some(session)
+      )
+      withClue(s"create body: ${created.body()}") {
+        created.statusCode() shouldBe 200
+      }
+      val id = field(created.body(), "id").getOrElse(fail("no id in create response"))
+
+      val listed = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/list",
+        // `list` declares no body input, so nothing would consume one: an unread
+        // request body desynchronizes the reused HTTP/1.1 connection.
+        "",
+        apiKey = Some(session)
+      )
+      withClue(s"list body: ${listed.body()}") {
+        listed.statusCode() shouldBe 200
+      }
+      tokenEntries(listed.body()).flatMap(_.hcursor.get[String]("id").toOption) should contain(id)
+
+      val revoked = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/revoke",
+        s"""{"id":"$id"}""",
+        apiKey = Some(session)
+      )
+      withClue(s"revoke body: ${revoked.body()}") {
+        revoked.statusCode() shouldBe 200
+      }
+    }
+
+  // ------------------------------------------------------------------
+  // 7. cross-user isolation
+  // ------------------------------------------------------------------
+
+  "one user" should "neither see nor revoke another user's token" in withHarness() { h =>
+    val alice = tenantSession(h, SecurityFixtures.AliceUsername, SecurityFixtures.AlicePassword)
+    val bob   = tenantSession(h, SecurityFixtures.BobUsername, SecurityFixtures.BobPassword)
+
+    val created = post(
+      h.httpClient,
+      s"${h.baseUrl}/api/auth/pat/create",
+      """{"name":"alice-only"}""",
+      apiKey = Some(alice)
+    )
+    withClue(s"create body: ${created.body()}") {
+      created.statusCode() shouldBe 200
+    }
+    val aliceId  = field(created.body(), "id").getOrElse(fail("no id in create response"))
+    val aliceRaw = field(created.body(), "token").getOrElse(fail("no token in create response"))
+
+    // Bob's listing never contains it.
+    val bobList = post(h.httpClient, s"${h.baseUrl}/api/auth/pat/list", "", apiKey = Some(bob))
+    bobList.statusCode() shouldBe 200
+    tokenEntries(bobList.body()).flatMap(
+      _.hcursor.get[String]("id").toOption
+    ) should not contain aliceId
+
+    // And revoking it answers the same 404 an unknown id gets.
+    val stolen = post(
+      h.httpClient,
+      s"${h.baseUrl}/api/auth/pat/revoke",
+      s"""{"id":"$aliceId"}""",
+      apiKey = Some(bob)
+    )
+    withClue(s"cross-user revoke body: ${stolen.body()}") {
+      stolen.statusCode() shouldBe 404
+      errorCode(stolen.body()) should contain("not_found")
+    }
+    val unknown = post(
+      h.httpClient,
+      s"${h.baseUrl}/api/auth/pat/revoke",
+      """{"id":"pat-does-not-exist"}""",
+      apiKey = Some(bob)
+    )
+    unknown.statusCode() shouldBe 404
+    errorCode(unknown.body()) should contain("not_found")
+
+    // Alice's token is untouched by the attempt.
+    pats.verify(aliceRaw).map(_.id) shouldBe Some(aliceId)
+  }

--- a/src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
@@ -1,8 +1,9 @@
 // src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
 package ai.starlake.quack.security
 
+import ai.starlake.quack.ondemand.auth.PatAuthenticator
 import ai.starlake.quack.ondemand.state.testkit.TestPostgres
-import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserStore}
+import ai.starlake.quack.ondemand.state.{LiquibaseRunner, PatStore, UserGrant, UserStore}
 import io.circe.parser.parse
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
@@ -68,7 +69,9 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
     ()
 
   /** Boot a harness wired to the shared PAT store, with `userIdOf` resolved through the real
-    * [[UserStore]] exactly as `Main` does.
+    * [[UserStore]] and `patAuth` composed into the guard exactly as `Main` does -- without it a PAT
+    * presented as the credential would die at the guard's 401 instead of reaching the handler's
+    * session-only gate that case 4 pins.
     */
   private def withHarness(
       staticApiKey: Option[String] = None
@@ -81,7 +84,9 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
       patStore = Some(pats),
       // Whole row, as Main wires it: `enabled` is part of the handler's decision.
       patUserOf =
-        Some((tenant, username) => users.userIdOf(tenant, username).flatMap(users.userById))
+        Some((tenant, username) => users.userIdOf(tenant, username).flatMap(users.userById)),
+      patAuth =
+        Some(new PatAuthenticator(pats, users.userById, u => List(UserGrant(u.tenant, u.role))))
     )
     try body(h)
     finally h.shutdown()
@@ -260,9 +265,9 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
       created.statusCode() shouldBe 200
       val raw = field(created.body(), "token").getOrElse(fail("no token in create response"))
 
-      // Open-mode harness on purpose: the api-key guard is out of the way, so what
-      // answers here is the handler's own session-only gate (which is what must hold
-      // once the guard learns to admit PATs as a bearer credential).
+      // The guard admits the PAT (patAuth is wired), so what answers here is the
+      // handler's own session-only gate: even a fully-admitted PAT cannot manage
+      // PATs.
       val denied = post(
         h.httpClient,
         s"${h.baseUrl}/api/auth/pat/create",

--- a/src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/PatRestSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.sql.DriverManager
 import scala.util.Try
 
 /** End-to-end contract of the three personal-access-token REST routes
@@ -31,6 +32,9 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
 
   private val dbName = s"qodpatrest_test_${System.nanoTime()}"
 
+  // Shared across every case in the suite (one database, one Liquibase run): assertions
+  // must therefore filter the listing by the id they just minted and never assert an
+  // absolute token count.
   private var users: UserStore = null
   private var pats: PatStore   = null
 
@@ -75,7 +79,9 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
       fix.store,
       staticApiKey = staticApiKey,
       patStore = Some(pats),
-      patUserIdOf = Some((tenant, username) => users.userIdOf(tenant, username))
+      // Whole row, as Main wires it: `enabled` is part of the handler's decision.
+      patUserOf =
+        Some((tenant, username) => users.userIdOf(tenant, username).flatMap(users.userById))
     )
     try body(h)
     finally h.shutdown()
@@ -90,6 +96,28 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
 
   private def entryFlag(entry: io.circe.Json, name: String): Option[Boolean] =
     entry.hcursor.get[Boolean](name).toOption
+
+  /** Flip `qodstate_user.enabled` on the PAT database directly: the login fixture is the in-memory
+    * store, so this is how a session outlives the enablement of the row behind it.
+    */
+  private def setEnabled(tenant: Option[String], username: String, enabled: Boolean): Unit =
+    val c = DriverManager.getConnection(
+      TestPostgres.dbUrl(dbName),
+      TestPostgres.pgUser,
+      TestPostgres.pgPass
+    )
+    try
+      val ps = c.prepareStatement(
+        "UPDATE qodstate_user SET enabled = ? WHERE tenant IS NOT DISTINCT FROM ? AND username = ?"
+      )
+      try
+        ps.setBoolean(1, enabled)
+        ps.setString(2, tenant.orNull)
+        ps.setString(3, username)
+        ps.executeUpdate()
+        ()
+      finally ps.close()
+    finally c.close()
 
   private def rootSession(h: ManagerServerHarness.Harness): String =
     h.mintToken(SecurityFixtures.RootUsername, SecurityFixtures.RootPassword)
@@ -138,6 +166,28 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
       entryFlag(mine.head, "revoked") shouldBe Some(false)
       // The listing is metadata only: the raw secret is unrecoverable after mint.
       listed.body() should not include raw
+
+      // Both request-shape rejections, pinned on the same session.
+      val blankName = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        """{"name":"   "}""",
+        apiKey = Some(session)
+      )
+      withClue(s"blank-name body: ${blankName.body()}") {
+        blankName.statusCode() shouldBe 400
+        errorCode(blankName.body()) should contain("invalid_name")
+      }
+      val pastExpiry = post(
+        h.httpClient,
+        s"${h.baseUrl}/api/auth/pat/create",
+        s"""{"name":"stale","expiresAt":"${java.time.Instant.now().minusSeconds(60)}"}""",
+        apiKey = Some(session)
+      )
+      withClue(s"past-expiry body: ${pastExpiry.body()}") {
+        pastExpiry.statusCode() shouldBe 400
+        errorCode(pastExpiry.body()) should contain("invalid_expiry")
+      }
     }
 
   // ------------------------------------------------------------------
@@ -364,3 +414,40 @@ class PatRestSpec extends AnyFlatSpec with Matchers with SecurityHttpHelpers wit
     // Alice's token is untouched by the attempt.
     pats.verify(aliceRaw).map(_.id) shouldBe Some(aliceId)
   }
+
+  // ------------------------------------------------------------------
+  // 8. a disabled owner cannot mint (use-time is already gated by PatAuthenticator)
+  // ------------------------------------------------------------------
+
+  "a disabled owner" should "be refused 403 account_disabled on a still-live session" in
+    withHarness() { h =>
+      // Session minted while the row was still enabled: the JWT is stateless, so it
+      // outlives the disablement and the refusal has to come from the handler.
+      val session = tenantSession(h, SecurityFixtures.BobUsername, SecurityFixtures.BobPassword)
+      setEnabled(Some(SecurityFixtures.TenantId), SecurityFixtures.BobUsername, false)
+      try
+        val denied = post(
+          h.httpClient,
+          s"${h.baseUrl}/api/auth/pat/create",
+          """{"name":"after-disable"}""",
+          apiKey = Some(session)
+        )
+        withClue(s"create-while-disabled body: ${denied.body()}") {
+          denied.statusCode() shouldBe 403
+          errorCode(denied.body()) should contain("account_disabled")
+        }
+        // Same identity gate gates the read and the revoke.
+        val deniedList = post(
+          h.httpClient,
+          s"${h.baseUrl}/api/auth/pat/list",
+          "",
+          apiKey = Some(session)
+        )
+        withClue(s"list-while-disabled body: ${deniedList.body()}") {
+          deniedList.statusCode() shouldBe 403
+          errorCode(deniedList.body()) should contain("account_disabled")
+        }
+      finally
+        // The fixture rows are shared by the whole suite; leave bob usable.
+        setEnabled(Some(SecurityFixtures.TenantId), SecurityFixtures.BobUsername, true)
+    }

--- a/src/test/scala/ai/starlake/quack/security/StatementHistoryScopeSpec.scala
+++ b/src/test/scala/ai/starlake/quack/security/StatementHistoryScopeSpec.scala
@@ -18,7 +18,7 @@ import java.time.Instant
   *   - superuser sees all
   *   - tenant-A admin sees only A's rows
   *   - static-key bypass sees all
-  *   - open mode sees all
+  *   - a keyless call with no static key configured is 401 (the former open mode is gone)
   *   - records carrying either the id or the display-name form pass the filter (mirrors the
   *     FlightSQL handshake convention; the router records the display name today but future changes
   *     might switch)
@@ -139,13 +139,12 @@ class StatementHistoryScopeSpec extends AnyFlatSpec with Matchers with SecurityH
     finally h.shutdown()
   }
 
-  it should "return all rows in open mode (no api key configured)" in {
+  it should "refuse a keyless call even with no api key configured (open mode is gone)" in {
     val (h, _) = bootTwoTenants(staticApiKey = None)
     try
       val resp = get(h.httpClient, s"${h.baseUrl}/api/node/statements")
-      withClue(s"open-mode body: ${resp.body()}") {
-        resp.statusCode() shouldBe 200
-        tenantsOf(resp.body()).size shouldBe 4
+      withClue(s"keyless body: ${resp.body()}") {
+        resp.statusCode() shouldBe 401
       }
     finally h.shutdown()
   }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -140,6 +140,7 @@ function Shell() {
         {role === 'admin' && isSuperuser && (
           <NavLink to="/config"    className={({ isActive }) => isActive ? 'active' : ''}>Config</NavLink>
         )}
+        <NavLink to="/profile"     className={({ isActive }) => isActive ? 'active' : ''}>Profile</NavLink>
         <span className="spacer" />
         {authEnabled ? (
           <>
@@ -170,6 +171,7 @@ function Shell() {
           <Route path="/audit"                                     element={<Audit />} />
           <Route path="/history"                                   element={<History />} />
           <Route path="/usage"                                     element={<Usage />} />
+          <Route path="/profile"                                   element={<Profile />} />
         </Routes>
       </main>
     </>

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -33,6 +33,9 @@ import type {
   WhoamiResponse,
   ForgotPasswordRequest,
   ResetPasswordRequest,
+  PatCreateRequest,
+  PatCreateResponse,
+  PatListResponse,
   StatementHistoryResponse,
   CatalogSchemaEntry,
   CatalogTableEntry,
@@ -185,6 +188,13 @@ export const api = {
   // tenant_forbidden) before the handler even runs.
   profileUsage:      (days?: number)  => get<UsageResponse>('/profile/usage' + (days ? `?days=${days}` : '')),
   profileStatements: (limit?: number) => get<StatementHistoryResponse>('/profile/statements' + (limit ? `?limit=${limit}` : '')),
+  // ----- pats -----
+  // Self-scoped like the profile routes above: identity comes from the session
+  // cookie, so there is NO tenant param anywhere (a stray one would trip the
+  // perimeter guard). Management is session-only; a PAT credential is refused.
+  createPat: (req: PatCreateRequest) => post<PatCreateResponse>('/auth/pat/create', req),
+  listPats:  () => post<PatListResponse>('/auth/pat/list'),
+  revokePat: (id: string) => post<void>('/auth/pat/revoke', { id }),
   // Per-tenant login mode (unauthenticated). Drives the password-form vs. SSO-redirect branch.
   authMode: (tenant?: string) =>
     get<AuthModeResponse>('/auth/mode' + (tenant ? `?tenant=${encodeURIComponent(tenant)}` : '')),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -412,6 +412,35 @@ export interface ResetPasswordRequest {
   newPassword: string;
 }
 
+// ----- Auth: personal access tokens -----
+// Session-only management surface: a PAT can never mint, list, or revoke PATs
+// (the server answers 403 session_required). The raw token appears exactly once,
+// in PatCreateResponse; listings are metadata only.
+export interface PatCreateRequest {
+  name: string;
+  expiresAt?: string | null; // ISO-8601, must be in the future
+}
+
+export interface PatCreateResponse {
+  id: string;
+  name: string;
+  token: string;
+  expiresAt?: string | null;
+}
+
+export interface PatEntry {
+  id: string;
+  name: string;
+  createdAt: string;
+  expiresAt?: string | null;
+  lastUsedAt?: string | null;
+  revoked: boolean;
+}
+
+export interface PatListResponse { tokens: PatEntry[]; }
+
+export interface PatRevokeRequest { id: string; }
+
 // ----- RBAC: roles -----
 export interface RoleResponse {
   id:          string;

--- a/ui/src/pages/Profile.tsx
+++ b/ui/src/pages/Profile.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { useAuth } from '../auth/AuthContext';
 import { api, ApiError, errorMessage } from '../api/client';
-import type { UsageDayEntry, StatementHistoryEntry } from '../api/types';
+import type { UsageDayEntry, StatementHistoryEntry, PatEntry } from '../api/types';
 
 function shortTs(iso: string): string {
   try {
@@ -65,6 +65,79 @@ export default function Profile() {
       setPwErr(errorMessage(e));
     } finally {
       setPwBusy(false);
+    }
+  }
+
+  // ---- personal access tokens ----
+  const [pats, setPats] = useState<PatEntry[]>([]);
+  const [patName, setPatName] = useState('');
+  const [patExpiry, setPatExpiry] = useState('');
+  const [patErr, setPatErr] = useState('');
+  const [patBusy, setPatBusy] = useState(false);
+  const [mintedName, setMintedName] = useState('');
+  const [mintedToken, setMintedToken] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  async function loadPats() {
+    try {
+      const resp = await api.listPats();
+      setPats(resp.tokens);
+    } catch (e) {
+      setPatErr(errorMessage(e));
+    }
+  }
+
+  useEffect(() => { loadPats(); }, []);
+
+  async function submitCreatePat(e: FormEvent) {
+    e.preventDefault();
+    setPatErr('');
+    setMintedToken('');
+    setCopied(false);
+    setPatBusy(true);
+    try {
+      const resp = await api.createPat({
+        name: patName.trim(),
+        // datetime-local yields a zone-less local timestamp; send it as ISO UTC.
+        expiresAt: patExpiry ? new Date(patExpiry).toISOString() : null,
+      });
+      setMintedName(resp.name);
+      setMintedToken(resp.token);
+      setPatName('');
+      setPatExpiry('');
+      await loadPats();
+    } catch (e) {
+      setPatErr(errorMessage(e));
+    } finally {
+      setPatBusy(false);
+    }
+  }
+
+  async function onRevokePat(p: PatEntry) {
+    if (!window.confirm(`Revoke token "${p.name}"? Clients using it stop working immediately.`)) {
+      return;
+    }
+    setPatErr('');
+    try {
+      await api.revokePat(p.id);
+      await loadPats();
+    } catch (e) {
+      setPatErr(errorMessage(e));
+    }
+  }
+
+  function patStatus(p: PatEntry): 'active' | 'revoked' | 'expired' {
+    if (p.revoked) return 'revoked';
+    if (p.expiresAt && new Date(p.expiresAt) < new Date()) return 'expired';
+    return 'active';
+  }
+
+  async function copyMinted() {
+    try {
+      await navigator.clipboard.writeText(mintedToken);
+      setCopied(true);
+    } catch {
+      // Clipboard can be unavailable (http origin); the token stays selectable.
     }
   }
 
@@ -158,6 +231,96 @@ export default function Profile() {
             {pwBusy ? 'Updating…' : 'Change password'}
           </button>
         </form>
+      </div>
+
+      <div className="card" style={{ marginBottom: 16 }}>
+        <div className="card-title">Personal access tokens</div>
+        <p className="subtle" style={{ marginTop: 0 }}>
+          Long-lived credentials for agents and scripts (MCP, CLI). A token acts with exactly your
+          permissions and can be revoked here at any time.
+        </p>
+        {patErr && <div className="login-err">{patErr}</div>}
+        {mintedToken && (
+          <div className="login-notice" style={{ marginBottom: 12 }}>
+            <div>
+              Token <strong>{mintedName}</strong> created. This token is shown only once.
+            </div>
+            <code
+              style={{
+                display: 'block',
+                margin: '8px 0',
+                padding: '6px 8px',
+                wordBreak: 'break-all',
+                userSelect: 'all',
+              }}
+            >
+              {mintedToken}
+            </code>
+            <button type="button" onClick={copyMinted}>
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        )}
+        <form onSubmit={submitCreatePat} style={{ maxWidth: 360 }}>
+          <label>
+            Name
+            <input
+              value={patName}
+              onChange={e => setPatName(e.target.value)}
+              placeholder="claude-code"
+            />
+          </label>
+          <label>
+            Expires (optional)
+            <input
+              type="datetime-local"
+              value={patExpiry}
+              onChange={e => setPatExpiry(e.target.value)}
+            />
+          </label>
+          <button type="submit" disabled={patBusy || !patName.trim()}>
+            {patBusy ? 'Creating…' : 'Create token'}
+          </button>
+        </form>
+        {pats.length > 0 && (
+          <table style={{ marginTop: 12 }}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Created</th>
+                <th>Expires</th>
+                <th>Last used</th>
+                <th>Status</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {pats.map(p => {
+                const status = patStatus(p);
+                return (
+                  <tr key={p.id}>
+                    <td>{p.name}</td>
+                    <td className="subtle">{shortTs(p.createdAt)}</td>
+                    <td className="subtle">{p.expiresAt ? shortTs(p.expiresAt) : '-'}</td>
+                    <td className="subtle">{p.lastUsedAt ? shortTs(p.lastUsedAt) : 'never'}</td>
+                    <td>
+                      <span className={`badge ${status === 'active' ? 'good' : 'bad'}`}>
+                        {status}
+                      </span>
+                    </td>
+                    <td>
+                      {status === 'active' && (
+                        <button className="danger" type="button" onClick={() => onRevokePat(p)}>
+                          Revoke
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
       </div>
 
       <div className="card" style={{ marginBottom: 16 }}>

--- a/website/docs/cli/reference.md
+++ b/website/docs/cli/reference.md
@@ -18,6 +18,9 @@ Purposes below are one line each; run `qod <noun> <verb> --help` for the full fl
 | `qod auth change-password` | Change your own password (works pre-login; prompts for current and new). |
 | `qod auth forgot-password` | Request a password-reset link (always answers 200; account existence stays hidden). |
 | `qod auth reset-password` | Redeem a single-use reset link token and set a new password (prompts for both). |
+| `qod auth pat create` | Create a personal access token (`--name`, optional `--expires-at`); the token prints once. |
+| `qod auth pat list` | List your PATs (metadata only; token values are never shown again). |
+| `qod auth pat revoke` | Revoke a PAT immediately (`--id`). |
 | `qod health` | Liveness plus pool/node counts (open endpoint). |
 
 ## tenant

--- a/website/docs/connecting/mcp.md
+++ b/website/docs/connecting/mcp.md
@@ -1,0 +1,106 @@
+---
+id: mcp
+title: MCP server (AI agents)
+---
+
+The manager embeds an MCP (Model Context Protocol) server at `POST /mcp` on the REST port (default `:20900`), so AI agents such as Claude Code, Claude Desktop, or Cursor can discover schemas, run SQL with full RBAC/RLS/CLS enforcement, use DuckLake time travel, and (for admin credentials) operate pools and nodes.
+
+The transport is stateless Streamable HTTP: each POST carries one JSON-RPC message and the response is plain JSON. There is no SSE, no server push, and no session id, so any HA replica answers any request. `GET /mcp` returns 405.
+
+## Authentication
+
+`/mcp` accepts exactly two credentials in the `Authorization: Bearer <token>` header:
+
+| Credential | Principal |
+|---|---|
+| Personal access token (`qod_pat_...`) | The owning user, with that user's live tenant, role, and grants |
+| The static API key (`QOD_API_KEY`) | Superuser-equivalent; only when the key is set non-empty |
+
+Session JWTs, passwords, and missing headers are all 401. `/mcp` never admits unauthenticated requests.
+
+Create a PAT from the profile page in the UI, or with the CLI:
+
+```bash
+qod auth pat create --name claude-code
+# the token is printed ONCE; store it now
+```
+
+A PAT acts with exactly its owner's permissions and can be revoked at any time (`qod auth pat revoke --id <id>`, or the profile page). Tenant-scoped principals get their tenant inferred from the PAT owner; superuser and static-key callers pass an explicit `tenant` argument on tools that need one.
+
+## Client configuration
+
+Claude Code:
+
+```bash
+claude mcp add --transport http qod http://localhost:20900/mcp \
+  --header "Authorization: Bearer qod_pat_..."
+```
+
+Claude Desktop or any client that takes a JSON server entry:
+
+```json
+{
+  "url": "https://your-manager:20900/mcp",
+  "headers": { "Authorization": "Bearer qod_pat_..." }
+}
+```
+
+## Tools: data tier (every authenticated principal)
+
+| Tool | Arguments | Returns |
+|---|---|---|
+| `run_sql` | `sql`, `database`, `pool?`, `max_rows?` | Columns and rows as JSON, a `truncated` flag, rows affected for writes |
+| `list_databases` | superuser: `tenant?` | Tenant databases with kind and pools |
+| `list_tables` | `database`, `schema?` | Schemas and tables |
+| `describe_table` | `database`, `schema`, `table` | Columns and types plus a few sample rows |
+| `table_history` | `database`, `schema`, `table`, `limit?` | Snapshot history with change verbs |
+| `list_snapshots` | `database`, `limit?` | Snapshots and tags, for time-travel queries (`AT (VERSION => n)`) |
+| `my_usage` | none | Own usage counters and recent statements (PAT principals only) |
+
+`run_sql` executes through the same in-process path as the FlightSQL edge: statement validation (ACL), classification, routing, then the node. RBAC verbs decide whether writes are allowed, RLS/CLS apply, and suspended pools wake on the first statement exactly as they do for FlightSQL clients. Results are capped server-side by `QOD_MCP_MAX_ROWS` (default 500); the tool's `max_rows` argument can only lower the cap, and truncated results carry `truncated: true` so the agent aggregates or filters instead of paginating blindly.
+
+## Tools: admin tier (admin or superuser principals)
+
+| Tool | Notes |
+|---|---|
+| `list_pools`, `get_pool_status` | Nodes, health, served counts, suspended flag, autoscale band |
+| `scale_pool` | Band refusals (`outside_band`) surface as tool errors with the reason |
+| `suspend_pool`, `resume_pool` | Scale-to-zero and wake |
+| `restart_node`, `quarantine_node`, `unquarantine_node` | Node lifecycle |
+| `active_statements`, `kill_statement` | Inspect and kill running statements |
+| `run_maintenance`, `maintenance_runs` | Trigger and inspect managed maintenance |
+| `create_tag`, `protect_tag` | Protect only; there is no unprotect and no tag delete |
+| `audit_search` | Filtered read over the audit log |
+
+`tools/list` is computed per principal: a `role=user` PAT sees the data tier only; a tenant admin sees both tiers scoped to their tenant; superuser and static-key callers see both cross-tenant. `tools/call` re-checks the tier server-side. Tool calls land in the audit trail as the acting user.
+
+## Deny-list
+
+Some operations exist in no tier and have no code path from `/mcp`, regardless of credential:
+
+- Protection-weakening operations: tag unprotect, tag delete, lockdown off, any guardrail loosening
+- Irreversible destruction: tenant delete, database delete or purge, user delete, manifest import
+- Credential and secret operations: password set/reset, PAT create/list/revoke, federated secrets
+- RBAC mutations: grants, revokes, memberships, role/group/user create or update
+
+In particular, an agent holding a PAT can never mint, enumerate, or revoke tokens: PAT management requires a logged-in session (UI or CLI).
+
+## Errors
+
+Protocol failures (bad token, malformed JSON-RPC, unknown method) come back as HTTP 401 or JSON-RPC error objects. Everything that happens inside a tool (an ACL denial, a SQL error, an `outside_band` refusal, a "pool is resuming" timeout) returns a normal `tools/call` result with `isError: true` and a message written for the agent to act on. Internal exceptions are sanitized to a generic message with a correlation id in the server log.
+
+## Configuration
+
+| Key | Default | Env | Meaning |
+|---|---|---|---|
+| `quack-on-demand.mcp.enabled` | `true` | `QOD_MCP_ENABLED` | Serve `POST /mcp` at all |
+| `quack-on-demand.mcp.maxRows` | `500` | `QOD_MCP_MAX_ROWS` | Hard cap on rows returned by `run_sql` |
+
+Statement execution inherits the edge's existing timeouts.
+
+## Troubleshooting
+
+- **401 on every call**: the bearer is not a live PAT (revoked, expired, owner disabled) or is a session JWT, which `/mcp` refuses by design. Mint a fresh PAT.
+- **A tool is missing from `tools/list`**: the credential's tier does not include it; admin tools need an admin-owned PAT or the static key.
+- **`run_sql` returns an ACL error**: the message names the table and missing verb; grant the owning role `RO`/`RW`/`DDL` as needed.
+- **"pool is resuming"**: the target pool was suspended and is waking; retry in a few seconds.

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -78,7 +78,7 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | --- | --- | --- | --- | --- |
 | `quack-on-demand.host` | `QOD_ON_DEMAND_HOST` | `0.0.0.0` |  | Manager REST bind address (0.0.0.0 to listen on all interfaces). |
 | `quack-on-demand.port` | `QOD_ON_DEMAND_PORT` | `20900` |  | Manager REST + admin UI port. |
-| `quack-on-demand.apiKey` | `QOD_API_KEY` | `***` | yes | Static admin API key sent as X-API-Key. Unset = REST namespace is open. |
+| `quack-on-demand.apiKey` | `QOD_API_KEY` | `***` | yes | Static admin API key sent as X-API-Key. Unset or empty disables the static-key arm; /api then accepts only session and PAT credentials (never open). |
 | `quack-on-demand.runtimeType` | `QOD_RUNTIME_TYPE` | `local` |  | Quack node runtime backend: 'local' (child processes) or 'kubernetes'. |
 | `quack-on-demand.minPort` | `QOD_MIN_PORT` | `21900` |  | Lower bound of the port range LocalQuackBackend allocates child nodes from. |
 | `quack-on-demand.maxPort` | `QOD_MAX_PORT` | `22500` |  | Upper bound of the port range LocalQuackBackend allocates child nodes from. |
@@ -91,6 +91,7 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | `quack-on-demand.drainTimeoutSec` | `QOD_DRAIN_TIMEOUT_SEC` | `60` |  | Seconds to wait for in-flight statements during graceful pool shutdown. |
 | `quack-on-demand.healthCheckIntervalSec` | `QOD_HEALTH_CHECK_INTERVAL_SEC` | `5` |  | Seconds between supervisor health checks against child nodes. |
 | `quack-on-demand.reconcileIntervalSec` | `QOD_RECONCILE_INTERVAL_SEC` | `30` |  | Seconds between supervisor reconcile passes that respawn dead nodes. 0 disables the periodic loop (reconcile still runs once at boot). |
+| `quack-on-demand.publicBaseUrl` | `QOD_PUBLIC_BASE_URL` | _(unset)_ |  | Externally visible base URL (e.g. https://qod.example.com) used to build password-reset links mailed to users. When empty the link is host-relative (/ui/reset-password?...) and Main logs a boot warning. |
 | `quack-on-demand.sessionIdleTtlSec` | `QOD_SESSION_IDLE_TTL_SEC` | `28800` |  | UI session idle TTL in seconds. A session unused for this long is dropped on the next access; each successful access slides the window. Manager restart still invalidates everything (sessions are heap-only). |
 
 ## `quack-on-demand.admin`
@@ -114,6 +115,8 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | `quack-on-demand.auth.management.oidc.clientId` | `QOD_MGMT_OIDC_CLIENT_ID` | _(unset)_ |  | OIDC client id for admin-UI SSO (system scope). |
 | `quack-on-demand.auth.management.oidc.clientSecret` | `QOD_MGMT_OIDC_CLIENT_SECRET` | `***` | yes | OIDC client secret for admin-UI SSO (system scope). |
 | `quack-on-demand.auth.management.oidc.scopes` | `QOD_MGMT_OIDC_SCOPES` | `openid email profile` |  | OIDC scopes requested for admin-UI SSO. Default 'openid email profile'. |
+| `quack-on-demand.auth.lockout.enabled` | `QOD_AUTH_LOCKOUT_ENABLED` | `false` |  | Lock a database-backed user out after maxFailures consecutive bad passwords. Requires SMTP to be configured (quack-on-demand.smtp.host) so a locked-out user has a self-service reset path; Main refuses to boot otherwise. |
+| `quack-on-demand.auth.lockout.maxFailures` | `QOD_AUTH_LOCKOUT_MAX_FAILURES` | `10` |  | Consecutive failed logins before a database-backed user is locked out. |
 
 ## `quack-on-demand.autoscale`
 
@@ -208,6 +211,13 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | `quack-on-demand.managedObjectStore.retainDays` | `QOD_MANAGED_STORE_RETAIN_DAYS` | `7` |  | Days a deleted tenant-db prefix is retained before the purge worker removes it. |
 | `quack-on-demand.managedObjectStore.purgeSweepSec` | `QOD_MANAGED_STORE_PURGE_SWEEP_SEC` | `300` |  | Purge worker sweep interval in seconds; clamped to a 60s floor. |
 
+## `quack-on-demand.mcp`
+
+| Key | Env var | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `quack-on-demand.mcp.enabled` | `QOD_MCP_ENABLED` | `true` |  | Serve the MCP endpoint at POST /mcp. |
+| `quack-on-demand.mcp.maxRows` | `QOD_MCP_MAX_ROWS` | `500` |  | Hard cap on rows returned by the run_sql MCP tool. |
+
 ## `quack-on-demand.metrics`
 
 | Key | Env var | Default | Sensitive | Description |
@@ -227,6 +237,17 @@ Every scalar accepts the listed `QOD_*` / `PROXY_*` environment-variable overrid
 | `quack-on-demand.routing.cacheAware` | `QOD_ROUTING_CACHE_AWARE` | `true` |  | Cache-aware placement on object-store pools. false instantly reverts routing decisions to pure least-loaded; locality metrics and their memoized statement parse keep running. |
 | `quack-on-demand.routing.loadCapFactor` | `QOD_ROUTING_LOAD_CAP_FACTOR` | `2.0` |  | Load cap c: a table's home node is bypassed when its inFlight exceeds c x pool average. |
 | `quack-on-demand.routing.directoryMaxTables` | `QOD_ROUTING_DIRECTORY_MAX_TABLES` | `4096` |  | Per-pool bound on placement-directory entries (LRU-evicted). Safety bound. |
+
+## `quack-on-demand.smtp`
+
+| Key | Env var | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `quack-on-demand.smtp.host` | `QOD_SMTP_HOST` | _(unset)_ |  | SMTP relay host. Unset keeps the manager on the log-only mail sender. |
+| `quack-on-demand.smtp.port` | `QOD_SMTP_PORT` | `587` |  | SMTP relay port. |
+| `quack-on-demand.smtp.user` | `QOD_SMTP_USER` | _(unset)_ |  | SMTP auth username. Unset disables SMTP auth. |
+| `quack-on-demand.smtp.password` | `QOD_SMTP_PASSWORD` | `***` | yes | SMTP auth password. |
+| `quack-on-demand.smtp.from` | `QOD_SMTP_FROM` | `no-reply@quack-on-demand.local` |  | From address stamped on outgoing mail. |
+| `quack-on-demand.smtp.starttls` | `QOD_SMTP_STARTTLS` | `true` |  | Use STARTTLS when connecting to the SMTP relay. |
 
 ## `quack-on-demand.telemetry`
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -86,6 +86,7 @@ const sidebars: SidebarsConfig = {
         'connecting/clients',
         'connecting/authenticating',
         'connecting/sql',
+        'connecting/mcp',
         'connecting/dbeaver',
         'connecting/powerbi',
         'connecting/tableau',


### PR DESCRIPTION
## Summary

Makes QoD usable by AI agents through an embedded MCP (Model Context Protocol) server, introduces personal access tokens as the agent credential, and aligns `/api` to a strict no-open-mode auth posture. Implements the approved design in `docs/superpowers/specs/2026-08-18-mcp-server-design.md`.

### Personal access tokens (PATs)

- `qodstate_pat` table + `PatStore`: `qod_pat_`-prefixed 256-bit tokens, stored as SHA-256 hashes only, shown once at mint; optional expiry, revocation and `last_used_at` checked per use.
- `PatAuthenticator` resolves a PAT to its owner's live principal (disabled owner = dead token); a PAT never outranks its owner's login session.
- Management is human-only and session-only: REST `POST /api/auth/pat/create|list|revoke`, CLI `qod auth pat create|list|revoke`, and a profile-page UI card with a once-only copy-to-clipboard reveal. A PAT presented on the management routes is refused `403 session_required`, so a leaked token can never mint a successor or revoke its siblings.
- PATs are admitted on `/api` wherever a session JWT is, carrying exactly the owner's scope (admin PATs manage; `role=user` PATs are demoted to the profile allowlist; perimeter tenant-scope checks apply unchanged).

### MCP server at `POST /mcp`

- Hand-rolled stateless MCP Streamable HTTP (one JSON-RPC message per POST, no SSE, no session id, so any HA replica answers any request), mounted on the manager port, gated by `QOD_MCP_ENABLED` (default on).
- Auth: PAT or the static API key via `Authorization: Bearer`. Session JWTs and unauthenticated requests are 401 by construction; `GET /mcp` is 405.
- Data tier (every principal): `run_sql` through the same in-process path as FlightSQL (ACL validator, RLS/CLS, router, author-stamped snapshots; rows hard-capped by `QOD_MCP_MAX_ROWS`, default 500, with a `truncated` flag), `list_databases`, `list_tables`, `describe_table`, `table_history`, `list_snapshots`, `my_usage`.
- Admin tier (re-checked server-side at call time): pool status/scale/suspend/resume, node restart/quarantine/unquarantine, active statements + kill, maintenance trigger/list, tag create + protect (protect only; no unprotect and no tag delete exist here), audit search.
- Deny-listed operations (destruction, credentials, RBAC mutations, guardrail loosening) have no code path from `/mcp`.
- Tool failures return `isError` results with agent-actionable text (ACL denials keep table/verb detail; a waking pool and a node still starting both say retry shortly).

### BREAKING: strict `/api` auth posture

An unset or empty `QOD_API_KEY` no longer leaves `/api` open. The `openMode` admit is deleted from `apiKeyGuard`: every non-public `/api` call requires a session, a PAT, or the static key, and a keyless call answers 401 regardless of configuration. Public endpoints (login, password reset, client config, auth mode, OIDC callbacks) are unaffected. Keyless dev scripts must log in via `/api/auth/login` or set `QOD_API_KEY`.

## Verification

- Full Scala suite 2399/2399 green; CLI suite 269 green including the REST-parity gate; UI `npm run build` green.
- 40 new MCP tests (`McpProtocolSpec`, `McpDataToolsSpec`, `McpAdminToolsSpec`, `McpEndToEndSpec` over real HTTP + Postgres PATs) plus `PatStoreSpec`, `PatAuthenticatorSpec`, `PatRestSpec`, `PatApiAdmissionSpec`.
- Live smoke on the assembled jar (TPCH demo, `QOD_ACL_ENABLED=true`): analyst flow (discover, describe with sample, aggregate query, snapshots, `AT (VERSION => n)` time travel) and ops flow (status, scale, suspend with auto-wake, statement kill, maintenance, quarantine round-trip, tag create + protect, audit search), plus all negative arms (session JWT 401 on `/mcp`, PAT refused on PAT management, revoked PAT 401 everywhere).

## Notes for reviewers

- A statement racing a freshly spawned node right after a suspend-wake can still hit the pre-existing readiness-hold gap (the hold releases on the node record, not its first passed health probe); `/mcp` maps it to a retry hint. The core race predates this PR and stays on the suspend/resume follow-up list.
- Data-tier discovery tools ride the same `TenantScopeCheck` gates as REST, so a `role=user` PAT can effectively use `run_sql` and `my_usage` only. Deliberate (enforcement identical to REST); widening discovery for regular users would be a separate decision.
- `kill_statement` on an unknown id answers `already-completed` (the handler's no-existence-leak contract); `not_found` is the cross-tenant arm only.

Generated with [Claude Code](https://claude.com/claude-code)
