### PR TITLE
feat(boot): create the control-plane database at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.8.3 (unreleased)
+
+- **Manager creates the control-plane database at startup.** The boot
+  preflight now classifies the initial connect failure: when the server is
+  reachable but the control-plane database is missing (SQLState `3D000`), it
+  is created through the admin database (`PG_ADMIN_DB`, default `postgres`)
+  and boot proceeds, logging `control-plane database '<db>' did not exist;
+  created it`. Every other failure (server unreachable, bad credentials)
+  still refuses to start with the existing operator message. This removes
+  the launchers' `psql` dependency: a fresh install needs only a Postgres
+  user with `CREATEDB`. The `psql` preflight arms in `run-jar.sh` and the
+  CLI remain as optional fail-fast conveniences.
+
 ## 0.8.2
 
 - **`qod setup`: configure `qod start` once.** New CLI command persisting the

--- a/src/main/scala/ai/starlake/quack/Banner.scala
+++ b/src/main/scala/ai/starlake/quack/Banner.scala
@@ -14,30 +14,29 @@ object Banner:
     s"jdbc:postgresql://${meta.getOrElse("pgHost", "localhost")}:${meta
         .getOrElse("pgPort", "5432")}/${meta.getOrElse("dbName", "qod")}"
 
-  /** Probe the control-plane Postgres BEFORE anything else touches it. Right(()) when a connection
-    * opens within `timeoutSec`; Left(operator message) otherwise. Pure of exit decisions so it is
-    * unit-testable; Main prints the message and exits on Left.
+  /** Probe the control-plane Postgres BEFORE anything else touches it, creating the control-plane
+    * database when the server is up but the database is missing (SQLState 3D000), so a fresh
+    * install needs no `psql` in the launcher. Right(()) when the database is reachable (or was
+    * just created) within `timeoutSec`; Left(operator message) on any other failure. Pure of exit
+    * decisions so it is unit-testable; Main prints the message and exits on Left.
     */
   def postgresPreflight(meta: Map[String, String], timeoutSec: Int = 5): Either[String, Unit] =
     val url  = jdbcControlPlaneUrl(meta)
     val user = meta.getOrElse("pgUser", "postgres")
     println(s"control-plane Postgres: $url (user $user)")
-    try
-      DriverManager.setLoginTimeout(timeoutSec)
-      val c = DriverManager.getConnection(url, user, meta.getOrElse("pgPassword", ""))
-      c.close()
-      Right(())
-    catch
-      case t: Throwable =>
+    ai.starlake.quack.ondemand.state.ControlPlaneBootstrap
+      .ensureDatabase(meta, timeoutSec = timeoutSec) match
+      case Right(created) =>
+        if created then
+          println(s"control-plane database '${meta.getOrElse("dbName", "qod")}' did not exist; created it")
+        Right(())
+      case Left(reason) =>
         Left(
           s"""$Line
              | Postgres is NOT reachable; refusing to start.
              |   url    : $url
              |   user   : $user
-             |   error  : ${Option(t.getMessage)
-              .getOrElse(t.getClass.getSimpleName)
-              .linesIterator
-              .next()}
+             |   error  : $reason
              | Check that Postgres is running and that the QOD_* metastore overrides
              | (quack-on-demand.defaultMetastore: pgHost/pgPort/pgUser/pgPassword/dbName)
              | point at it.

--- a/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneBootstrap.scala
+++ b/src/main/scala/ai/starlake/quack/ondemand/state/ControlPlaneBootstrap.scala
@@ -1,0 +1,74 @@
+package ai.starlake.quack.ondemand.state
+
+import com.typesafe.scalalogging.LazyLogging
+
+import java.sql.{DriverManager, SQLException}
+import java.util.Properties
+
+/** Ensures the control-plane database exists before anything (Liquibase, Hikari pools) touches
+  * it, so a fresh install needs no `psql` preflight in the launcher.
+  *
+  * Classification is deliberately narrow: only a connect failure with SQLState `3D000`
+  * (invalid_catalog_name, "database does not exist") triggers a `CREATE DATABASE` through
+  * [[PostgresDbAdmin]] on the admin database. Every other failure (server unreachable, bad
+  * credentials, TLS trouble) is returned as `Left` untouched, so boot keeps refusing to start
+  * instead of masking a real problem.
+  */
+object ControlPlaneBootstrap extends LazyLogging:
+
+  /** Postgres SQLState for "database does not exist" on connect. */
+  private val MissingDatabase = "3D000"
+
+  Class.forName("org.postgresql.Driver")
+
+  /** Ensure `meta`'s control-plane database (`dbName`, default `qod`) exists.
+    *
+    *   - `Right(false)`: the database already existed.
+    *   - `Right(true)`: the server was reachable, the database was missing, and it was created.
+    *   - `Left(reason)`: the server is unreachable, credentials are wrong, or the create failed.
+    *
+    * `adminDb` is the maintenance database used to issue `CREATE DATABASE` (override with the
+    * `PG_ADMIN_DB` env var for managed Postgres whose maintenance DB is not named `postgres`).
+    */
+  def ensureDatabase(
+      meta: Map[String, String],
+      adminDb: String = sys.env.getOrElse("PG_ADMIN_DB", "postgres"),
+      timeoutSec: Int = 5
+  ): Either[String, Boolean] =
+    val host = meta.getOrElse("pgHost", "localhost")
+    val port = meta.getOrElse("pgPort", "5432")
+    val user = meta.getOrElse("pgUser", "postgres")
+    val db   = meta.getOrElse("dbName", "qod")
+
+    def probe(): Unit =
+      val props = new Properties()
+      props.setProperty("user", user)
+      props.setProperty("password", meta.getOrElse("pgPassword", ""))
+      // Per-connection timeouts: DriverManager.setLoginTimeout is JVM-global and racy.
+      props.setProperty("connectTimeout", timeoutSec.toString)
+      props.setProperty("loginTimeout", timeoutSec.toString)
+      DriverManager.getConnection(s"jdbc:postgresql://$host:$port/$db", props).close()
+
+    def firstLine(t: Throwable): String =
+      Option(t.getMessage).getOrElse(t.getClass.getSimpleName).linesIterator.next()
+
+    try
+      probe()
+      Right(false)
+    catch
+      case t: SQLException if t.getSQLState == MissingDatabase =>
+        logger.info(s"control-plane database '$db' does not exist; creating it via '$adminDb'")
+        val admin =
+          new PostgresDbAdmin(host, port, user, meta.getOrElse("pgPassword", ""), adminDb)
+        admin.createDatabase(db) match
+          case Left(err) =>
+            Left(s"control-plane database '$db' is missing and CREATE DATABASE failed: $err")
+          case Right(()) =>
+            try
+              probe()
+              Right(true)
+            catch
+              case t2: Throwable =>
+                Left(s"created control-plane database '$db' but cannot connect to it: ${firstLine(t2)}")
+      case t: Throwable =>
+        Left(firstLine(t))

--- a/src/test/scala/ai/starlake/quack/BannerSpec.scala
+++ b/src/test/scala/ai/starlake/quack/BannerSpec.scala
@@ -27,6 +27,24 @@ class BannerSpec extends AnyFlatSpec with Matchers:
     msg should include("pgHost/pgPort/pgUser/pgPassword/dbName")
   }
 
+  it should "create the control-plane database when the server is up but the database is missing" in {
+    import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+    TestPostgres.ensureReachable()
+    val name = s"qod_cpb_banner_test_${System.nanoTime()}"
+    val m = Map(
+      "pgHost"     -> TestPostgres.pgHost,
+      "pgPort"     -> TestPostgres.pgPort.toString,
+      "pgUser"     -> TestPostgres.pgUser,
+      "pgPassword" -> TestPostgres.pgPass,
+      "dbName"     -> name
+    )
+    try
+      Banner.postgresPreflight(m) shouldBe Right(())
+      // The database must now exist: a second probe succeeds without creating anything.
+      Banner.postgresPreflight(m) shouldBe Right(())
+    finally scala.util.Try(TestPostgres.dropDatabase(name))
+  }
+
   "startup" should "render copy-pasteable strings with TLS on and 0.0.0.0 mapped" in {
     val b = Banner.startup(meta, "0.0.0.0", 20900, "0.0.0.0", 31338, tlsEnabled = true)
     b should include("http://localhost:20900/ui")

--- a/src/test/scala/ai/starlake/quack/ondemand/state/ControlPlaneBootstrapSpec.scala
+++ b/src/test/scala/ai/starlake/quack/ondemand/state/ControlPlaneBootstrapSpec.scala
@@ -1,0 +1,84 @@
+package ai.starlake.quack.ondemand.state
+
+import ai.starlake.quack.ondemand.state.testkit.TestPostgres
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.DriverManager
+import scala.util.Try
+
+/** Integration test for [[ControlPlaneBootstrap]]. Requires a local Postgres reachable with the
+  * SL_TEST_PG_* env vars (defaults: localhost:5432, user `postgres`, password `azizam`).
+  */
+class ControlPlaneBootstrapSpec extends AnyFlatSpec with Matchers:
+
+  TestPostgres.dropStrayTestDatabases("qod_cpb")
+
+  private def meta(dbName: String, extra: Map[String, String] = Map.empty): Map[String, String] =
+    Map(
+      "pgHost"     -> TestPostgres.pgHost,
+      "pgPort"     -> TestPostgres.pgPort.toString,
+      "pgUser"     -> TestPostgres.pgUser,
+      "pgPassword" -> TestPostgres.pgPass,
+      "dbName"     -> dbName
+    ) ++ extra
+
+  private def exists(name: String): Boolean =
+    val c = DriverManager.getConnection(TestPostgres.adminUrl, TestPostgres.pgUser, TestPostgres.pgPass)
+    try
+      val ps = c.prepareStatement("SELECT 1 FROM pg_database WHERE datname = ?")
+      try
+        ps.setString(1, name)
+        val rs = ps.executeQuery()
+        try rs.next()
+        finally rs.close()
+      finally ps.close()
+    finally c.close()
+
+  private def withFreshName(test: String => Unit): Unit =
+    TestPostgres.ensureReachable()
+    val name = s"qod_cpb_test_${System.nanoTime()}"
+    try test(name)
+    finally Try(TestPostgres.dropDatabase(name))
+
+  "ControlPlaneBootstrap" should "create the control-plane database when the server is up but the database is missing" in withFreshName {
+    name =>
+      exists(name) shouldBe false
+      ControlPlaneBootstrap.ensureDatabase(meta(name)) shouldBe Right(true)
+      exists(name) shouldBe true
+  }
+
+  it should "be a no-op when the database already exists" in withFreshName { name =>
+    ControlPlaneBootstrap.ensureDatabase(meta(name)) shouldBe Right(true)
+    ControlPlaneBootstrap.ensureDatabase(meta(name)) shouldBe Right(false)
+    exists(name) shouldBe true
+  }
+
+  it should "refuse when the server is unreachable instead of trying to create" in withFreshName {
+    name =>
+      // Port 1 is never a Postgres; connectTimeout keeps the failure fast.
+      val result =
+        ControlPlaneBootstrap.ensureDatabase(meta(name, Map("pgPort" -> "1")), timeoutSec = 2)
+      result.isLeft shouldBe true
+      exists(name) shouldBe false
+  }
+
+  it should "refuse on bad credentials without creating the database" in withFreshName { name =>
+    // On a trust-auth dev Postgres every password is accepted, so there is no auth failure to
+    // classify; the scenario only exists under md5/scram. Cancel rather than fake it.
+    val acceptsAnyPassword = Try {
+      val c = DriverManager.getConnection(
+        TestPostgres.adminUrl,
+        TestPostgres.pgUser,
+        "definitely-wrong"
+      )
+      c.close()
+      true
+    }.getOrElse(false)
+    if acceptsAnyPassword then
+      cancel("local Postgres accepts any password (trust auth); skipping bad-credentials case")
+    val result = ControlPlaneBootstrap.ensureDatabase(meta(name) + ("pgPassword" -> "definitely-wrong"))
+    result.isLeft shouldBe true
+    // An auth failure must never be classified as "database missing": nothing gets created.
+    exists(name) shouldBe false
+  }


### PR DESCRIPTION
## Summary

The manager now creates its own control-plane database at startup, removing the launchers' `psql` dependency: a fresh install needs only a Postgres user with `CREATEDB`.

`Banner.postgresPreflight` delegates to a new `ControlPlaneBootstrap.ensureDatabase`:

- Connect to the control-plane URL succeeds: proceed as before (`Right(false)`).
- Connect fails with SQLState `3D000` (database does not exist): create the database through the existing `PostgresDbAdmin` on the admin database (`PG_ADMIN_DB`, default `postgres`), re-probe, and proceed (`Right(true)`), printing `control-plane database '<db>' did not exist; created it` so a typo'd `QOD_PG_DBNAME` stays visible in the boot output.
- Any other failure (server unreachable, bad credentials, TLS): the existing refuse-to-start operator message, unchanged. Auto-create never masks a real problem.

The classification is deliberately narrow, and HA replicas racing the create are safe: `PostgresDbAdmin.createDatabase` pre-checks `pg_database` and the lost-race "already exists" is tolerated.

Also replaces the JVM-global `DriverManager.setLoginTimeout` in the preflight with per-connection `connectTimeout`/`loginTimeout` properties (the global setter is racy across concurrent connects).

The `psql` arms in `run-jar.sh` and the CLI's `start.py` are untouched and remain optional pre-JVM fail-fast conveniences.

## Tests

TDD, red then green:

- `ControlPlaneBootstrapSpec` (new, integration against the local `SL_TEST_PG_*` Postgres): creates the database when missing; no-op when it exists; refuses on unreachable server without creating; refuses on bad credentials without creating (self-cancels on trust-auth dev Postgres, exercises under scram).
- `BannerSpec`: new case proving `postgresPreflight` now succeeds and creates the missing control-plane database; the existing unreachable-port refusal case still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTEeW6bdzjimJ81dsdY64x
