### PR TITLE
docs: lead the README with the zero-commitment demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/xHj9D6Rebp)
 
+```bash
+uvx qod start --demo   # the full gateway on your laptop: no install, no Postgres
+```
+
 **The open-source serving layer for DuckLake.** Turn a DuckLake lakehouse into a multi-tenant SQL warehouse your whole org can query: on-demand DuckDB nodes, least-loaded routing, table-level RBAC with column-level security and dynamic data masking, and Arrow Flight SQL on the wire so Power BI, Tableau, DBeaver, and any JDBC / ODBC / ADBC client just connect. Self-hosted. Single uber-jar.
 
 DuckLake gives you a Postgres-backed lakehouse catalog. DuckDB gives you the engine. What's missing between them and a room full of analysts is the part that handles *concurrent users, authentication, authorization, and connection routing* - which DuckLake [explicitly leaves out](https://ducklake.select/faq) by design. That is Quack on Demand: think self-hosted MotherDuck, scoped to serving, on your own infrastructure.


### PR DESCRIPTION
Marketing review finding: uvx qod start --demo is the best conversion mechanic the project has (zero commitment, one line, works before reading a doc) and it was buried in the quickstart. It now leads the README, above the description. Verified real: documented demo mode in the quickstart, qod package live on PyPI.

Companion PRs put the same line in the QoD hero on docs.starlake.ai/qod and on the starlake.ai home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLuy2yBXT6ynzrrzapdjr