### PR TITLE
fix(rls): quoted table identifiers bypassed row policies (fail-open)

### DIFF
--- a/src/main/scala/ai/starlake/quack/edge/rls/RowPolicyRewriter.scala
+++ b/src/main/scala/ai/starlake/quack/edge/rls/RowPolicyRewriter.scala
@@ -57,6 +57,13 @@ object RowPolicyRewriter:
   /** SQL-escape a scalar value into a quoted literal: `O'Brien` -> `'O''Brien'`. */
   private def lit(v: String): String = "'" + v.replace("'", "''") + "'"
 
+  /** jsqlparser keeps the double quotes on quoted identifiers (`"customer"`), so policy matching
+    * must strip them or a quoted reference silently escapes its row policies (fail-open). Mirrors
+    * ColumnPolicyRewriter's unquote; only the MATCH uses the stripped form - the rewritten SQL
+    * keeps the caller's original (possibly quoted) identifiers.
+    */
+  private def unquote(s: String): String = s.stripPrefix("\"").stripSuffix("\"")
+
   /** Build the identity-token substitution map for one principal. List tokens that resolve to an
     * empty set collapse to `NULL` so `col IN (${groups})` becomes `col IN (NULL)` - a predicate
     * that matches nothing (safe-restrictive) rather than invalid `IN ()`.
@@ -160,10 +167,11 @@ class RowPolicyRewriter(enabled: Boolean = true):
       values: Map[String, String],
       changed: java.util.concurrent.atomic.AtomicBoolean
   ): net.sf.jsqlparser.statement.select.FromItem =
-    val name    = t.getName
-    val schema  = Option(t.getSchemaName).getOrElse(ctx.defaultSchema.getOrElse(""))
+    val name    = unquote(t.getName)
+    val schema  = Option(t.getSchemaName).map(unquote).getOrElse(ctx.defaultSchema.getOrElse(""))
     val catalog = Option(t.getDatabase)
       .flatMap(d => Option(d.getDatabaseName))
+      .map(unquote)
       .getOrElse(ctx.defaultDatabase.getOrElse(""))
 
     val matched = eff.rowPolicies.filter(p => policyMatches(p, catalog, schema, name))
@@ -174,7 +182,8 @@ class RowPolicyRewriter(enabled: Boolean = true):
       val expr: Expression = CCJSqlParserUtil.parseCondExpression(predicate)
 
       val alias: Alias = t.getAlias
-      val baseTable    = new Table(name)
+      // Rebuild from the RAW parts: a quoted identifier stays quoted in the output.
+      val baseTable = new Table(t.getName)
       Option(t.getSchemaName).foreach(_ => baseTable.setSchemaName(t.getSchemaName))
       Option(t.getDatabase).foreach(baseTable.setDatabase)
 
@@ -187,7 +196,7 @@ class RowPolicyRewriter(enabled: Boolean = true):
       wrapped.setSelect(inner)
       // Preserve the caller's alias so outer `alias.col` references still resolve; when the table
       // had no alias, fall back to the table name so a bare `SELECT t.col` keeps working.
-      wrapped.setAlias(if alias != null then alias else new Alias(name))
+      wrapped.setAlias(if alias != null then alias else new Alias(t.getName))
       changed.set(true)
       wrapped
 

--- a/src/test/scala/ai/starlake/quack/edge/rls/RowPolicyRewriterSpec.scala
+++ b/src/test/scala/ai/starlake/quack/edge/rls/RowPolicyRewriterSpec.scala
@@ -101,6 +101,38 @@ class RowPolicyRewriterSpec extends AnyFlatSpec with Matchers:
     sql should include("c_region = 'eu'")
   }
 
+  it should "wrap a double-quoted table reference (BI folded SQL shape)" in {
+    // Power BI's folded SQL quotes every identifier; jsqlparser keeps the quotes
+    // on getName/getSchemaName/getDatabaseName, and an unstripped match let the
+    // reference silently escape its row policies (fail-open).
+    val sql = rewritten(
+      go(
+        "select distinct \"c_mktsegment\" from \"tpch1\".\"customer\"",
+        eff(tenantUser, List(policy("c_mktsegment = 'BUILDING'")))
+      )
+    )
+    sql should include("c_mktsegment = 'building'")
+    // the caller's quoting survives in the rewritten reference
+    sql should include("\"tpch1\".\"customer\"")
+  }
+
+  it should "wrap a fully catalog-qualified quoted reference" in {
+    val sql = rewritten(
+      go(
+        "select \"c_id\" from \"acme_tpch\".\"tpch1\".\"customer\"",
+        eff(tenantUser, List(policy("c_region = 'eu'")))
+      )
+    )
+    sql should include("c_region = 'eu'")
+  }
+
+  it should "still not match a policy for a different quoted table" in {
+    go(
+      "select \"o_id\" from \"tpch1\".\"orders\"",
+      eff(tenantUser, List(policy("c_region = 'eu'", table = "customer")))
+    ) shouldBe Passthrough
+  }
+
   it should "preserve the caller's table alias" in {
     val sql = rewritten(go("SELECT c.c_id FROM customer c", eff(tenantUser, List(policy("c_region = 'eu'")))))
     // outer reference c.c_id must still resolve -> wrapper carries alias `c`


### PR DESCRIPTION
## Security fix

Row-level security silently did not apply to statements that reference tables with double-quoted identifiers. jsqlparser keeps the quotes on `getName` / `getSchemaName` / `getDatabaseName`, so `RowPolicyRewriter.maybeWrap` matched `"customer"` against policies keyed on `customer`, found nothing, and passed the reference through unwrapped - fail-open. The column-level rewriter already unquotes before matching (its `unquote` helper), which is why masking applied to the very same statements while row filtering did not.

**Impact:** any client sending quoted SQL escapes row policies. Notably, every query folded by the Power BI connector quotes every identifier, so all folded queries bypassed RLS while CLS still applied. Repro as the demo's alice (analyst, BUILDING-only row policy):

```sql
SELECT DISTINCT c_mktsegment FROM acme_tpch.tpch1.customer          -- BUILDING only (correct)
select distinct "c_mktsegment" from "tpch1"."customer"              -- ALL FIVE segments (leak)
```

## Fix

Strip the quotes for the policy match only (mirroring `ColumnPolicyRewriter`); the rewritten SQL keeps the caller's original quoting so identifiers that genuinely need quotes survive.

## Verification

- `RowPolicyRewriterSpec`: 3 new cases (quoted `schema.table` wraps, quoted `catalog.schema.table` wraps, quoted non-matching table still passes through); suite 21/21.
- Live against a `qod demo` rebuilt from this branch: every previously leaking quoted form now returns the BUILDING-only rows through `adbc_driver_flightsql`.
- The Power BI connector's PQTest folding suite (`qod-powerbi-connector` PR #1, `Tests/TestSuites/QodFolding/FoldRlsCls`) pins the corrected single-row `(BUILDING, ***)` expectation and passes against this branch; it fails against an unfixed edge by design.

Found by the connector's Phase 4 screen-survival testing (folded SQL vs the RLS/CLS rewriters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWsHn2vuEtWUG9REUeVgqq